### PR TITLE
Prefer encrypted config attributes by default

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.coffee
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.coffee
@@ -18,11 +18,14 @@ VersionActionCreators = require '../components/VersionsActionCreators'
 
 deleteComponentConfiguration = require './utils/deleteComponentConfiguration'
 removeEmptyEncryptAttributes = require './utils/removeEmptyEncryptAttributes'
+preferEncryptedAttributes = require './utils/preferEncryptedAttributes'
 
 storeEncodedConfig = (componentId, configId, dataToSave, changeDescription) ->
   component = InstalledComponentsStore.getComponent(componentId)
   dataToSave = {
-    configuration: JSON.stringify(removeEmptyEncryptAttributes(dataToSave))
+    configuration: JSON.stringify(
+      removeEmptyEncryptAttributes(preferEncryptedAttributes(dataToSave))
+    )
   }
   if changeDescription
     dataToSave.changeDescription = changeDescription

--- a/src/scripts/modules/components/utils/preferEncryptedAttributes.js
+++ b/src/scripts/modules/components/utils/preferEncryptedAttributes.js
@@ -1,0 +1,56 @@
+var isObject = function(val) {
+  if (val === null) { return false;}
+  return ( (typeof val === 'function') || (typeof val === 'object') );
+};
+
+var preferEncryptedAttributesFromObject = function(data) {
+  var keys = Object.keys(data);
+  keys.forEach(function(key) {
+    if (key.substr(0, 1) === '#') {
+      var plainKey = key.substr(1);
+      if (data[key] !== '' && data[key] !== null) {
+        // try to delete plain value if encrypted value is not empty/null
+        if (data[plainKey]) {
+          delete data[plainKey];
+        }
+      } else {
+        // try to replace empty/null encrypted value by plain value if exists
+        if (data[plainKey]) {
+          data[key] = data[plainKey];
+          delete data[plainKey];
+        }
+      }
+    } else {
+      var encKey = '#' + key;
+      // delete plain value if encrypted exists and is not empty/null
+      if (data[encKey] && data[encKey] !== null && data[encKey] !== '') {
+        delete data[key];
+      }
+    }
+    if (isObject(data[key])) {
+      preferEncryptedAttributesFromObject(data[key]);
+    } else if (Array.isArray(data[key])) {
+      preferEncryptedAttributesFromArray(data[key]);
+    }
+  });
+};
+
+var preferEncryptedAttributesFromArray = function(data) {
+  data.forEach(function(item) {
+    if (isObject(item)) {
+      preferEncryptedAttributesFromObject(item);
+    }
+    if (Array.isArray(item)) {
+      preferEncryptedAttributesFromArray(item);
+    }
+  });
+};
+
+module.exports = function(configuration) {
+  if (isObject(configuration)) {
+    preferEncryptedAttributesFromObject(configuration);
+  } else if (Array.isArray(configuration)) {
+    preferEncryptedAttributesFromArray(configuration);
+  }
+  return configuration;
+};

--- a/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
+++ b/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
@@ -1,0 +1,123 @@
+var assert = require('assert');
+var preferEncryptedAttributes = require('./preferEncryptedAttributes');
+
+describe('preferEncryptedAttributes', function() {
+  describe('#preferEncryptedAttributes()', function() {
+    it('should return scalar when scalar', function() {
+      assert.equal('test', preferEncryptedAttributes('test'));
+    });
+
+    it('should return only encrypted key', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key1': 'val1',
+        '#key1': 'val2'
+      }), {
+        '#key1': 'val2'
+      });
+    });
+
+    it('should return only encrypted key in array', function() {
+      assert.deepEqual(preferEncryptedAttributes([
+        {
+          'key1': 'val1',
+          '#key1': 'val2'
+        }
+      ]), [
+        {
+          '#key1': 'val2'
+        }
+      ]);
+    });
+
+    it('should return only encrypted key in nested object', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key2': {
+          'key1': 'val1',
+          '#key1': 'val2'
+        }
+      }), {
+        'key2': {
+          '#key1': 'val2'
+        }
+      });
+    });
+
+    it('should return only encrypted key in array nested', function() {
+      assert.deepEqual(preferEncryptedAttributes([
+        {
+          'key2': {
+            'key1': 'val1',
+            '#key1': 'val2'
+          }
+        }
+      ]), [
+        {
+          'key2': {
+            '#key1': 'val2'
+          }
+        }
+      ]);
+    });
+
+    it('should replace by plain value if encrypted key is empty string', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key1': 'val2',
+        '#key1': ''
+      }), {
+        '#key1': 'val2'
+      });
+    });
+
+    it('should replace by plain value if encrypted key is null', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key1': 'val2',
+        '#key1': null
+      }), {
+        '#key1': 'val2'
+      });
+    });
+
+    // multiple
+    it('should return only encrypted keys', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key1': 'val1',
+        '#key1': 'val2',
+        'key2': 'val3',
+        '#key2': 'val4'
+      }), {
+        '#key1': 'val2',
+        '#key2': 'val4'
+      });
+    });
+
+    // multiple nested
+    it('should return only encrypted key in nested object', function() {
+      assert.deepEqual(preferEncryptedAttributes({
+        'key2': {
+          'key1': 'val1',
+          '#key1': 'val2'
+        },
+        'key3': 'val3',
+        '#key3': 'val4',
+        'key4': {
+          'key5': 'val5',
+          '#key5': 'val6'
+        },
+        'key5': {
+          'key5': 'val5',
+          '#key5': 'val6'
+        },
+        '#key5': 'val7'
+      }), {
+        'key2': {
+          '#key1': 'val2'
+        },
+        '#key3': 'val4',
+        'key4': {
+          '#key5': 'val6'
+        },
+        '#key5': 'val7'
+      });
+    });
+  });
+});


### PR DESCRIPTION
Fixes #648

This:
```json
{
  "key2": {
    "key1": "val1",
    "#key1": "val2"
  }
}
```

Became this:
```json
{
  "key2": {
    "#key1": "val2"
  }
}
```

cc @ondrejhlavacek 