### PR TITLE
Remove link to Gravatar from menu

### DIFF
--- a/src/scripts/react/layout/CurrentUser.coffee
+++ b/src/scripts/react/layout/CurrentUser.coffee
@@ -62,13 +62,6 @@ module.exports = React.createClass
     ,
       'Account Settings'
 
-    links.push React.createElement MenuItem,
-      key: 'avatar'
-      href: 'https://gravatar.com/'
-      target: '_blank'
-    ,
-      'Change Profile Picture'
-
     if @props.canManageApps
       links.push React.createElement MenuItem,
         key: 'manageApps'


### PR DESCRIPTION
It was moved to Account Setting as tooltip.

![untitled](https://cloud.githubusercontent.com/assets/419849/20632274/960066e4-b33c-11e6-9d86-1c14e2ed0bb5.png)
