### PR TITLE
fix(orchestrations): startTime instead of endTime in last run

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationRow.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationRow.coffee
@@ -64,7 +64,7 @@ OrchestrationRow = React.createClass(
         @props.orchestration.get('name')
       ),
       (span {className: 'td'},
-        (FinishedWithIcon endTime: lastExecutedJob?.get('endTime')) if lastExecutedJob?.get('endTime')
+        (FinishedWithIcon endTime: lastExecutedJob?.get('startTime')) if lastExecutedJob?.get('startTime')
       ),
       (span {className: 'td'},
         duration


### PR DESCRIPTION
ISSUE https://github.com/keboola/kbc-ui/issues/558