### PR TITLE
Hotfix: Check for existence of delete_where_values

### DIFF
--- a/src/scripts/modules/components/react/components/generic/TableOutputMappingDetail.coffee
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMappingDetail.coffee
@@ -64,13 +64,14 @@ TableInputMappingDetail = React.createClass(
               @props.value.get('delete_where_operator')
               ' '
               strong {},
-                @props.value.get('delete_where_values').map((value) ->
-                  if value == ''
-                    return '[empty string]'
-                  if value == ' '
-                    return '[space character]'
-                  return value
-                ).join(', ')
+                if @props.value.get('delete_where_values')
+                  @props.value.get('delete_where_values').map((value) ->
+                    if value == ''
+                      return '[empty string]'
+                    if value == ' '
+                      return '[space character]'
+                    return value
+                  ).join(', ')
           else
             'N/A'
 


### PR DESCRIPTION
Ked ulozime toto (t.j. nedam ziadne `delete_where_values`), tak padne UI a uz sa nedostanu na detail aplikacie a niekedy ani na zoznam.
![screenshot_2016-03-29_14-50-53](https://cloud.githubusercontent.com/assets/419849/14110721/0214eeb4-f5c8-11e5-91a6-d272ccd6d353.png)

Co je divne je, ze vyzera, ze sa to deje len v aplikaciach (v transformaciach mi to nerobilo, zatial som nezistil preco).