### PR TITLE
yarn watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "worker-loader": "^0.8.1"
   },
   "scripts": {
+    "start-https": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https",
     "start": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline",
     "start-projects-list": "webpack-dev-server --config webpack/dev-server-projects-list.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline",
     "build": "webpack --config webpack/production.config.js --profile --colors --bail && node webpack/generate-manifest.js",

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -51,7 +51,9 @@ module.exports = function (options) {
             './node_modules/intl/Intl.js',
             './node_modules/intl/locale-data/jsonp/en.js',
             options.entry
-          ]};
+          ],
+          parts: ['./src/scripts/parts']
+        };
     } else {
         entry = {
           bundle: [


### PR DESCRIPTION
webpack-dev-server doesn't write the bundle to disk, so it could be useful (it is at least for me) to be able to run a watcher when developing against the local bundle.