### PR TITLE
Transformation refresh input mapping tables

### DIFF
--- a/src/scripts/modules/components/react/components/SapiTableSelector.coffee
+++ b/src/scripts/modules/components/react/components/SapiTableSelector.coffee
@@ -16,11 +16,13 @@ module.exports = React.createClass
     value: React.PropTypes.string.isRequired
     excludeTableFn: React.PropTypes.func
     allowedBuckets: React.PropTypes.array
+    disabled: React.PropTypes.bool
 
   getDefaultProps: ->
     excludeTableFn: (tableId) ->
       return false
     allowedBuckets: ['in','out']
+    disabled: false
 
   getStateFromStores: ->
     isTablesLoading = storageTablesStore.getIsLoading()
@@ -38,16 +40,12 @@ module.exports = React.createClass
     nextProps.value != @props.value || nextState.isTablesLoading != @state.isTablesLoading
 
   render: ->
-    isTablesLoading = @state.isTablesLoading
-    if isTablesLoading
-      return React.DOM.div null,
-        Loader()
-        ' Loading tables...'
-
     Select
+      disabled: @props.disabled
       name: 'source'
       clearable: false
       value: @props.value
+      isLoading: @state.isTablesLoading
       placeholder: @props.placeholder
       onChange: (selectedOption) =>
         tableId = selectedOption.value

--- a/src/scripts/modules/components/react/components/SapiTableSelector.coffee
+++ b/src/scripts/modules/components/react/components/SapiTableSelector.coffee
@@ -47,12 +47,23 @@ module.exports = React.createClass
       value: @props.value
       isLoading: @state.isTablesLoading
       placeholder: @props.placeholder
+      valueRenderer: @valueRenderer
+      optionRenderer: @valueRenderer
       onChange: (selectedOption) =>
         tableId = selectedOption.value
         table = @state.tables.find (t) ->
           t.get('id') == tableId
         @props.onSelectTableFn(tableId, table)
       options: @_getTables()
+
+  tableExist: (tableId) ->
+    @state.tables.find((t) -> tableId == t.get('id'))
+
+  valueRenderer: (op) ->
+    if @tableExist(op.value)
+      return op.label
+    else
+      return React.DOM.span className: "text-muted", op.label
 
   _getTables: ->
     tables = @state.tables
@@ -68,4 +79,9 @@ module.exports = React.createClass
         label: tableId
         value: tableId
       }
-    tables.toList().toJS()
+    result = tables.toList().toJS()
+    hasValue = result.find((t) => t.value == @props.value)
+    if !!@props.value and not hasValue
+      return result.concat({label: @props.value, value: @props.value})
+    else
+      return result

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.coffee
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.coffee
@@ -5,6 +5,7 @@ Immutable = require('immutable')
 {Input} = require('./../../../../../react/common/KbcBootstrap')
 Input = React.createFactory Input
 Select = React.createFactory require('../../../../../react/common/Select').default
+SapiTableSelector = React.createFactory(require('../SapiTableSelector'))
 DaysFilterInput = require('./DaysFilterInput').default
 DataFilterRow = require('./DataFilterRow').default
 
@@ -57,23 +58,6 @@ module.exports = React.createClass
     value = @props.value.set("destination", e.target.value.trim())
     @props.onChange(value)
 
-  _getTables: ->
-    props = @props
-    inOutTables = @props.tables.filter((table) ->
-      table.get("id").substr(0, 3) == "in." || table.get("id").substr(0, 4) == "out."
-    )
-    map = inOutTables.map((table) ->
-      {
-        label: table.get("id")
-        value: table.get("id")
-      }
-    )
-    map.toList().sort( (valA, valB) ->
-      return 1 if valA.label > valB.label
-      return -1 if valA.label < valB.label
-      return 0
-    ).toJS()
-
   _getFileName: ->
     if @props.value.get("destination") && @props.value.get("destination") != ''
       return @props.value.get("destination")
@@ -97,13 +81,11 @@ module.exports = React.createClass
         React.DOM.div className: 'form-group',
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
-            Select
-              name: 'source'
+            SapiTableSelector
               value: @props.value.get("source")
               disabled: @props.disabled
               placeholder: "Source table"
-              onChange: @_handleChangeSource
-              options: @_getTables()
+              onSelectTableFn: @_handleChangeSource
       if (!@props.definition.has('destination'))
         React.DOM.div {className: "row col-md-12"},
           Input

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.coffee
@@ -4,6 +4,7 @@ Immutable = require('immutable')
 {Input} = require('./../../../../../react/common/KbcBootstrap')
 Input = React.createFactory Input
 Select = React.createFactory require('../../../../../react/common/Select').default
+SapiTableSelector = React.createFactory(require('../../../../components/react/components/SapiTableSelector'))
 
 module.exports = React.createClass
   displayName: 'InputMappingRowDockjerEditor'
@@ -79,23 +80,6 @@ module.exports = React.createClass
     value = @props.value.set("whereValues", newValue)
     @props.onChange(value)
 
-  _getTables: ->
-    props = @props
-    inOutTables = @props.tables.filter((table) ->
-      table.get("id").substr(0, 3) == "in." || table.get("id").substr(0, 4) == "out."
-    )
-    map = inOutTables.map((table) ->
-      {
-        label: table.get("id")
-        value: table.get("id")
-      }
-    )
-    map.toList().sort( (valA, valB) ->
-      return 1 if valA.label > valB.label
-      return -1 if valA.label < valB.label
-      return 0
-    ).toJS()
-
   _getColumns: ->
     if !@props.value.get("source")
       return []
@@ -153,14 +137,11 @@ module.exports = React.createClass
         React.DOM.div className: 'form-group',
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
-            Select
-              name: 'source'
+            SapiTableSelector
               value: @props.value.get("source")
               disabled: @props.disabled
               placeholder: "Source table"
-              onChange: @_handleChangeSource
-              options: @_getTables()
-
+              onSelectTableFn: @_handleChangeSource
       if (!@props.definition.has('destination'))
         React.DOM.div {className: "row col-md-12"},
           Input
@@ -242,4 +223,3 @@ module.exports = React.createClass
                 placeholder: 'Add a value...'
                 emptyStrings: true,
                 onChange: @_handleChangeWhereValues
-

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowMySqlEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowMySqlEditor.coffee
@@ -4,6 +4,7 @@ Immutable = require('immutable')
 {Input} = require('./../../../../../react/common/KbcBootstrap')
 Input = React.createFactory Input
 Select = React.createFactory require('../../../../../react/common/Select').default
+SapiTableSelector = React.createFactory(require('../../../../components/react/components/SapiTableSelector'))
 MySqlIndexesContainer = React.createFactory(require("./input/MySqlIndexesContainer"))
 MySqlDataTypesContainer = React.createFactory(require("./input/MySqlDataTypesContainer"))
 
@@ -100,23 +101,6 @@ module.exports = React.createClass
     value = @props.value.set("datatypes", datatypes)
     @props.onChange(value)
 
-  _getTables: ->
-    props = @props
-    inOutTables = @props.tables.filter((table) ->
-      table.get("id").substr(0, 3) == "in." || table.get("id").substr(0, 4) == "out."
-    )
-    map = inOutTables.map((table) ->
-      {
-        label: table.get("id")
-        value: table.get("id")
-      }
-    )
-    map.toList().sort( (valA, valB) ->
-      return 1 if valA.label > valB.label
-      return -1 if valA.label < valB.label
-      return 0
-    ).toJS()
-
   _getColumns: ->
     if !@props.value.get("source")
       return []
@@ -166,13 +150,11 @@ module.exports = React.createClass
         React.DOM.div className: 'form-group',
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
-            Select
-              name: 'source'
+            SapiTableSelector
               value: @props.value.get("source")
               disabled: @props.disabled
               placeholder: "Source table"
-              onChange: @_handleChangeSource
-              options: @_getTables()
+              onSelectTableFn: @_handleChangeSource
             if @state.showDetails
               React.DOM.div className: 'checkbox',
                 React.DOM.label null,

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.coffee
@@ -4,6 +4,7 @@ Immutable = require('immutable')
 {Input} = require('./../../../../../react/common/KbcBootstrap')
 Input = React.createFactory Input
 Select = React.createFactory require('../../../../../react/common/Select').default
+SapiTableSelector = React.createFactory(require('../../../../components/react/components/SapiTableSelector'))
 RedshiftDataTypesContainer = React.createFactory(require("./input/RedshiftDataTypesContainer"))
 
 ApplicationStore = require('../../../../../stores/ApplicationStore')
@@ -129,23 +130,6 @@ module.exports = React.createClass
       value = value.set("distKey", "")
     @props.onChange(value)
 
-  _getTables: ->
-    props = @props
-    inOutTables = @props.tables.filter((table) ->
-      table.get("id").substr(0, 3) == "in." || table.get("id").substr(0, 4) == "out."
-    )
-    map = inOutTables.map((table) ->
-      {
-        label: table.get("id")
-        value: table.get("id")
-      }
-    )
-    map.toList().sort( (valA, valB) ->
-      return 1 if valA.label > valB.label
-      return -1 if valA.label < valB.label
-      return 0
-    ).toJS()
-
   _getColumns: ->
     if !@props.value.get("source")
       return []
@@ -212,13 +196,11 @@ module.exports = React.createClass
         React.DOM.div className: 'form-group',
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
-            Select
-              name: 'source'
+            SapiTableSelector
               value: @props.value.get("source")
               disabled: @props.disabled
               placeholder: "Source table"
-              onChange: @_handleChangeSource
-              options: @_getTables()
+              onSelectTableFn: @_handleChangeSource
             if @state.showDetails
               React.DOM.div className: 'checkbox',
                 React.DOM.label null,

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.coffee
@@ -4,6 +4,7 @@ Immutable = require('immutable')
 {Input} = require('./../../../../../react/common/KbcBootstrap')
 Input = React.createFactory Input
 Select = React.createFactory require('../../../../../react/common/Select').default
+SapiTableSelector = React.createFactory(require('../../../../components/react/components/SapiTableSelector'))
 SnowflakeDataTypesContainer = React.createFactory(require("./input/SnowflakeDataTypesContainer"))
 
 module.exports = React.createClass
@@ -87,23 +88,6 @@ module.exports = React.createClass
     value = @props.value.set("datatypes", datatypes)
     @props.onChange(value)
 
-  _getTables: ->
-    props = @props
-    inOutTables = @props.tables.filter((table) ->
-      table.get("id").substr(0, 3) == "in." || table.get("id").substr(0, 4) == "out."
-    )
-    map = inOutTables.map((table) ->
-      {
-        label: table.get("id")
-        value: table.get("id")
-      }
-    )
-    map.toList().sort( (valA, valB) ->
-      return 1 if valA.label > valB.label
-      return -1 if valA.label < valB.label
-      return 0
-    ).toJS()
-
   _getColumns: ->
     if !@props.value.get("source")
       return []
@@ -154,13 +138,11 @@ module.exports = React.createClass
         React.DOM.div className: 'form-group',
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
-            Select
-              name: 'source'
+            SapiTableSelector
               value: @props.value.get("source")
               disabled: @props.disabled
               placeholder: "Source table"
-              onChange: @_handleChangeSource
-              options: @_getTables()
+              onSelectTableFn: @_handleChangeSource
       React.DOM.div {className: "row col-md-12"},
         Input
           type: 'text'


### PR DESCRIPTION
FIXES #1019 
- sapitableselector vyuziva loading stav react-selectu(loader embednuty v selectu)
- input table mapping si pri kazdom otvoreni modalu refreshne zoznam tabuliek

Navonok to vypada rovnako ako predtym:
![image](https://user-images.githubusercontent.com/1412120/29830630-12a22432-8ce3-11e7-8a1b-e0f7a699bfa7.png)

![imtablesrefresh](https://user-images.githubusercontent.com/1412120/29830877-b434171a-8ce3-11e7-985a-69f85f6e067d.gif)

