### PR TITLE
ex db generic password handling

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -12,23 +12,24 @@ export function loadConfiguration(componentId, configId) {
 }
 
 export function createActions(componentId) {
-  function excludeProtectedProperties(credentials) {
+  function resetProtectedProperties(credentials) {
     let result = credentials;
     const props = getProtectedProperties(componentId);
     for (let prop of props) {
-      const protectedProp = `#${prop}`;
-      result = result.delete(protectedProp);
+      result = result.set(prop, '');
     }
     return result;
   }
 
-  function encryptProtectedFields(credentials) {
-    let result = credentials;
+  function updateProtectedProperties(newCredentials, oldCredentials) {
     const props = getProtectedProperties(componentId);
+    let result = newCredentials;
     for (let prop of props) {
-      const protectedProp = `#${prop}`;
-      const protectedValue = credentials.get(prop);
-      result = result.set(protectedProp, protectedValue).delete(prop);
+      const newValue = newCredentials.get(prop);
+      const oldValue = oldCredentials.get(prop);
+      if (!newValue) {
+        result = result.set(prop, oldValue);
+      }
     }
     return result;
   }
@@ -64,7 +65,7 @@ export function createActions(componentId) {
       if (!credentials.get('port') &&  getDefaultPort(componentId)) {
         credentials = credentials.set('port', getDefaultPort(componentId));
       }
-      credentials = excludeProtectedProperties(credentials);
+      credentials = resetProtectedProperties(credentials);
       updateLocalState(configId, 'editingCredentials', credentials);
     },
 
@@ -108,7 +109,7 @@ export function createActions(componentId) {
     saveNewCredentials(configId) {
       const store = getStore(configId);
       let newCredentials = store.getNewCredentials();
-      newCredentials = encryptProtectedFields(newCredentials);
+      newCredentials = updateProtectedProperties(newCredentials, store.getCredentials());
       const newData = store.configData.setIn(['parameters', 'db'], newCredentials);
       return saveConfigData(configId, newData, ['isSavingCredentials']).then(() => this.resetNewCredentials(configId));
     },
@@ -133,7 +134,7 @@ export function createActions(componentId) {
     saveCredentialsEdit(configId) {
       const store = getStore(configId);
       let credentials = store.getEditingCredentials();
-      credentials = encryptProtectedFields(credentials);
+      credentials = updateProtectedProperties(credentials, store.getCredentials());
       const newConfigData = store.configData.setIn(['parameters', 'db'], credentials);
       return saveConfigData(configId, newConfigData, 'isSavingCredentials').then(() => this.cancelCredentialsEdit(configId));
     },
@@ -170,8 +171,9 @@ export function createActions(componentId) {
 
     testCredentials(configId, credentials) {
       const store = getStore(configId);
+      const testingCredentials = updateProtectedProperties(credentials, store.getCredentials());
       let runData = store.configData.setIn(['parameters', 'tables'], List());
-      runData = runData.setIn(['parameters', 'db'], credentials);
+      runData = runData.setIn(['parameters', 'db'], testingCredentials);
       const params = {
         configData: runData.toJS()
       };

--- a/src/scripts/modules/ex-db-generic/react/components/CredentialsHeaderButtons.coffee
+++ b/src/scripts/modules/ex-db-generic/react/components/CredentialsHeaderButtons.coffee
@@ -22,7 +22,7 @@ module.exports = (componentId, actionsProvisioning, storeProvisioning) ->
       currentConfigId: configId
       isEditing: ExDbStore.isEditingCredentials()
       isSaving: ExDbStore.isSavingCredentials()
-      isValid: ExDbStore.hasValidCredentials(creds, {skipProtected: true})
+      isValid: ExDbStore.hasValidCredentials(creds)
 
     _handleEditStart: ->
       ExDbActionCreators.editCredentials @state.currentConfigId

--- a/src/scripts/modules/ex-db-generic/react/components/NewCredentialsHeaderButtons.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/NewCredentialsHeaderButtons.jsx
@@ -13,7 +13,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
     getStateFromStores() {
       const config = routesStore.getCurrentRouteParam('config');
       const dbStore = storeProvisioning.createStore(componentId, config);
-      const isValid = dbStore.hasValidCredentials(dbStore.getNewCredentials(config), {skipProtected: true});
+      const isValid = dbStore.hasValidCredentials(dbStore.getNewCredentials(config));
       return {
         configId: config,
         isSaving: dbStore.isSavingCredentials(),

--- a/src/scripts/modules/ex-db-generic/react/pages/credentials/Credentials.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/credentials/Credentials.jsx
@@ -6,6 +6,7 @@ import {TabbedArea, TabPane} from 'react-bootstrap';
 
 export default React.createClass({
   propTypes: {
+    savedCredentials: PropTypes.object.isRequired,
     credentials: PropTypes.object.isRequired,
     isEditing: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -22,6 +23,7 @@ export default React.createClass({
         <TabbedArea defaultActiveKey="db" animation={false}>
           <TabPane eventKey="db" tab="Database Credentials">
             <CredentialsForm
+              savedCredentials={this.props.savedCredentials}
               credentials={this.props.credentials}
               enabled={this.props.isEditing}
               onChange={this.props.onChange}

--- a/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsForm.coffee
+++ b/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsForm.coffee
@@ -14,6 +14,7 @@ SshTunnelRow = React.createFactory(require('./SshTunnelRow').default)
 module.exports = React.createClass
   displayName: 'ExDbCredentialsForm'
   propTypes:
+    savedCredentials: React.PropTypes.object.isRequired
     credentials: React.PropTypes.object.isRequired
     enabled: React.PropTypes.bool.isRequired
     onChange: React.PropTypes.func
@@ -53,13 +54,16 @@ module.exports = React.createClass
 
   _createInput: (labelValue, propName, type = 'text', isProtected = false) ->
     if @props.enabled
-      Input
-        label: labelValue
-        type: type
-        value: @props.credentials.get propName
-        labelClassName: 'col-xs-4'
-        wrapperClassName: 'col-xs-8'
-        onChange: @_handleChange.bind @, propName
+      if isProtected
+        @_createProtectedInput(labelValue, propName)
+      else
+        Input
+          label: labelValue
+          type: type
+          value: @props.credentials.get propName
+          labelClassName: 'col-xs-4'
+          wrapperClassName: 'col-xs-8'
+          onChange: @_handleChange.bind @, propName
     else if isProtected
       StaticText
         label: labelValue
@@ -79,6 +83,17 @@ module.exports = React.createClass
         if @props.credentials.get propName
           Clipboard
             text: @props.credentials.get propName
+
+  _createProtectedInput: (labelValue, propName) ->
+    savedValue = this.props.savedCredentials.get(propName)
+    Input
+      label: labelValue
+      type: 'password'
+      placeholder: savedValue
+      value: @props.credentials.get propName
+      labelClassName: 'col-xs-4'
+      wrapperClassName: 'col-xs-8'
+      onChange: @_handleChange.bind @, propName
 
   _createSelect: (labelValue, propName, options) ->
     if @props.enabled

--- a/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsForm.coffee
+++ b/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsForm.coffee
@@ -9,7 +9,7 @@ StaticText = React.createFactory(require('react-bootstrap').FormControls.Static)
 Tooltip = require('../../../../../react/common/Tooltip').default
 SshTunnelRow = React.createFactory(require('./SshTunnelRow').default)
 
-{span, form, div, label, p, option} = React.DOM
+{small, span, form, div, label, p, option} = React.DOM
 
 module.exports = React.createClass
   displayName: 'ExDbCredentialsForm'
@@ -86,14 +86,28 @@ module.exports = React.createClass
 
   _createProtectedInput: (labelValue, propName) ->
     savedValue = this.props.savedCredentials.get(propName)
+
     Input
-      label: labelValue
+      label: @_renderProtectedLabel(labelValue, !!savedValue)
       type: 'password'
-      placeholder: savedValue
+      placeholder: if savedValue then 'type new password to change it' else ''
       value: @props.credentials.get propName
       labelClassName: 'col-xs-4'
       wrapperClassName: 'col-xs-8'
       onChange: @_handleChange.bind @, propName
+
+  _renderProtectedLabel: (labelValue, alreadyEncrypted) ->
+    msg = "#{labelValue} will be stored securely encrypted."
+    if alreadyEncrypted
+      msg = msg + ' The most recently stored value will be used if left empty.'
+    span null,
+      labelValue
+      small null,
+        React.createElement Tooltip,
+          placement: 'top'
+          tooltip: msg,
+          span className: 'fa fa-fw fa-question-circle', null
+
 
   _createSelect: (labelValue, propName, options) ->
     if @props.enabled

--- a/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsPage.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/credentials/CredentialsPage.jsx
@@ -31,6 +31,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning, cre
           credentialsTemplate={credentialsTemplate}
           hasSshTunnel={hasSshTunnel}
           actionsProvisioning={actionsProvisioning}
+          savedCredentials={this.state.credentials}
         />
       );
     },

--- a/src/scripts/modules/ex-db-generic/react/pages/credentials/NewCredentialsPage.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/credentials/NewCredentialsPage.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Map} from 'immutable';
 import Credentials from './Credentials';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import routesStore from '../../../../../stores/RoutesStore';
@@ -21,6 +22,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning, cre
     render() {
       return (
         <Credentials
+          savedCredentials={Map()}
           credentials={ this.state.credentials }
           isEditing={ !this.state.isSaving }
           onChange={ this.handleChange }

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.coffee
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.coffee
@@ -42,7 +42,7 @@ module.exports = (componentId) ->
       configId: config
       pendingActions: ExDbStore.getQueriesPendingActions()
       latestJobs: LatestJobsStore.getJobs componentId, config
-      hasCredentials: ExDbStore.hasValidCredentials(credentials, {skipProtected: false})
+      hasCredentials: ExDbStore.hasValidCredentials(credentials)
       queries: queries
       queriesFilter: ExDbStore.getQueriesFilter()
       queriesFiltered: ExDbStore.getQueriesFiltered()

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -43,8 +43,8 @@ export function createStore(componentId, configId) {
 
 
   return {
-    hasValidCredentials(credentials, params) {
-      const skipProtected = params.skipProtected;
+    hasValidCredentials(credentials) {
+      const configCredentials = this.getCredentials();
       if (!credentials) {
         return false;
       }
@@ -58,7 +58,9 @@ export function createStore(componentId, configId) {
           value = value.toString();
         }
         const isProtected = templateFields.getProtectedProperties(componentId).indexOf(propName) > -1;
-        return memo && !_.isEmpty(value) || (isProtected && !skipProtected);
+        const alreadySaved = !_.isEmpty(configCredentials.get(propName));
+        const isValueValid = !_.isEmpty(value) || (isProtected && alreadySaved);
+        return memo && isValueValid;
       }, true);
       const ssh = credentials.get('ssh', Map());
       const sshFields = [

--- a/src/scripts/modules/ex-db-generic/templates/credentials.coffee
+++ b/src/scripts/modules/ex-db-generic/templates/credentials.coffee
@@ -4,7 +4,7 @@ defaultFields = [
   ['Host Name', 'host', 'text', false]
   ['Port', 'port', 'number', false]
   ['Username', 'user', 'text', false]
-  ['Password', 'password', 'password', true]
+  ['Password', '#password', 'password', true]
   ['Database', 'database', 'text', false]
 ]
 
@@ -20,14 +20,14 @@ defaultFields = [
 firebirdFields = [
   ['Database', 'dbname', 'text', false]
   ['Username', 'user', 'text', false]
-  ['Password', 'password', 'password', true]
+  ['Password', '#password', 'password', true]
 ]
 
 oracleFields = [
   ['Host Name', 'host', 'text', false]
   ['Port', 'port', 'number', false]
   ['Username', 'user', 'text', false]
-  ['Password', 'password', 'password', true]
+  ['Password', '#password', 'password', true]
   ['Service Name/SID', 'database', 'text', false]
 ]
 

--- a/src/scripts/modules/ex-mongodb/react/pages/index/Index.coffee
+++ b/src/scripts/modules/ex-mongodb/react/pages/index/Index.coffee
@@ -42,7 +42,7 @@ module.exports = (componentId) ->
       configId: config
       pendingActions: ExDbStore.getQueriesPendingActions()
       latestJobs: LatestJobsStore.getJobs componentId, config
-      hasCredentials: ExDbStore.hasValidCredentials(credentials, {skipProtected: false})
+      hasCredentials: ExDbStore.hasValidCredentials(credentials)
       queries: queries
       queriesFilter: ExDbStore.getQueriesFilter()
       queriesFiltered: ExDbStore.getQueriesFiltered()

--- a/src/scripts/modules/ex-mongodb/storeProvisioning.js
+++ b/src/scripts/modules/ex-mongodb/storeProvisioning.js
@@ -59,8 +59,8 @@ export function createStore(componentId, configId) {
 
 
   return {
-    hasValidCredentials(credentials, params) {
-      const skipProtected = params.skipProtected;
+    hasValidCredentials(credentials) {
+      const configCredentials = this.getCredentials();
       if (!credentials) {
         return false;
       }
@@ -74,7 +74,9 @@ export function createStore(componentId, configId) {
           value = value.toString();
         }
         const isProtected = templateFields.getProtectedProperties(componentId).indexOf(propName) > -1;
-        return memo && !_.isEmpty(value) || (isProtected && !skipProtected);
+        const alreadySaved = !_.isEmpty(configCredentials.get(propName));
+        const isValueValid = !_.isEmpty(value) || (isProtected && alreadySaved);
+        return memo && isValueValid;
       }, true);
       const ssh = credentials.get('ssh', Map());
       const sshFields = [

--- a/src/scripts/modules/wr-dropbox/react/pages/index/Index.coffee
+++ b/src/scripts/modules/wr-dropbox/react/pages/index/Index.coffee
@@ -235,7 +235,7 @@ module.exports = React.createClass
       ul className: 'nav nav-stacked',
         li {className: classnames(disabled: !@_canRunUpload())},
           RunButtonModal
-            title: 'Upload selected tables'
+            title: 'Upload tables'
             icon: 'fa fa-fw fa-upload'
             mode: 'link'
             component: 'wr-dropbox'


### PR DESCRIPTION
fix handling credentials and password as discribed in #582 
**changes:**
- when editing existing credentials, user can either set new password or leave the password input empty and the last saved encrypted value will be used.
- all password handling is now done via `#password` property. 
- the `password` property is no more supported and used(ui BC break)
- mongo ex credentials handling is updated as well the same way