### PR TITLE
Better error handling

### DIFF
--- a/src/scripts/app.coffee
+++ b/src/scripts/app.coffee
@@ -2,6 +2,7 @@ console.time('load')
 console.log 'start'
 
 require './utils/react-shim'
+require './utils/ReactErrorHandler'
 
 React = require 'react'
 Router = require 'react-router'

--- a/src/scripts/utils/ReactErrorHandler.js
+++ b/src/scripts/utils/ReactErrorHandler.js
@@ -48,6 +48,7 @@ function monkeypatchRender(prototype) {
 
 const originalCreateElement = React.createElement;
 React.createElement = (Component, ...rest) => {
+  let newComponent = Component;
   if (typeof Component === 'function') {
     if (typeof Component.prototype.render === 'function') {
       monkeypatchRender(Component.prototype);
@@ -55,7 +56,7 @@ React.createElement = (Component, ...rest) => {
     // stateless functional component
     if (!Component.prototype.render) {
       const originalStatelessComponent = Component;
-      Component = (...args) => {
+      newComponent = (...args) => {
         try {
           return originalStatelessComponent(...args);
         } catch (error) {
@@ -67,7 +68,7 @@ React.createElement = (Component, ...rest) => {
     }
   }
 
-  return originalCreateElement.call(React, Component, ...rest);
+  return originalCreateElement.call(React, newComponent, ...rest);
 };
 
 

--- a/src/scripts/utils/ReactErrorHandler.js
+++ b/src/scripts/utils/ReactErrorHandler.js
@@ -1,0 +1,79 @@
+// from https://gist.github.com/Aldredcz/4d63b0a9049b00f54439f8780be7f0d8
+// This code handles any JS runtime error during rendering React components. Without this handling, once an error occurs, whole component tree is damaged and can't be used at all. With this handling, nothing will be rendered in production environment (error span in dev env.) + in production the error is logged to Sentry (if you are not using it just delete related code)
+// This is basicaly a workaround for proposed feature in React core - described in Issue: https://github.com/facebook/react/issues/2461
+// Works for all variants of Component creation - React.createClass, extending React.Component and also stateless functional components.
+// To get this work, just put this snippet into your entry js file. Then it will work in whole application.
+// Also supporting React Hot Reload!
+
+import React from 'react';
+
+let errorPlaceholder = <noscript/>;
+
+if (process.env.__DEV__) {
+  errorPlaceholder = (
+      <span
+    style={{
+      background: 'red',
+      color: 'white'
+    }}
+      >
+      Render error!
+    </span>
+  );
+}
+
+function logError(Component, error) {
+  const errorMsg = `Error. Check render() method of component '${Component.displayName || Component.name || '[unidentified]'}'.`;
+
+  console.error(errorMsg, 'Error details:', error); // eslint-disable-line
+}
+
+function monkeypatchRender(prototype) {
+  if (prototype && prototype.render && !prototype.render.__handlingErrors) {
+    const originalRender = prototype.render;
+
+    prototype.render = function monkeypatchedRender() {
+      try {
+        return originalRender.call(this);
+      } catch (error) {
+        logError(prototype.constructor, error);
+
+        return errorPlaceholder;
+      }
+    };
+
+    prototype.render.__handlingErrors = true; // flag render method so it's not wrapped multiple times
+  }
+}
+
+const originalCreateElement = React.createElement;
+React.createElement = (Component, ...rest) => {
+  if (typeof Component === 'function') {
+    if (typeof Component.prototype.render === 'function') {
+      monkeypatchRender(Component.prototype);
+    }
+    // stateless functional component
+    if (!Component.prototype.render) {
+      const originalStatelessComponent = Component;
+      Component = (...args) => {
+        try {
+          return originalStatelessComponent(...args);
+        } catch (error) {
+          logError(originalStatelessComponent, error);
+
+          return errorPlaceholder;
+        }
+      };
+    }
+  }
+
+  return originalCreateElement.call(React, Component, ...rest);
+};
+
+
+// allowing hot reload
+const originalForceUpdate = React.Component.prototype.forceUpdate;
+React.Component.prototype.forceUpdate = function monkeypatchedForceUpdate() {
+  monkeypatchRender(this);
+  originalForceUpdate.call(this);
+};

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -9,6 +9,7 @@ module.exports = function (options) {
     var plugins = [
         new webpack.DefinePlugin({
             'process.env': {
+                __DEV__: isDevelopment,
                 NODE_ENV: JSON.stringify(isDevelopment ? 'development' :
                     'production'),
                 IS_BROWSER: true


### PR DESCRIPTION
#### Idea
- specify custom error renderer (global / per component, e.g. by implementing method `renderOnError()` in a component)

### Notes
- This code handles any JS runtime error during rendering React components. Without this handling, once an error occurs, whole component tree is damaged and can't be used at all. With this handling, nothing will be rendered in production environment (error span in dev env.) + in production the error is logged to Sentry (if you are not using it just delete related code)
- This is basicaly a workaround for proposed feature in React core - described in Issue: https://github.com/facebook/react/issues/2461
- Works for all variants of Component creation - `React.createClass`, extending `React.Component` and also stateless functional components.
- To get this work, just put this snippet into your entry js file. Then it will work in whole application.
- Also supporting React Hot Reload!

grabbed from the following document:
https://gist.github.com/Aldredcz/4d63b0a9049b00f54439f8780be7f0d8