### PR TITLE
DB EX - rename configuration

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/NewCredentialsHeaderButtons.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/NewCredentialsHeaderButtons.jsx
@@ -33,7 +33,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
     },
 
     goToIndex() {
-      this.transitionTo(`ex-db-generic-${componentId}`, {
+      this.transitionTo(componentId, {
         config: this.state.configId
       });
     },

--- a/src/scripts/modules/ex-db-generic/react/components/NewQueryHeaderButtons.coffee
+++ b/src/scripts/modules/ex-db-generic/react/components/NewQueryHeaderButtons.coffee
@@ -23,13 +23,13 @@ module.exports = (componentId, actionsProvisioning, storeProvisioning) ->
 
     _handleCancel: ->
       ExDbActionCreators.resetNewQuery @state.currentConfigId
-      @transitionTo "ex-db-generic-#{componentId}", config: @state.currentConfigId
+      @transitionTo componentId, config: @state.currentConfigId
 
     _handleCreate: ->
       ExDbActionCreators
       .createQuery @state.currentConfigId
       .then (query) =>
-        @transitionTo "ex-db-generic-#{componentId}",
+        @transitionTo componentId,
           config: @state.currentConfigId
 
     render: ->

--- a/src/scripts/modules/ex-db-generic/react/components/QueryDeleteButton.coffee
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryDeleteButton.coffee
@@ -49,7 +49,7 @@ module.exports = React.createClass
             i className: 'kbc-icon-cup'
 
   _deleteQuery: ->
-    @transitionTo "ex-db-generic-#{@props.componentId}",
+    @transitionTo @props.componentId,
       config: @props.configurationId
 
     # if query is deleted immediatelly view is rendered with missing orchestration because of store changed

--- a/src/scripts/modules/ex-db-generic/routes.coffee
+++ b/src/scripts/modules/ex-db-generic/routes.coffee
@@ -26,7 +26,7 @@ credentialsTemplate = require './templates/credentials'
 hasSshTunnel = require('../ex-db-generic/templates/hasSshTunnel').default
 
 module.exports = (componentId) ->
-  name: "ex-db-generic-#{componentId}"
+  name: componentId
   path: ':config'
   isComponent: true
   requireData: [

--- a/src/scripts/modules/ex-mongodb/routes.coffee
+++ b/src/scripts/modules/ex-mongodb/routes.coffee
@@ -27,7 +27,7 @@ credentialsTemplate = require '../ex-db-generic/templates/credentials'
 hasSshTunnel = require('../ex-db-generic/templates/hasSshTunnel').default
 
 module.exports = (componentId) ->
-  name: "ex-db-generic-#{componentId}"
+  name: componentId
   path: ':config'
   isComponent: true
   requireData: [


### PR DESCRIPTION
V DB extractorech (vcetne Monga) se nenabizela editace nazvu konfigurace

Je to z duvodu, ze routy tam jsou prefixovany 'ex-db-generic-'
Vyhodil jsem ten prefix u indexu a upravil nazev routy v editacnich tlacitkach 