### PR TITLE
Jobs reload fix

### DIFF
--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -23,8 +23,8 @@ module.exports =
     return Promise.resolve() if JobsStore.getIsLoaded()
     @loadJobsForce(JobsStore.getOffset(), false, true)
 
-  # poll for non terminated jobs
-  reloadNotTerminatedJobs: (self) ->
+  # poll for not finished jobs
+  reloadNotFinishedJobs: (self) ->
     allJobs = JobsStore.getAll()
       .filter((job, jobId) -> !job.get('isFinished'))
       .map((j) -> j.get('id'))
@@ -36,7 +36,7 @@ module.exports =
 
   reloadJobs: ->
     if JobsStore.loadJobsErrorCount() < 10
-      @loadJobsForce(0, false, true).then(@reloadNotTerminatedJobs(@))
+      @loadJobsForce(0, false, true).then(@reloadNotFinishedJobs(@))
 
   loadMoreJobs: ->
     offset = JobsStore.getNextOffset()

--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -42,10 +42,12 @@ module.exports =
     offset = JobsStore.getNextOffset()
     @loadJobsForce(offset, false, false)
 
-  loadJobsForce: (offset, resetJobs, preserveCurrentOffset, forceQuery) ->
+  loadJobsForce: (offset, forceResetJobs, preserveCurrentOffset, forceQuery) ->
     actions = @
     limit = JobsStore.getLimit()
     query = forceQuery || JobsStore.getQuery()
+    # always do reset if there is a filter set on ui
+    resetJobs = forceResetJobs || (JobsStore.getQuery() && !forceQuery)
     dispatcher.handleViewAction type: constants.ActionTypes.JOBS_LOAD
     jobsApi
     .getJobsParametrized(query, limit, offset)

--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -46,8 +46,9 @@ module.exports =
     actions = @
     limit = JobsStore.getLimit()
     query = forceQuery || JobsStore.getQuery()
-    # always do reset if there is a filter set on ui
-    resetJobs = forceResetJobs || (JobsStore.getQuery() && !forceQuery)
+    # always reset jobs if showing only first page
+    isFirstPageOnly = offset == 0 && JobsStore.getAll().count() <= limit
+    resetJobs = forceResetJobs || isFirstPageOnly
     dispatcher.handleViewAction type: constants.ActionTypes.JOBS_LOAD
     jobsApi
     .getJobsParametrized(query, limit, offset)


### PR DESCRIPTION
FIXES #1036 
1. po kazdom reloade(10s poll trigger) sa zvlast pollne zoznam not finished jobov
2. ak je na ui nastaveny filter tak sa natvrdo resetnu joby ulozene v jobs store a zobrazi iba to co mu vrati api s filtrom

