### PR TITLE
Jobs reload fix

### DIFF
--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -23,8 +23,8 @@ module.exports =
     return Promise.resolve() if JobsStore.getIsLoaded()
     @loadJobsForce(JobsStore.getOffset(), false, true)
 
-  # poll for non terminated jobs
-  reloadNotTerminatedJobs: (self) ->
+  # poll for not finished jobs
+  reloadNotFinishedJobs: (self) ->
     allJobs = JobsStore.getAll()
       .filter((job, jobId) -> !job.get('isFinished'))
       .map((j) -> j.get('id'))
@@ -36,7 +36,7 @@ module.exports =
 
   reloadJobs: ->
     if JobsStore.loadJobsErrorCount() < 10
-      @loadJobsForce(0, false, true).then(@reloadNotTerminatedJobs(@))
+      @loadJobsForce(0, false, true).then(@reloadNotFinishedJobs(@))
 
   loadMoreJobs: ->
     offset = JobsStore.getNextOffset()

--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -42,10 +42,12 @@ module.exports =
     offset = JobsStore.getNextOffset()
     @loadJobsForce(offset, false, false)
 
-  loadJobsForce: (offset, resetJobs, preserveCurrentOffset, forceQuery) ->
+  loadJobsForce: (offset, forceResetJobs, preserveCurrentOffset, forceQuery) ->
     actions = @
     limit = JobsStore.getLimit()
     query = forceQuery || JobsStore.getQuery()
+    # always do reset if there is a filter set on ui
+    resetJobs = forceResetJobs || (JobsStore.getQuery() && !forceQuery)
     dispatcher.handleViewAction type: constants.ActionTypes.JOBS_LOAD
     jobsApi
     .getJobsParametrized(query, limit, offset)

--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -46,8 +46,9 @@ module.exports =
     actions = @
     limit = JobsStore.getLimit()
     query = forceQuery || JobsStore.getQuery()
-    # always do reset if there is a filter set on ui
-    resetJobs = forceResetJobs || (JobsStore.getQuery() && !forceQuery)
+    # always reset jobs if showing only first page
+    isFirstPageOnly = offset == 0 && JobsStore.getAll().count() <= limit
+    resetJobs = forceResetJobs || isFirstPageOnly
     dispatcher.handleViewAction type: constants.ActionTypes.JOBS_LOAD
     jobsApi
     .getJobsParametrized(query, limit, offset)

--- a/src/scripts/modules/jobs/ActionCreators.coffee
+++ b/src/scripts/modules/jobs/ActionCreators.coffee
@@ -48,7 +48,7 @@ module.exports =
     query = forceQuery || JobsStore.getQuery()
     # always reset jobs if showing only first page
     isFirstPageOnly = offset == 0 && JobsStore.getAll().count() <= limit
-    resetJobs = forceResetJobs || isFirstPageOnly
+    resetJobs = forceResetJobs || (isFirstPageOnly && !forceQuery)
     dispatcher.handleViewAction type: constants.ActionTypes.JOBS_LOAD
     jobsApi
     .getJobsParametrized(query, limit, offset)


### PR DESCRIPTION
- extra poll for unfinished jobs and dont reset store(only merge with existing)
- force reset jobs if loading only first page