### PR TITLE
Google analytics select profiles workflow refined

### DIFF
--- a/src/scripts/modules/components/stores/StorageBucketsStore.coffee
+++ b/src/scripts/modules/components/stores/StorageBucketsStore.coffee
@@ -54,6 +54,7 @@ Dispatcher.register (payload) ->
           store = store.setIn ['buckets', bObj.get 'id'], bObj
         )
         store.set 'isLoading', false
+        store.set 'isLoaded', true
       StorageBucketsStore.emitChange()
 
     when constants.ActionTypes.STORAGE_BUCKETS_LOAD_ERROR

--- a/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
@@ -105,11 +105,12 @@ module.exports =
     @loadProfilesForce(configId)
 
 
-  setLoadedProfiles: (configId, profiles) ->
+  setLoadedProfiles: (configId, profiles, email) ->
     dispatcher.handleViewAction
       type: Constants.ActionTypes.EX_GANAL_PROFILES_LOAD_SUCCESS
       configId: configId
       profiles: profiles
+      email: email
 
   loadProfilesForce: (configId) ->
     exGanalApi.getProfiles(configId).then (result) =>

--- a/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
@@ -105,22 +105,15 @@ module.exports =
     @loadProfilesForce(configId)
 
 
-  setProfilesForce: (configId, profiles) ->
+  setLoadedProfiles: (configId, profiles) ->
     dispatcher.handleViewAction
       type: Constants.ActionTypes.EX_GANAL_PROFILES_LOAD_SUCCESS
       configId: configId
       profiles: profiles
-    dispatcher.handleViewAction
-      type: Constants.ActionTypes.EX_GANAL_SELECT_PROFILE_CANCEL
-      configId: configId
 
   loadProfilesForce: (configId) ->
-    exGanalApi.getProfiles(configId).then (result) ->
-      dispatcher.handleViewAction
-        type: Constants.ActionTypes.EX_GANAL_PROFILES_LOAD_SUCCESS
-        configId: configId
-        profiles: result
-
+    exGanalApi.getProfiles(configId).then (result) =>
+      @setLoadedProfiles(configId, result)
 
   generateExternalLink: (configId) ->
     dispatcher.handleViewAction

--- a/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalActionCreators.coffee
@@ -105,6 +105,15 @@ module.exports =
     @loadProfilesForce(configId)
 
 
+  setProfilesForce: (configId, profiles) ->
+    dispatcher.handleViewAction
+      type: Constants.ActionTypes.EX_GANAL_PROFILES_LOAD_SUCCESS
+      configId: configId
+      profiles: profiles
+    dispatcher.handleViewAction
+      type: Constants.ActionTypes.EX_GANAL_SELECT_PROFILE_CANCEL
+      configId: configId
+
   loadProfilesForce: (configId) ->
     exGanalApi.getProfiles(configId).then (result) ->
       dispatcher.handleViewAction

--- a/src/scripts/modules/ex-google-analytics/exGanalRoutes.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalRoutes.coffee
@@ -38,10 +38,10 @@ module.exports =
     title: 'Select Profiles'
     headerButtonsHandler: ProfilesHeaderButton
     handler: ExGanalProfiles
-    requireData: [
-      (params) ->
-        ExGanalActionCreators.loadProfiles params.config
-    ]
+    # requireData: [
+    #   (params) ->
+    #     ExGanalActionCreators.loadProfiles params.config
+    # ]
 
   ,
     name: 'ex-google-analytics-query'

--- a/src/scripts/modules/ex-google-analytics/exGanalStore.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalStore.coffee
@@ -166,7 +166,9 @@ Dispatcher.register (payload) ->
 
     when Constants.ActionTypes.EX_GANAL_PROFILES_LOAD_SUCCESS
       configId = action.configId
-      profiles = Immutable.fromJS action.profiles
+      profiles = Immutable.fromJS
+        profiles: action.profiles
+        email: action.email
       _store = _store.setIn ['profiles', configId], profiles
       GanalStore.emitChange()
 

--- a/src/scripts/modules/ex-google-analytics/exGanalStore.coffee
+++ b/src/scripts/modules/ex-google-analytics/exGanalStore.coffee
@@ -42,15 +42,6 @@ GanalStore = StoreUtils.createStore
     _store.getIn ['savingProfiles', configId]
   getSelectedProfiles: (configId) ->
     _store.getIn ['selectedProfiles', configId]
-  resetSelectedProfiles: (configId) ->
-    config = GanalStore.getConfig configId
-    if config.has('items') and config.get('items').count() > 0
-      mappedProfiles = config.get('items').map( (profile, key) ->
-        profile = profile.set 'id', profile.get 'googleId'
-        return profile).toMap()
-        #remap by googleId
-      _store = _store.setIn(['selectedProfiles', configId], mappedProfiles.mapKeys (key, profile) ->
-        return profile.get 'googleId')
 
   hasProfiles: (configId) ->
     _store.hasIn ['profiles', configId]
@@ -98,6 +89,17 @@ GanalStore = StoreUtils.createStore
 
     _store.setIn ['newQuery', configId], newQuery
     return newQuery
+
+
+resetSelectedProfiles = (configId) ->
+  config = GanalStore.getConfig configId
+  if config.has('items') and config.get('items').count() > 0
+    mappedProfiles = config.get('items').map( (profile, key) ->
+      profile = profile.set 'id', profile.get 'googleId'
+      return profile).toMap()
+      #remap by googleId
+    _store = _store.setIn(['selectedProfiles', configId], mappedProfiles.mapKeys (key, profile) ->
+      return profile.get 'googleId')
 
 
 Dispatcher.register (payload) ->
@@ -264,14 +266,14 @@ Dispatcher.register (payload) ->
     when Constants.ActionTypes.EX_GANAL_SELECT_PROFILE_CANCEL
       configId = action.configId
       _store = _store.deleteIn ['selectedProfiles', configId]
-      GanalStore.resetSelectedProfiles(configId)
+      resetSelectedProfiles(configId)
       GanalStore.emitChange()
 
     when Constants.ActionTypes.EX_GANAL_CONFIGURATION_LOAD_SUCCEES
       configId = action.configId
       data = Immutable.fromJS(action.data)
       _store = _store.setIn(['configs', configId], data)
-      GanalStore.resetSelectedProfiles(configId)
+      resetSelectedProfiles(configId)
       GanalStore.emitChange()
 
     when Constants.ActionTypes.EX_GANAL_CHANGE_NEW_QUERY

--- a/src/scripts/modules/ex-google-analytics/react/components/ProfilesHeaderButton.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/components/ProfilesHeaderButton.coffee
@@ -18,8 +18,10 @@ module.exports = React.createClass
 
   getStateFromStores: ->
     configId = RoutesStore.getCurrentRouteParam 'config'
+    selectedProfiles = ExGanalStore.getSelectedProfiles(configId)
     currentConfigId: configId
     isSaving: ExGanalStore.isSavingProfiles configId
+    isValid: selectedProfiles and selectedProfiles.count() > 0
 
 
   _handleCancel: ->
@@ -46,6 +48,6 @@ module.exports = React.createClass
       button
         className: 'btn btn-success'
         onClick: @_handleCreate
-        disabled: @state.isSaving
+        disabled: @state.isSaving or not @state.isValid
       ,
         'Save'

--- a/src/scripts/modules/ex-google-analytics/react/pages/index/Index.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/index/Index.coffee
@@ -191,7 +191,7 @@ module.exports = React.createClass
     @state.config.get('external') == '1'
 
   _showSelectProfiles: ->
-    return true
+    return @_isAuthorized()
     #@_isCurrentAuthorized() and not @_isExtLinkOnly()
 
   _renderAddQueryButton: ->

--- a/src/scripts/modules/ex-google-analytics/react/pages/index/Index.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/index/Index.coffee
@@ -191,7 +191,8 @@ module.exports = React.createClass
     @state.config.get('external') == '1'
 
   _showSelectProfiles: ->
-    @_isCurrentAuthorized() and not @_isExtLinkOnly()
+    return true
+    #@_isCurrentAuthorized() and not @_isExtLinkOnly()
 
   _renderAddQueryButton: ->
     if @_isAuthorized()

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
@@ -48,7 +48,7 @@ module.exports = React.createClass
         email: null
         onProfilesLoad: (profiles) =>
           console.log "PROFILESSS", profiles
-          ExGanalActionCreators.setProfilesForce(@state.configId, profiles)
+          ExGanalActionCreators.setLoadedProfiles(@state.configId, profiles)
 
       React.DOM.h2 className: '', "Available Profiles of #{@state.config.get('email')}"
       PanelGroup accordion: true,

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
@@ -14,6 +14,8 @@ PanelGroup = React.createFactory PanelGroup
 ListGroup = React.createFactory ListGroup
 ListGroupItem = React.createFactory ListGroupItem
 
+require('./Profiles.less')
+
 {span, h3, div, form} = React.DOM
 
 module.exports = React.createClass
@@ -56,13 +58,17 @@ module.exports = React.createClass
       else
         span null,
           React.DOM.h2 null, "2. Select Profiles of #{email}"
-          PanelGroup accordion: true,
-            if profiles and profiles.count() > 0
-              profiles.map( (profileGroup, profileGroupName) =>
-                @_renderProfileGroup(profileGroup, profileGroupName)
-              ,@).toArray()
-            else
-              EmptyState null, 'The account has no profiles.'
+          @_renderProfilesPanel(profiles)
+
+  _renderProfilesPanel: (profiles) ->
+    div className: 'kbc-accordion kbc-panel-heading-with-table kbc-panel-heading-with-table',
+      if profiles and profiles.count() > 0
+        profiles.map( (profileGroup, profileGroupName) =>
+          @_renderProfileGroup(profileGroup, profileGroupName)
+        ,@).toArray()
+      else
+        EmptyState null, 'The account has no profiles.'
+
 
   _renderProfilesLoader: ->
     div className: 'text-center',
@@ -78,10 +84,19 @@ module.exports = React.createClass
     header = div
       className: ''
       profileGroupName
+
+    header = span null,
+      span {className: 'table', style: {margin: '0'}},
+        span className: 'tbody',
+          span className: 'tr',
+            span className: 'td',
+              profileGroupName
     Panel
       header: header
       key: profileGroupName
       eventKey: profileGroupName,
+      collapsible: true
+      className: 'profile-panel'
     ,
       profileGroup.map( (profile, profileName) =>
         @_renderProfilePanel(profile, profileName, profileGroupName, profileGroup)
@@ -92,11 +107,19 @@ module.exports = React.createClass
     header = div
       className: ''
       profileName
-    PanelGroup accordion: true,
+    header = span null,
+      span {className: 'table', style: {margin: '0'} },
+        span className: 'tbody',
+          span className: 'tr',
+            span className: 'td',
+              profileName
+    #PanelGroup accordion: true,
+    div className: 'kbc-accordion kbc-panel-heading-with-table kbc-panel-heading-with-table',
       Panel
         header: header
         key: profileName
         eventKey: profileName
+        collapsible: true
       ,
         div {className: 'row'},
           ListGroup {},
@@ -110,7 +133,7 @@ module.exports = React.createClass
                   profileItem = profileItem.set 'googleId', profileItem.get 'id'
                   @_profileOnClick(profileItem)
                 ,
-                  profileItem.get 'name'
+                  div className: 'text-center', profileItem.get 'name'
             ).toArray()
 
   _profileOnClick: (profile) ->

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
@@ -4,6 +4,7 @@ createStoreMixin = require '../../../../../react/mixins/createStoreMixin'
 ExGanalActionCreators  = require '../../../exGanalActionCreators'
 RoutesStore = require '../../../../../stores/RoutesStore'
 
+ProfilesLoader = require('../../../../google-utils/react/ProfilesPicker').default
 {Panel, PanelGroup, ListGroup, ListGroupItem} = require('react-bootstrap')
 Accordion = React.createFactory(require('react-bootstrap').Accordion)
 Panel  = React.createFactory Panel
@@ -22,6 +23,7 @@ module.exports = React.createClass
     name = RoutesStore.getRouterState().getIn ['params', 'name']
     config = exGanalStore.getConfig(configId)
     configLoaded = exGanalStore.hasConfig configId
+
     config: config
     configId: configId
     isConfigLoaded: configLoaded
@@ -42,6 +44,10 @@ module.exports = React.createClass
 
   _renderProfiles: ->
     div className: '',
+      React.createElement ProfilesLoader,
+        email: null
+        onProfilesLoad: (profiles) ->
+          console.log "PROFILESSS", profiles
       React.DOM.h2 className: '', "Available Profiles of #{@state.config.get('email')}"
       PanelGroup accordion: true,
         if @state.profiles and @state.profiles.count() > 0

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
@@ -46,8 +46,10 @@ module.exports = React.createClass
     div className: '',
       React.createElement ProfilesLoader,
         email: null
-        onProfilesLoad: (profiles) ->
+        onProfilesLoad: (profiles) =>
           console.log "PROFILESSS", profiles
+          ExGanalActionCreators.setProfilesForce(@state.configId, profiles)
+
       React.DOM.h2 className: '', "Available Profiles of #{@state.config.get('email')}"
       PanelGroup accordion: true,
         if @state.profiles and @state.profiles.count() > 0
@@ -67,11 +69,11 @@ module.exports = React.createClass
       eventKey: profileGroupName,
     ,
       profileGroup.map( (profile, profileName) =>
-        @_renderProfilePanel(profile, profileName, profileGroupName)
+        @_renderProfilePanel(profile, profileName, profileGroupName, profileGroup)
       ).toArray()
 
 
-  _renderProfilePanel: (profile, profileName, profileGroupName) ->
+  _renderProfilePanel: (profile, profileName, profileGroupName, profileGroup) ->
     header = div
       className: ''
       profileName

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.coffee
@@ -2,12 +2,13 @@ React = require 'react'
 exGanalStore = require('../../../exGanalStore')
 createStoreMixin = require '../../../../../react/mixins/createStoreMixin'
 ExGanalActionCreators  = require '../../../exGanalActionCreators'
+ApplicationActionCreators = require '../../../../../actions/ApplicationActionCreators'
 RoutesStore = require '../../../../../stores/RoutesStore'
 
 ProfilesLoader = require('../../../../google-utils/react/ProfilesPicker').default
 EmptyState = require('../../../../components/react/components/ComponentEmptyState').default
 EmptyState = React.createFactory EmptyState
-{Panel, PanelGroup, ListGroup, ListGroupItem} = require('react-bootstrap')
+{Alert, Panel, PanelGroup, ListGroup, ListGroupItem} = require('react-bootstrap')
 Accordion = React.createFactory(require('react-bootstrap').Accordion)
 Panel  = React.createFactory Panel
 PanelGroup = React.createFactory PanelGroup
@@ -16,7 +17,7 @@ ListGroupItem = React.createFactory ListGroupItem
 
 require('./Profiles.less')
 
-{span, h3, div, form} = React.DOM
+{strong, span, h3, div, form} = React.DOM
 
 module.exports = React.createClass
   displayName: 'ExGanalProfiles'
@@ -58,7 +59,19 @@ module.exports = React.createClass
       else
         span null,
           React.DOM.h2 null, "2. Select Profiles of #{email}"
+          @_renderWarning(email)
           @_renderProfilesPanel(profiles)
+
+  _renderWarning: (profilesEmail) ->
+    authorizedEmail = @state.config.get('email')
+    if profilesEmail and authorizedEmail and authorizedEmail != profilesEmail
+      React.createElement Alert, bsStyle: 'warning',
+        strong null, 'Warning: '
+        'Selected account ',
+        strong null, profilesEmail
+        ' does not match account authorized for data extraction ',
+        strong null, authorizedEmail
+        '.'
 
   _renderProfilesPanel: (profiles) ->
     div className: 'kbc-accordion kbc-panel-heading-with-table kbc-panel-heading-with-table',
@@ -74,9 +87,13 @@ module.exports = React.createClass
     div className: 'text-center',
       React.createElement ProfilesLoader,
         email: null
+        onProfilesLoadError: (err) ->
+          ApplicationActionCreators.sendNotification({
+            message: err.message,
+            type: 'error'
+          })
         onProfilesLoad: (profiles, email) =>
           console.log "loaded profiles", profiles
-
           ExGanalActionCreators.setLoadedProfiles(@state.configId, profiles, email)
 
 

--- a/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.less
+++ b/src/scripts/modules/ex-google-analytics/react/pages/profiles/Profiles.less
@@ -1,0 +1,5 @@
+.profile-panel > div > .panel-body{
+  padding-right: 0px;
+  padding-left: 7px;
+  padding-top: 3px;
+}

--- a/src/scripts/modules/google-utils/react/GapiFlux.js
+++ b/src/scripts/modules/google-utils/react/GapiFlux.js
@@ -1,0 +1,82 @@
+import {Map} from 'immutable';
+import StoreUtils from '../../../utils/StoreUtils';
+import keyMirror from 'react/lib/keyMirror';
+import Dispatcher from '../../../Dispatcher';
+
+const ActionTypes = keyMirror({
+  GAPI_START_INIT: null,
+  GAPI_FINISH_INIT: null,
+  GAPI_START_PICK: null,
+  GAPI_FINISH_PICK: null,
+  GAPI_ERROR: null
+});
+
+let _store = Map({
+  isInitializing: false,
+  isInitialized: false,
+  isPicking: Map() // what true/false
+});
+
+
+export const GapiStore = StoreUtils.createStore({
+  isInitializing: () => _store.get('isInitializing'),
+  isInitialized: () => _store.get('isInitialized'),
+  isPicking: (what) => _store.getIn(['isPicking', what], false)
+});
+
+
+Dispatcher.register( (payload) => {
+  const action = payload.action;
+  switch (action.type) {
+    case ActionTypes.GAPI_START_INIT:
+      _store = _store.set('isInitializing', true);
+      _store = _store.set('isInitialized', false);
+      GapiStore.emitChange();
+      break;
+    case ActionTypes.GAPI_FINISH_INIT:
+      _store = _store.set('isInitializing', false);
+      _store = _store.set('isInitialized', true);
+      GapiStore.emitChange();
+      break;
+
+    case ActionTypes.GAPI_START_PICK:
+      _store = _store.setIn(['isPicking', action.what], true);
+      GapiStore.emitChange();
+      break;
+
+    case ActionTypes.GAPI_FINISH_PICK:
+      _store = _store.setIn(['isPicking', action.what], false);
+      GapiStore.emitChange();
+      break;
+    default:
+      return;
+  }
+});
+
+export const GapiActions = {
+  startInit: () => {
+    Dispatcher.handleViewAction({
+      type: ActionTypes.GAPI_START_INIT
+    });
+  },
+
+  finishInit: () => {
+    Dispatcher.handleViewAction({
+      type: ActionTypes.GAPI_FINISH_INIT
+    });
+  },
+
+  startPick: (what) => {
+    Dispatcher.handleViewAction({
+      type: ActionTypes.GAPI_START_PICK,
+      what: what
+    });
+  },
+
+  finishPick: (what) => {
+    Dispatcher.handleViewAction({
+      type: ActionTypes.GAPI_FINISH_PICK,
+      what: what
+    });
+  }
+};

--- a/src/scripts/modules/google-utils/react/GooglePicker.coffee
+++ b/src/scripts/modules/google-utils/react/GooglePicker.coffee
@@ -5,6 +5,8 @@ _ = require('underscore')
 InitGoogleApis = require('./InitGoogleApis')
 {apiKey, authorize, injectGapiScript} = InitGoogleApis
 templates = require './PickerViewTemplates'
+{GapiStore} = require './GapiFlux'
+createStoreMixin = require '../../../react/mixins/createStoreMixin'
 
 scope = 'https://www.googleapis.com/auth/drive.readonly'
 
@@ -36,6 +38,7 @@ createGdrivePicker = (views, viewGroups) ->
 module.exports = React.createClass
 
   displayName: "googlePicker"
+  mixins: [createStoreMixin(GapiStore)]
   propTypes:
     dialogTitle: React.PropTypes.string.isRequired
     buttonLabel: React.PropTypes.string.isRequired
@@ -44,6 +47,9 @@ module.exports = React.createClass
     viewGroups: React.PropTypes.array
     email: React.PropTypes.string
     buttonProps: React.PropTypes.object
+
+  getStateFromStores: ->
+    isInitialized: GapiStore.isInitialized()
 
   componentDidMount: ->
     injectGapiScript()
@@ -54,6 +60,7 @@ module.exports = React.createClass
     if @props.buttonProps
       buttonProps = @props.buttonProps
     buttonProps['onClick'] = @_ButtonClick
+    buttonProps['disabled'] = not @state.isInitialized
 
     React.createElement Button,
       buttonProps

--- a/src/scripts/modules/google-utils/react/GooglePicker.coffee
+++ b/src/scripts/modules/google-utils/react/GooglePicker.coffee
@@ -16,11 +16,11 @@ setZIndex = ->
   for el in elements
     el.style.zIndex = '1500'
 
-window.handleGoogleClientLoad = ->
-
-  console.log  "GAPI LOADED", window.gapi
-  gapi.load('picker', -> )
-  gapi.load('auth', -> )
+# if not window.handleGoogleClientLoad
+#   window.handleGoogleClientLoad = ->
+#     console.log  "gdrive picker GAPI LOADED", window.gapi
+#     gapi.load('picker', -> )
+#     gapi.load('auth', -> )
 
 
 injectGoogleApiScript = ->
@@ -72,7 +72,7 @@ module.exports = React.createClass
     buttonProps: React.PropTypes.object
 
   componentDidMount: ->
-    injectGoogleApiScript()
+    #injectGoogleApiScript()
 
   render: ->
     buttonProps =

--- a/src/scripts/modules/google-utils/react/GooglePicker.coffee
+++ b/src/scripts/modules/google-utils/react/GooglePicker.coffee
@@ -2,44 +2,19 @@ React = require('react')
 _ = require('underscore')
 {Button} = require('react-bootstrap')
 {div, span} = React.DOM
-
+InitGoogleApis = require('./InitGoogleApis')
+{apiKey, authorize, injectGapiScript} = InitGoogleApis
 templates = require './PickerViewTemplates'
 
-apiUrl = 'https://apis.google.com/js/client.js?onload=handleGoogleClientLoad'
 scope = 'https://www.googleapis.com/auth/drive.readonly'
-clientId = '682649748090-hdan66m2vvudud332s99aud36fs15idj.apps.googleusercontent.com'
-apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc'
-
 
 setZIndex = ->
   elements = document.getElementsByClassName("picker")
   for el in elements
     el.style.zIndex = '1500'
 
-# if not window.handleGoogleClientLoad
-#   window.handleGoogleClientLoad = ->
-#     console.log  "gdrive picker GAPI LOADED", window.gapi
-#     gapi.load('picker', -> )
-#     gapi.load('auth', -> )
-
-
-injectGoogleApiScript = ->
-  scripts = document.body.getElementsByTagName('script')
-  apiScript = _.find scripts, (s) ->
-    s.src == apiUrl
-  if not apiScript and _.isUndefined(window.gapi)
-    script = document.createElement('script')
-    script.src = apiUrl
-    document.body.appendChild script
-
-
 authorizePicker = (userEmail, callbackFn) ->
-  gapi.auth.authorize(
-    'client_id': clientId
-    'scope': scope
-    'immediate': false
-    'user_id': userEmail if userEmail
-  , callbackFn)
+  authorize(scope, callbackFn, userEmail)
 
 createGdrivePicker = (views, viewGroups) ->
   picker = new google.picker.PickerBuilder()
@@ -54,7 +29,6 @@ createGdrivePicker = (views, viewGroups) ->
 
   for view in views
     picker = picker.addView(view())
-  console.log picker
   #picker.A.style.zIndex = 2000
   return picker
 
@@ -72,7 +46,7 @@ module.exports = React.createClass
     buttonProps: React.PropTypes.object
 
   componentDidMount: ->
-    #injectGoogleApiScript()
+    injectGapiScript()
 
   render: ->
     buttonProps =

--- a/src/scripts/modules/google-utils/react/InitGoogleApis.js
+++ b/src/scripts/modules/google-utils/react/InitGoogleApis.js
@@ -3,8 +3,6 @@ const apiUrl = 'https://apis.google.com/js/client.js?onload=handleGoogleClientLo
 const clientId = '682649748090-hdan66m2vvudud332s99aud36fs15idj.apps.googleusercontent.com';
 export const apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc';
 
-// import request from '../../../utils/request';
-
 let gapi;
 let initialized = false;
 
@@ -17,12 +15,13 @@ if (!window.handleGoogleClientLoad) {
   };
 }
 
-export function authorize(scope, callBackFn) {
+export function authorize(scope, callBackFn, userEmail) {
   const signInOptions = {
     'client_id': clientId,
     'scope': scope,
     'cookie_policy': 'single_host_origin',
-    'prompt': 'select_account'
+    'user_id': userEmail, // forces to log in specific email
+    'prompt': 'select_account' // forces to always select account(no cached selection)
   };
   return gapi.auth.authorize(signInOptions, callBackFn);
 }

--- a/src/scripts/modules/google-utils/react/InitGoogleApis.js
+++ b/src/scripts/modules/google-utils/react/InitGoogleApis.js
@@ -1,6 +1,7 @@
 import _ from 'underscore';
 const apiUrl = 'https://apis.google.com/js/client.js?onload=handleGoogleClientLoad';
 const clientId = '682649748090-hdan66m2vvudud332s99aud36fs15idj.apps.googleusercontent.com';
+export const apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc';
 
 // import request from '../../../utils/request';
 
@@ -11,42 +12,24 @@ if (!window.handleGoogleClientLoad) {
   window.handleGoogleClientLoad = function() {
     gapi = window.gapi;
     gapi.load('picker');
-    // gapi.load('auth');
-    gapi.load('auth2', () => initialized = true);
+    gapi.load('auth');
+    initialized = true;
   };
 }
 
-export function authorize(scope, callbackFn) {
-  const authObject = gapi.auth2.getAuthInstance() || gapi.auth2.init({
+export function authorize(scope, callBackFn) {
+  const signInOptions = {
     'client_id': clientId,
     'scope': scope,
-    'fetch_basic_profile': false
-  });
-
-  const sigInOptions = {
-    'fetch_basic_profile': false,
-    'scope': scope,
+    'cookie_policy': 'single_host_origin',
     'prompt': 'select_account'
-
   };
-  if (authObject.isSignedIn.get()) {
-    callbackFn();
-  } else {
-    return authObject.signIn(sigInOptions).then((params) => {
-      callbackFn(params);
-    }, (err) => console.log('SIGN FAILED', err));
-  }
+  return gapi.auth.authorize(signInOptions, callBackFn);
 }
 
 export function disconnect() {
-  const authObject = gapi.auth2.getAuthInstance();
-  if (authObject) {
-    console.log('DISCONNECT');
-    authObject.signOut().then(() => {
-      console.log('SIGN OUT');
-      authObject.disconnect();
-    });
-  }
+  gapi.auth.signOut();
+  gapi.auth.setToken(null);
 }
 
 /*

--- a/src/scripts/modules/google-utils/react/InitGoogleApis.js
+++ b/src/scripts/modules/google-utils/react/InitGoogleApis.js
@@ -1,17 +1,18 @@
 import _ from 'underscore';
+import {GapiActions} from './GapiFlux';
 const apiUrl = 'https://apis.google.com/js/client.js?onload=handleGoogleClientLoad';
 const clientId = '682649748090-hdan66m2vvudud332s99aud36fs15idj.apps.googleusercontent.com';
 export const apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc';
 
 let gapi;
-let initialized = false;
+
 
 if (!window.handleGoogleClientLoad) {
   window.handleGoogleClientLoad = function() {
+    GapiActions.startInit();
     gapi = window.gapi;
     gapi.load('picker');
-    gapi.load('auth');
-    initialized = true;
+    gapi.load('auth', () => GapiActions.finishInit());
   };
 }
 
@@ -68,8 +69,4 @@ export function injectGapiScript() {
 
 export default function() {
   return window.gapi;
-}
-
-export function isInitialized() {
-  return initialized;
 }

--- a/src/scripts/modules/google-utils/react/InitGoogleApis.js
+++ b/src/scripts/modules/google-utils/react/InitGoogleApis.js
@@ -1,0 +1,93 @@
+import _ from 'underscore';
+const apiUrl = 'https://apis.google.com/js/client.js?onload=handleGoogleClientLoad';
+const clientId = '682649748090-hdan66m2vvudud332s99aud36fs15idj.apps.googleusercontent.com';
+
+// import request from '../../../utils/request';
+
+let gapi;
+let initialized = false;
+
+if (!window.handleGoogleClientLoad) {
+  window.handleGoogleClientLoad = function() {
+    gapi = window.gapi;
+    gapi.load('picker');
+    // gapi.load('auth');
+    gapi.load('auth2', () => initialized = true);
+  };
+}
+
+export function authorize(scope, callbackFn) {
+  const authObject = gapi.auth2.getAuthInstance() || gapi.auth2.init({
+    'client_id': clientId,
+    'scope': scope,
+    'fetch_basic_profile': false
+  });
+
+  const sigInOptions = {
+    'fetch_basic_profile': false,
+    'scope': scope,
+    'prompt': 'select_account'
+
+  };
+  if (authObject.isSignedIn.get()) {
+    callbackFn();
+  } else {
+    return authObject.signIn(sigInOptions).then((params) => {
+      callbackFn(params);
+    }, (err) => console.log('SIGN FAILED', err));
+  }
+}
+
+export function disconnect() {
+  const authObject = gapi.auth2.getAuthInstance();
+  if (authObject) {
+    console.log('DISCONNECT');
+    authObject.signOut().then(() => {
+      console.log('SIGN OUT');
+      authObject.disconnect();
+    });
+  }
+}
+
+/*
+function authorize(scope, email, callbackFn) {
+  return gapi.auth.authorize(
+    {
+      'client_id': clientId,
+      'scope': scope,
+      'immediate': false,
+      'user_id': email
+    }
+    , callbackFn);
+}
+
+export function authorizeGoogleAccount(scope, email, callbackFn, preloadPromise) {
+  if (preloadPromise) {
+    return preloadPromise.then(() => authorize(scope, email, callbackFn));
+  } else {
+    return authorize(scope, email, callbackFn);
+  }
+}
+
+*/
+
+
+export function injectGapiScript() {
+  const scripts = document.body.getElementsByTagName('script');
+  const apiScript = _.find(scripts, (s) =>
+                           s.src === apiUrl
+                          );
+  if (!apiScript && _.isUndefined(window.gapi)) {
+    let script = document.createElement('script');
+    script.src = apiUrl;
+    document.body.appendChild(script);
+  }
+}
+
+export default function() {
+  return window.gapi;
+}
+
+export function isInitialized() {
+  return initialized;
+}

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -42,7 +42,14 @@ export default React.createClass({
 
   propTypes: {
     email: PropTypes.string,
+    buttonLabel: PropTypes.string,
     onProfilesLoad: PropTypes.func
+  },
+
+  getDefaultProps() {
+    return {
+      buttonLabel: 'Select Google Account and Load Profiles'
+    };
   },
 
   getStateFromStores() {
@@ -62,7 +69,7 @@ export default React.createClass({
         disabled={!this.state.isInitialized}
         bsStyle="success"
         onClick={this.onButtonClick}>
-        Pick me up bitch!
+        {this.props.buttonLabel}
       </Button>
     );
   },
@@ -73,7 +80,7 @@ export default React.createClass({
       (resp) => {
         console.log('PROFILES', resp);
         disconnect();
-        this.props.onProfilesLoad(reparseProfiles(resp));
+        this.props.onProfilesLoad(reparseProfiles(resp), resp.username);
       },
       (err) => {
         console.log(err);

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -3,10 +3,9 @@
 import React, {PropTypes} from 'react';
 import {Button} from 'react-bootstrap';
 
-import gapi, {authorize, disconnect, injectGapiScript} from './InitGoogleApis';
+import gapi, {authorize, disconnect, apiKey, injectGapiScript} from './InitGoogleApis';
 
 const scope = 'https://www.googleapis.com/auth/analytics.readonly';
-const apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc';
 
 function authorizeAnal(callbackFn) {
   gapi().client.load('analytics', 'v3').then( () => {
@@ -17,10 +16,14 @@ function authorizeAnal(callbackFn) {
 
 function getProfiles() {
   const request = gapi().client.analytics.management.accountSummaries.list();
-  request.execute((resp) => {
-    console.log('PROFILES', resp);
-    disconnect();
-  }, (err) => (console.log(err))
+  request.execute(
+    (resp) => {
+      console.log('PROFILES', resp);
+      disconnect();
+    },
+    (err) => {
+      console.log(err);
+    }
   );
 }
 

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -1,0 +1,60 @@
+// Google analytics komponenta ktora vynuti od uzivatela docasny oauth token a
+// vylistuje mu jeho google analytics profily z ktorych si vyberie
+import React, {PropTypes} from 'react';
+import {Button} from 'react-bootstrap';
+
+import gapi, {authorize, disconnect, injectGapiScript} from './InitGoogleApis';
+
+const scope = 'https://www.googleapis.com/auth/analytics.readonly';
+const apiKey = 'AIzaSyBYjYUY81-DWMZBuNYRWOTSLt9NZqWG0cc';
+
+function authorizeAnal(callbackFn) {
+  gapi().client.load('analytics', 'v3').then( () => {
+    gapi().client.setApiKey(apiKey);
+    authorize(scope, callbackFn);
+  });
+}
+
+function getProfiles() {
+  const request = gapi().client.analytics.management.accountSummaries.list();
+  request.execute((resp) => {
+    console.log('PROFILES', resp);
+    disconnect();
+  }, (err) => (console.log(err))
+  );
+}
+
+export default React.createClass({
+
+  propTypes: {
+    email: PropTypes.string,
+    onProfilesLoad: PropTypes.func
+  },
+
+  componentDidMount() {
+    injectGapiScript();
+  },
+
+  render() {
+    return (
+      <Button
+        bsStyle="success"
+        onClick={this.onButtonClick}>
+        Pick me up bitch!
+      </Button>
+    );
+  },
+
+  loadAnalProfiles() {
+    getProfiles();
+  },
+
+  onButtonClick() {
+    authorizeAnal((authResult) => {
+      if (authResult && !authResult.error) {
+        this.loadAnalProfiles();
+      }
+    });
+  }
+
+});

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -1,6 +1,7 @@
 // Google analytics komponenta ktora vynuti od uzivatela docasny oauth token a
 // vylistuje mu jeho google analytics profily z ktorych si vyberie
 import React, {PropTypes} from 'react';
+import Tooltip from '../../../react/common/Tooltip';
 import {Button} from 'react-bootstrap';
 import _ from 'underscore';
 
@@ -43,7 +44,8 @@ export default React.createClass({
   propTypes: {
     email: PropTypes.string,
     buttonLabel: PropTypes.string,
-    onProfilesLoad: PropTypes.func
+    onProfilesLoad: PropTypes.func,
+    onProfilesLoadError: PropTypes.func
   },
 
   getDefaultProps() {
@@ -70,6 +72,12 @@ export default React.createClass({
         bsStyle="success"
         onClick={this.onButtonClick}>
         {this.props.buttonLabel}
+          <Tooltip
+             tooltip="Requires temporal authorization of a Google Account."
+             placement="top">
+            <i className="fa fa-fw fa-question-circle"></i>
+          </Tooltip>
+
       </Button>
     );
   },
@@ -80,11 +88,11 @@ export default React.createClass({
       (resp) => {
         console.log('PROFILES', resp);
         disconnect();
-        this.props.onProfilesLoad(reparseProfiles(resp), resp.username);
-      },
-      (err) => {
-        console.log(err);
-        throw err.message;
+        if (resp.error) {
+          return this.props.onProfilesLoadError(resp);
+        } else {
+          this.props.onProfilesLoad(reparseProfiles(resp), resp.username);
+        }
       }
     );
   },

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -4,6 +4,9 @@ import React, {PropTypes} from 'react';
 import {Button} from 'react-bootstrap';
 import _ from 'underscore';
 
+import {GapiStore} from './GapiFlux';
+import createStoreMixin from '../../../react/mixins/createStoreMixin';
+
 import gapi, {authorize, disconnect, apiKey, injectGapiScript} from './InitGoogleApis';
 
 const scope = 'https://www.googleapis.com/auth/analytics.readonly';
@@ -35,9 +38,18 @@ function reparseProfiles(profiles) {
 
 export default React.createClass({
 
+  mixins: [createStoreMixin(GapiStore)],
+
   propTypes: {
     email: PropTypes.string,
     onProfilesLoad: PropTypes.func
+  },
+
+  getStateFromStores() {
+    return {
+      isInitialized: GapiStore.isInitialized(),
+      isPicking: GapiStore.isPicking('profiles')
+    };
   },
 
   componentDidMount() {
@@ -47,6 +59,7 @@ export default React.createClass({
   render() {
     return (
       <Button
+        disabled={!this.state.isInitialized}
         bsStyle="success"
         onClick={this.onButtonClick}>
         Pick me up bitch!

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -73,7 +73,7 @@ export default React.createClass({
         onClick={this.onButtonClick}>
         {this.props.buttonLabel}
           <Tooltip
-             tooltip="Requires temporal authorization of a Google Account."
+             tooltip="Requires temporal authorization of a Google Account after which a short-lived access token is obtained to load profiles from the selected account."
              placement="top">
             <i className="fa fa-fw fa-question-circle"></i>
           </Tooltip>


### PR DESCRIPTION
New Workflow as follows
1. User authorize google account for offline access
2. User is prompted to select google account and authorize for temporal access
3. List of profiles from temporarly authorized account is loaded
4. User select a profile from the list of profiles
5. User save selected profiles

moreover:
 - Profiles selection page is always visible for a ex-ga configuration that has authorized offline access
- User can select profiles from different account that are shared with the account authorized for offline access

