### PR TITLE
Move table preview to a dedicated page

### DIFF
--- a/src/scripts/modules/apify/routes.js
+++ b/src/scripts/modules/apify/routes.js
@@ -3,6 +3,7 @@ import installedComponentsActions from '../components/InstalledComponentsActionC
 // import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const componentId = 'apify.apify';
 
@@ -18,5 +19,6 @@ export default {
   poll: {
     interval: 7,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
-  }
+  },
+  childRoutes: [ createTablesRoute(componentId)]
 };

--- a/src/scripts/modules/app-geneea-nlp-analysis/routes.js
+++ b/src/scripts/modules/app-geneea-nlp-analysis/routes.js
@@ -4,6 +4,7 @@ import HeaderButtons from './react/HeaderButtons';
 import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const componentId = 'geneea-nlp-analysis';
 
@@ -21,5 +22,6 @@ export default {
   poll: {
     interval: 5,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
-  }
+  },
+  childRoutes: [ createTablesRoute(componentId)]
 };

--- a/src/scripts/modules/components/createGenericDetailRoute.coffee
+++ b/src/scripts/modules/components/createGenericDetailRoute.coffee
@@ -16,6 +16,7 @@ JobsActionCreators = require '../jobs/ActionCreators'
 ComponentsActionCreators = require './ComponentsActionCreators'
 injectProps = require('./react/injectProps').default
 OauthUtils = require '../oauth-v2/OauthUtils'
+{createTablesRoute} = require '../table-browser/routes'
 
 module.exports = (componentType) ->
   # return
@@ -64,6 +65,7 @@ module.exports = (componentType) ->
       action: (params) ->
         JobsActionCreators.loadComponentConfigurationLatestJobs(params.component, params.config)
     childRoutes: [
+      createTablesRoute('generic-detail-' + componentType + '-config')
       createVersionsPageRoute(null, 'config', componentType + '-versions')
       OauthUtils.createRedirectRoute(
         'generic-' + componentType + '-oauth-redirect'

--- a/src/scripts/modules/csv-import/routes.js
+++ b/src/scripts/modules/csv-import/routes.js
@@ -2,6 +2,7 @@ import Index from './react/Index/Index';
 import storageActions from '../components/StorageActionCreators';
 import installedComponentsActions from '../components/InstalledComponentsActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const COMPONENT_ID = 'keboola.csv-import';
 
@@ -15,5 +16,6 @@ export default {
     (params) => versionsActions.loadVersions(COMPONENT_ID, params.config),
     () => storageActions.loadTables(),
     () => storageActions.loadBuckets()
-  ]
+  ],
+  childRoutes: [ createTablesRoute(COMPONENT_ID)]
 };

--- a/src/scripts/modules/ex-db-generic/routes.coffee
+++ b/src/scripts/modules/ex-db-generic/routes.coffee
@@ -12,6 +12,7 @@ ExDbQueryHeaderButtons = require('./react/components/QueryActionButtons').defaul
 ExDbCredentialsHeaderButtons = require './react/components/CredentialsHeaderButtons'
 ExDbNewCredentialsHeaderButtons = require('./react/components/NewCredentialsHeaderButtons').default
 ExDbQueryName = require './react/components/QueryName'
+{createTablesRoute} = require '../table-browser/routes'
 
 createVersionsPageRoute = require('../../modules/components/utils/createVersionsPageRoute').default
 injectProps = require('../components/react/injectProps').default
@@ -44,6 +45,7 @@ module.exports = (componentId) ->
       JobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
   defaultRouteHandler: ExDbIndex(componentId)
   childRoutes: [
+    createTablesRoute(componentId)
     createVersionsPageRoute(componentId, 'config')
   ,
     name: "ex-db-generic-#{componentId}-query"
@@ -61,8 +63,9 @@ module.exports = (componentId) ->
       ->
         StorageActionCreators.loadTables()
     ]
-    handler: ExDbQueryDetail(componentId, actionsProvisioning, storeProvisioning)
+    defaultRouteHandler: ExDbQueryDetail(componentId, actionsProvisioning, storeProvisioning)
     headerButtonsHandler: ExDbQueryHeaderButtons(componentId, actionsProvisioning, storeProvisioning)
+    childRoutes: [ createTablesRoute("ex-db-generic-#{componentId}-query")]
   ,
     name: "ex-db-generic-#{componentId}-new-query"
     path: 'new-query'

--- a/src/scripts/modules/ex-dropbox-v2/routes.js
+++ b/src/scripts/modules/ex-dropbox-v2/routes.js
@@ -2,7 +2,7 @@ import Index from './react/Index';
 import installedComponentsActions from '../components/InstalledComponentsActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
-
+import {createTablesRoute} from '../table-browser/routes';
 
 export default {
   name: 'radektomasek.ex-dropbox-v2',
@@ -16,5 +16,6 @@ export default {
     interval: 7,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs('radektomasek.ex-dropbox-v2', params.config)
   },
-  defaultRouteHandler: Index
+  defaultRouteHandler: Index,
+  childRoutes: [ createTablesRoute('radektomasek.ex-dropbox-v2')]
 };

--- a/src/scripts/modules/ex-dropbox/routes.js
+++ b/src/scripts/modules/ex-dropbox/routes.js
@@ -6,6 +6,7 @@ import oauthActions from '../components/OAuthActionCreators';
 import RouterStore from '../../stores/RoutesStore';
 import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 
 export default {
@@ -24,6 +25,7 @@ export default {
   defaultRouteHandler: Index,
 
   childRoutes: [
+    createTablesRoute('ex-dropbox'),
     {
       name: 'ex-dropbox-oauth-redirect',
       path: 'oauth-redirect',

--- a/src/scripts/modules/ex-facebook/routes.js
+++ b/src/scripts/modules/ex-facebook/routes.js
@@ -4,6 +4,7 @@ import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
 import * as oauthUtils from '../oauth-v2/OauthUtils';
+import {createTablesRoute} from '../table-browser/routes';
 
 export default function(componentId) {
   return {
@@ -21,6 +22,7 @@ export default function(componentId) {
     poll: {
       interval: 5,
       action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
-    }
+    },
+    childRoutes: [createTablesRoute(componentId)]
   };
 }

--- a/src/scripts/modules/ex-google-analytics-v4/routes.js
+++ b/src/scripts/modules/ex-google-analytics-v4/routes.js
@@ -8,6 +8,7 @@ import NewQueryHeaderButtons from './react/NewQuery/HeaderButtons';
 import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 import store from './storeProvisioning';
 import InstalledComponentsStore from '../components/stores/InstalledComponentsStore';
@@ -37,17 +38,19 @@ export default function(componentId) {
     },
 
     childRoutes: [
+      createTablesRoute(componentId),
       oauthUtils.createRedirectRouteSimple(componentId),
       {
         name: componentId + '-query-detail',
         path: 'query/:queryId',
-        handler: QueryDetail(componentId),
+        defaultRouteHandler: QueryDetail(componentId),
         headerButtonsHandler: QueryDetailHeaderButtons(componentId),
         title: (routerState) => {
           const configId = routerState.getIn(['params', 'config']);
           const queryId = routerState.getIn(['params', 'queryId']);
           return store(configId, componentId).getConfigQuery(queryId).get('name');
-        }
+        },
+        childRoutes: [ createTablesRoute(componentId + '-query-detail')]
       },
       {
         name: componentId + '-new-query',

--- a/src/scripts/modules/ex-google-bigquery/routes.js
+++ b/src/scripts/modules/ex-google-bigquery/routes.js
@@ -12,6 +12,7 @@ import installedComponentsActions from '../components/InstalledComponentsActionC
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
 import storageActions from '../components/StorageActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const ROUTE_PREFIX = 'ex-db-generic-';
 const COMPONENT_ID = 'keboola.ex-google-bigquery';
@@ -38,17 +39,19 @@ export default {
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(COMPONENT_ID, params.config)
   },
   childRoutes: [
+    createTablesRoute(COMPONENT_ID),
     oauthUtils.createRedirectRouteSimple(COMPONENT_ID),
     {
       name: ROUTE_PREFIX + COMPONENT_ID + '-query',
       path: 'query/:query',
-      handler: QueryDetail,
+      defaultRouteHandler: QueryDetail,
       headerButtonsHandler: QueryDetailHeaderButtons,
       title: (routerState) => {
         const configId = routerState.getIn(['params', 'config']);
         const query = routerState.getIn(['params', 'query']);
         return store(configId).getConfigQuery(query).get('name');
-      }
+      },
+      childRoutes: [ createTablesRoute(ROUTE_PREFIX + COMPONENT_ID + '-query')]
     },
     {
       name: ROUTE_PREFIX + COMPONENT_ID + '-new-query',

--- a/src/scripts/modules/ex-google-drive-old/exGdriveRoutes.coffee
+++ b/src/scripts/modules/ex-google-drive-old/exGdriveRoutes.coffee
@@ -9,6 +9,7 @@ ExGdriveSheetHeaderButtons = require './react/components/SheetHeaderButtons'
 sheetsPicker = require './react/pages/sheets-picker/SheetsPicker'
 ExGdriveSheetSelectionHeader = require './react/components/SaveSelectedSheetsHeader'
 JobsActionCreators = require '../jobs/ActionCreators'
+{createTablesRoute} = require '../table-browser/routes'
 
 module.exports =
   name: 'ex-google-drive'
@@ -27,6 +28,8 @@ module.exports =
     configId = routerState.getIn ['params', 'config']
     IntalledComponentsStore.getConfig('ex-google-drive', configId).get 'name'
   childRoutes: [
+    createTablesRoute('ex-google-drive')
+  ,
     name: 'ex-google-drive-select-sheets'
     path: 'sheets'
     handler: sheetsPicker
@@ -42,7 +45,8 @@ module.exports =
     path: 'sheet/:fileId/:sheetId'
     title: ->
       'sheet'
-    handler: sheetDetail
+    defaultRouteHandler: sheetDetail
     headerButtonsHandler: ExGdriveSheetHeaderButtons
+    childRoutes: [ createTablesRoute('ex-google-drive-sheet')]
 
   ]

--- a/src/scripts/modules/ex-google-drive/routes.js
+++ b/src/scripts/modules/ex-google-drive/routes.js
@@ -11,6 +11,7 @@ import * as oauthUtils from '../oauth-v2/OauthUtils';
 import installedComponentsActions from '../components/InstalledComponentsActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
 import storageActions from '../components/StorageActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const COMPONENT_ID = 'keboola.ex-google-drive';
 
@@ -36,6 +37,7 @@ export default {
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(COMPONENT_ID, params.config)
   },
   childRoutes: [
+    createTablesRoute(COMPONENT_ID),
     oauthUtils.createRedirectRouteSimple(COMPONENT_ID)
     // {
     //   name: COMPONENT_ID + '-sheet-detail',

--- a/src/scripts/modules/ex-mongodb/routes.coffee
+++ b/src/scripts/modules/ex-mongodb/routes.coffee
@@ -20,7 +20,7 @@ ExDbQueryName = require '../ex-db-generic/react/components/QueryName'
 JobsActionCreators = require '../jobs/ActionCreators'
 StorageActionCreators = require('../components/StorageActionCreators')
 VersionsActionsCreators = require('../components/VersionsActionCreators')
-
+{createTablesRoute} = require '../table-browser/routes'
 storeProvisioning = require './storeProvisioning'
 
 credentialsTemplate = require '../ex-db-generic/templates/credentials'
@@ -45,6 +45,8 @@ module.exports = (componentId) ->
       JobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
   defaultRouteHandler: ExDbIndex(componentId)
   childRoutes: [
+    createTablesRoute(componentId)
+  ,
     name: "ex-db-generic-#{componentId}-query"
     path: 'query/:query'
     title: (routerState) ->
@@ -60,13 +62,14 @@ module.exports = (componentId) ->
       ->
         StorageActionCreators.loadTables()
     ]
-    handler: ExDbQueryDetail(componentId, actionsProvisioning, storeProvisioning)
+    defaultRouteHandler: ExDbQueryDetail(componentId, actionsProvisioning, storeProvisioning)
     headerButtonsHandler: ExDbQueryHeaderButtons(
       componentId,
       actionsProvisioning,
       storeProvisioning,
       'Export'
     )
+    childRoutes: [ createTablesRoute("ex-db-generic-#{componentId}-query")]
   ,
     name: "ex-db-generic-#{componentId}-new-query"
     path: 'new-query'

--- a/src/scripts/modules/ex-s3/routes.js
+++ b/src/scripts/modules/ex-s3/routes.js
@@ -4,6 +4,7 @@ import installedComponentsActions from '../components/InstalledComponentsActionC
 import versionsActions from '../components/VersionsActionCreators';
 import jobsActions from '../jobs/ActionCreators';
 import InstalledComponentsStore from '../components/stores/InstalledComponentsStore';
+import {createTablesRoute} from '../table-browser/routes';
 
 const COMPONENT_ID = 'keboola.ex-s3';
 
@@ -25,5 +26,6 @@ export default {
     (params) => versionsActions.loadVersions(COMPONENT_ID, params.config),
     () => storageActions.loadTables(),
     () => storageActions.loadBuckets()
-  ]
+  ],
+  childRoutes: [ createTablesRoute(COMPONENT_ID)]
 };

--- a/src/scripts/modules/geneea-nlp-analysis-v2/routes.js
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/routes.js
@@ -4,6 +4,7 @@ import HeaderButtons from './react/HeaderButtons';
 import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
+import {createTablesRoute} from '../table-browser/routes';
 
 const componentId = 'geneea.nlp-analysis-v2';
 
@@ -21,5 +22,6 @@ export default {
   poll: {
     interval: 5,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
-  }
+  },
+  childRoutes: [ createTablesRoute(componentId)]
 };

--- a/src/scripts/modules/gooddata-writer/routes.coffee
+++ b/src/scripts/modules/gooddata-writer/routes.coffee
@@ -12,6 +12,7 @@ ModelPage = require './react/pages/model/Model'
 storageActionCreators = require '../components/StorageActionCreators'
 JobsActionCreators = require '../jobs/ActionCreators'
 VersionsActionCreators = require '../components/VersionsActionCreators'
+{createTablesRoute} = require '../table-browser/routes'
 
 module.exports =
   name: 'gooddata-writer'
@@ -38,6 +39,8 @@ module.exports =
     configId = routerState.getIn ['params', 'config']
     InstalledComponentsStore.getConfig('gooddata-writer', configId).get 'name'
   childRoutes: [
+    createTablesRoute('gooddata-writer')
+  ,
     name: 'gooddata-writer-table'
     path: 'table/:table'
     requireData: [

--- a/src/scripts/modules/jobs/Routes.coffee
+++ b/src/scripts/modules/jobs/Routes.coffee
@@ -8,6 +8,7 @@ JobDetailButtons = require './react/components/JobDetailButtons'
 JobsStore = require('./stores/JobsStore')
 Promise = require('bluebird')
 InstalledComponentsActionCreators = require('../components/InstalledComponentsActionCreators')
+{createTablesRoute} = require('../table-browser/routes')
 
 routes =
       name: 'jobs'
@@ -48,8 +49,7 @@ routes =
           jobId = routerState.getIn(['params', 'jobId'])
           job = JobsStore.get parseInt(jobId)
           job && !job.get('isFinished')
-
-        handler: JobDetail
+        defaultRouteHandler: JobDetail
         headerButtonsHandler: JobDetailButtons
         poll:
           interval: 2
@@ -62,6 +62,7 @@ routes =
           (params) ->
             JobsActionCreators.loadJobDetail(parseInt(params.jobId))
         ]
+        childRoutes: [ createTablesRoute('jobDetail')]
       ]
 
 module.exports = routes

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -16,7 +16,8 @@ import {startDataProfilerJob, getDataProfilerJob, fetchProfilerData} from './com
 import createStoreMixin from '../../../react/mixins/createStoreMixin';
 import { factory as EventsServiceFactory} from '../../sapi-events/EventsService';
 
-import RouterStore from '../../../stores/RoutesStore';
+import RoutesStore from '../../../stores/RoutesStore';
+import {PATH_PREFIX} from '../routes';
 
 const  IMPORT_EXPORT_EVENTS = ['tableImportStarted', 'tableImportDone', 'tableImportError', 'tableExported'];
 
@@ -75,7 +76,7 @@ export default React.createClass({
   },
 
   getRouteTableId() {
-    return RouterStore.getCurrentRouteParam('tableId');
+    return RoutesStore.getCurrentRouteParam('tableId');
   },
 
   getTableId() {
@@ -293,11 +294,20 @@ export default React.createClass({
     return this.state.isLoading || this.state.loadingPreview || this.state.eventService.getIsLoading();
   },
 
+  redirectBack() {
+    const routerState = RoutesStore.getRouterState();
+    const currentPath = routerState.get('path') || '';
+    const parts = currentPath.split(`${PATH_PREFIX}/`);
+    const backPath = parts ? parts[0] : '/';
+    RoutesStore.getRouter().transitionTo(backPath || '/');
+  },
+
   onHide() {
     this.setState({show: false});
     this.changeTable(this.getRouteTableId(), true);
     this.stopPollingDataProfilerJob();
     this.stopEventService();
+    this.redirectBack();
   },
 
   reload() {

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -105,7 +105,7 @@ export default React.createClass({
   },
 
   componentDidMount() {
-    setTimeout(() => this.onShow());
+    setTimeout(() => storageActions.loadTables().then(this.onShow));
   },
 
   componentWilUnmount() {

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -297,7 +297,7 @@ export default React.createClass({
   redirectBack() {
     const routerState = RoutesStore.getRouterState();
     const currentPath = routerState.get('path') || '';
-    const parts = currentPath.split(`${PATH_PREFIX}/`);
+    const parts = currentPath.split(`/${PATH_PREFIX}/`);
     const backPath = parts ? parts[0] : '/';
     RoutesStore.getRouter().transitionTo(backPath || '/');
   },

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -91,7 +91,6 @@ export default React.createClass({
     return ({
       eventService: es,
       events: Immutable.List(),
-      show: false,
       dataPreview: Immutable.List(),
       dataPreviewError: null,
       loadingPreview: false,
@@ -207,7 +206,6 @@ export default React.createClass({
     return (
       <TableLinkModalDialog
         moreTables={this.props.moreTables.toArray()}
-        show={true}
         tableId={this.getTableId()}
         reload={this.reload}
         tableExists={this.tableExists()}

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -106,7 +106,7 @@ export default React.createClass({
   },
 
   componentDidMount() {
-    setTimeout(() => storageActions.loadTables());
+    setTimeout(() => this.onShow());
   },
 
   componentWilUnmount() {
@@ -317,15 +317,12 @@ export default React.createClass({
     this.findEnhancedJob();
   },
 
-  onShow(e) {
+  onShow() {
     if (this.state.isLoading) {
       storageApi.getTables().then(() => this.loadAll());
     } else {
       this.loadAll();
     }
-
-    e.stopPropagation();
-    e.preventDefault();
   },
 
   startEventService() {

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -1,0 +1,389 @@
+import React from 'react';
+import Immutable, {List, Map} from 'immutable';
+import _ from 'underscore';
+import Promise from 'bluebird';
+import moment from 'moment';
+import filesize from 'filesize';
+import later from 'later';
+
+import storageActions from '../../components/StorageActionCreators';
+import storageApi from '../../components/StorageApi';
+import tablesStore from '../../components/stores/StorageTablesStore';
+
+import TableLinkModalDialog from './components/ModalDialog';
+import {startDataProfilerJob, getDataProfilerJob, fetchProfilerData} from './components/DataProfilerUtils';
+
+import createStoreMixin from '../../../react/mixins/createStoreMixin';
+import { factory as EventsServiceFactory} from '../../sapi-events/EventsService';
+
+import RouterStore from '../../../stores/RoutesStore';
+
+const  IMPORT_EXPORT_EVENTS = ['tableImportStarted', 'tableImportDone', 'tableImportError', 'tableExported'];
+
+export default React.createClass({
+
+  mixins: [createStoreMixin(tablesStore)],
+
+  propTypes: {
+    moreTables: React.PropTypes.object
+  },
+
+  getDefaultProps() {
+    return {
+      moreTables: List()
+    };
+  },
+
+  getStateFromStores() {
+    return this.prepareStateFromProps({tableId: this.getTableId()});
+  },
+
+  componentWillReceiveProps(nextProps) {
+    this.setState(this.prepareStateFromProps(nextProps));
+  },
+
+  prepareStateFromProps(props) {
+    const isLoading = tablesStore.getIsLoading();
+    const tables = tablesStore.getAll() || Map();
+    const table = tables.get(props.tableId, Map());
+    return {
+      tableId: props.tableId,
+      table: table,
+      isLoading: isLoading
+    };
+  },
+
+  changeTable(newTableId, dontLoadAll) {
+    let newState = _.clone(this.prepareStateFromProps({tableId: newTableId}));
+    const initDataState = {
+      detailEventId: null,
+      isCallingRunAnalysis: false,
+      profilerData: Map(),
+      loadingPreview: false,
+      loadingProfilerData: false,
+      dataPreview: Immutable.List(),
+      dataPreviewError: null,
+      events: Immutable.List()
+    };
+    newState = _.extend(newState, initDataState);
+    this.setState(newState, () => {
+      if (!dontLoadAll) {
+        this.resetTableEvents();
+        this.loadAll();
+      }
+    });
+  },
+
+  getRouteTableId() {
+    return RouterStore.getCurrentRouteParam('tableId');
+  },
+
+  getTableId() {
+    return this.state ? this.state.tableId : this.getRouteTableId();
+  },
+
+  getInitialState() {
+    const omitFetches = true, omitExports = false, filterIOEvents = false;
+    const es = EventsServiceFactory({limit: 10});
+    const eventQuery = this.prepareEventQuery({omitFetches, omitExports, filterIOEvents});
+    es.setQuery(eventQuery);
+
+    return ({
+      eventService: es,
+      events: Immutable.List(),
+      show: false,
+      dataPreview: Immutable.List(),
+      dataPreviewError: null,
+      loadingPreview: false,
+      loadingProfilerData: false,
+      omitFetches: omitFetches,
+      omitExports: omitExports,
+      filterIOEvents: filterIOEvents,
+      isCallingRunAnalysis: false,
+      detailEventId: null,
+      profilerData: Map()
+    });
+  },
+
+  componentDidMount() {
+    setTimeout(() => storageActions.loadTables());
+  },
+
+  componentWilUnmount() {
+    this.stopEventService();
+    this.stopPollingDataProfilerJob();
+  },
+
+  pollDataProfilerJob() {
+    const schedule = later.parse.recur().every(5).second();
+    this.stopPollingDataProfilerJob();
+    this.timeout = later.setInterval(this.getDataProfilerJobResult, schedule);
+  },
+
+  getDataProfilerJobResult() {
+    const jobId = this.state.profilerData.getIn(['runningJob', 'id']);
+    getDataProfilerJob(jobId).then( (runningJob) => {
+      if (runningJob.isFinished) {
+        this.stopPollingDataProfilerJob();
+        this.findEnhancedJob();
+      }
+    });
+  },
+
+  stopPollingDataProfilerJob() {
+    if (this.timeout) {
+      this.timeout.clear();
+    }
+  },
+
+  findEnhancedJob() {
+    // do the enhanced analysis only for redshift tables
+    if (!this.isRedshift()) {
+      return;
+    }
+    this.setState({loadingProfilerData: true});
+    const tableId = this.getTableId();
+    const component = this;
+    fetchProfilerData(tableId).then( (result) =>{
+      component.setState({
+        profilerData: Immutable.fromJS(result),
+        loadingProfilerData: false
+      });
+      if (result && result.runningJob) {
+        this.pollDataProfilerJob();
+      }
+    });
+  },
+
+  render() {
+    return (
+      <span key="mainspan">
+        {this.renderModal()}
+      </span>
+    );
+  },
+
+/*   renderLink() {
+    return (
+      <Tooltip key="tooltip"
+        tooltip={this.renderTooltip()}
+        placement="top">
+        <span key="buttonlink" className="kbc-sapi-table-link"
+          onClick={this.onShow}>
+          {this.props.children || this.props.linkLabel || this.props.tableId}
+        </span>
+      </Tooltip>
+    );
+  }, */
+
+  renderTooltip() {
+    if (this.state.isLoading) {
+      return 'Loading';
+    }
+
+    const table = this.state.table;
+    if (!this.tableExists()) {
+      return 'Table does not exist.';
+    }
+    if (table.get('lastChangeDate') === null) {
+      return 'Table exists, but was never imported.';
+    }
+    return (
+      <span key="tooltipinfo">
+        <div>
+          {moment(table.get('lastChangeDate')).fromNow()}
+        </div>
+        <div>
+          {filesize(table.get('dataSizeBytes', 'N/A'))}
+        </div>
+        <div>
+          {table.get('rowsCount', 'N/A')} rows
+        </div>
+      </span>
+    );
+  },
+
+  renderModal() {
+    return (
+      <TableLinkModalDialog
+        moreTables={this.props.moreTables.toArray()}
+        show={true}
+        tableId={this.getTableId()}
+        reload={this.reload}
+        tableExists={this.tableExists()}
+        omitFetches={this.state.omitFetches}
+        omitExports={this.state.omitExports}
+        onHideFn={this.onHide}
+        isLoading={this.isLoading()}
+        table={this.state.table}
+        dataPreview={this.state.dataPreview}
+        dataPreviewError={this.state.dataPreviewError}
+        onOmitExportsFn={this.onOmitExports}
+        onOmitFetchesFn={this.onOmitFetches}
+        events={this.state.events}
+        enhancedAnalysis={this.state.profilerData}
+        onRunAnalysis={this.onRunEnhancedAnalysis}
+        isCallingRunAnalysis={this.state.isCallingRunAnalysis}
+        loadingProfilerData={this.state.loadingProfilerData}
+        isRedshift={this.isRedshift()}
+        onChangeTable={this.changeTable}
+        filterIOEvents={this.state.filterIOEvents}
+        onFilterIOEvents={this.onFilterIOEvents}
+        onShowEventDetail={(eventId) => this.setState({detailEventId: eventId})}
+        detailEventId={this.state.detailEventId}
+      />
+    );
+  },
+
+  onRunEnhancedAnalysis() {
+    this.setState({isCallingRunAnalysis: true});
+    startDataProfilerJob(this.getTableId())
+      .then( () => {
+        this.findEnhancedJob().then(() => this.setState({isCallingRunAnalysis: false}));
+      })
+      .catch(() => this.setState({isCallingRunAnalysis: false}));
+  },
+
+  onOmitExports(e) {
+    const checked = e.target.checked;
+    this.setState({omitExports: checked}, () => {
+      const q = this.prepareEventQuery();
+      this.state.eventService.setQuery(q);
+      this.state.eventService.load();
+    });
+  },
+
+  onOmitFetches(e) {
+    const checked = e.target.checked;
+    this.setState({omitFetches: checked}, () => {
+      const q = this.prepareEventQuery();
+      this.state.eventService.setQuery(q);
+      this.state.eventService.load();
+    });
+  },
+
+  onFilterIOEvents(e) {
+    const checked = e.target.checked;
+    this.setState({filterIOEvents: checked}, () => {
+      const q = this.prepareEventQuery();
+      this.state.eventService.setQuery(q);
+      this.state.eventService.load();
+    });
+  },
+
+  resetTableEvents() {
+    const q = this.prepareEventQuery();
+    this.stopEventService();
+    this.state.eventService.reset();
+    this.state.eventService.setQuery(q);
+  },
+
+  prepareEventQuery(initState) {
+    const state = initState || this.state;
+    const {omitExports, omitFetches, filterIOEvents} = state;
+    const omitFetchesEvent = omitFetches ? ['tableDataPreview', 'tableDetail'] : [];
+    const omitExportsEvent = omitExports ? ['tableExported'] : [];
+    let omitsQuery = omitFetchesEvent.concat(omitExportsEvent).map((ev) => `NOT event:storage.${ev}`);
+    if (filterIOEvents) {
+      omitsQuery =  IMPORT_EXPORT_EVENTS.map((ev) => `event:storage.${ev}`);
+    }
+    const objectIdQuery = `objectId:${this.getTableId()}`;
+    return _.isEmpty(omitsQuery) ? objectIdQuery : `((${omitsQuery.join(' OR ')}) AND ${objectIdQuery})`;
+  },
+
+  isLoading() {
+    return this.state.isLoading || this.state.loadingPreview || this.state.eventService.getIsLoading();
+  },
+
+  onHide() {
+    this.setState({show: false});
+    this.changeTable(this.getRouteTableId(), true);
+    this.stopPollingDataProfilerJob();
+    this.stopEventService();
+  },
+
+  reload() {
+    Promise.props( {
+      'loadAllTablesFore': storageActions.loadTablesForce().then(() => this.findEnhancedJob()),
+      'exportData': this.exportDataSample(),
+      'loadEvents': this.state.eventService.load()
+    });
+  },
+
+  loadAll() {
+    this.exportDataSample();
+    this.startEventService();
+    this.setState({show: true});
+    this.findEnhancedJob();
+  },
+
+  onShow(e) {
+    if (this.state.isLoading) {
+      storageApi.getTables().then(() => this.loadAll());
+    } else {
+      this.loadAll();
+    }
+
+    e.stopPropagation();
+    e.preventDefault();
+  },
+
+  startEventService() {
+    this.state.eventService.addChangeListener(this.handleEventsChange);
+    this.state.eventService.load();
+  },
+
+  stopEventService() {
+    this.state.eventService.stopAutoReload();
+    this.state.eventService.removeChangeListener(this.handleEventsChange);
+  },
+
+  handleEventsChange() {
+    const events = this.state.eventService.getEvents();
+    this.setState({events: events});
+  },
+
+  exportDataSample() {
+    if (!this.tableExists()) {
+      return false;
+    }
+
+    this.setState({
+      loadingPreview: true
+    });
+    const component = this;
+    return storageApi
+      .tableDataPreview(this.getTableId(), {limit: 10})
+      .then( (csv) => {
+        component.setState({
+          loadingPreview: false,
+          dataPreview: Immutable.fromJS(csv)
+        });
+      })
+      .catch((error) => {
+        let dataPreviewError = null;
+        if (error.response && error.response.body) {
+          if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
+            dataPreviewError = 'Data sample cannot be displayed. Too many columns.';
+          } else {
+            dataPreviewError = error.response.body.message;
+          }
+        } else {
+          throw new Error(JSON.stringify(error));
+        }
+        component.setState({
+          loadingPreview: false,
+          dataPreviewError: dataPreviewError
+        });
+      });
+  },
+
+  tableExists() {
+    return !_.isEmpty(this.state.table.toJS());
+  },
+
+  isRedshift() {
+    return this.tableExists() && this.state.table.getIn(['bucket', 'backend']) === 'redshift';
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/Index.jsx
+++ b/src/scripts/modules/table-browser/react/Index.jsx
@@ -80,7 +80,7 @@ export default React.createClass({
   },
 
   getTableId() {
-    return this.state ? this.state.tableId : this.getRouteTableId();
+    return (this.state && this.state.tableId) ? this.state.tableId : this.getRouteTableId();
   },
 
   getInitialState() {

--- a/src/scripts/modules/table-browser/react/components/ColumnsInfoTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/ColumnsInfoTab.jsx
@@ -1,0 +1,249 @@
+import React, {PropTypes} from 'react';
+import _ from 'underscore';
+
+import EmptyState from '../../../components/react/components/ComponentEmptyState';
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+
+import Tooltip from '../../../../react/common/Tooltip';
+import enhancedColumnsTemplate from './EnhancedComlumnsTemplate';
+import EnhancedAnalysisRunControl from './EnhancedAnalysisRunControl';
+import {Table} from 'react-bootstrap';
+
+
+export default React.createClass({
+  propTypes: {
+    tableExists: PropTypes.bool.isRequired,
+    table: PropTypes.object,
+    dataPreview: PropTypes.object,
+    dataPreviewError: PropTypes.string,
+    enhancedAnalysis: PropTypes.object,
+    isRedshift: PropTypes.bool,
+    onRunAnalysis: PropTypes.func,
+    isCallingRunAnalysis: PropTypes.bool,
+    loadingProfilerData: PropTypes.bool
+
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    if (this.props.dataPreviewError) {
+      return (
+          <EmptyState>
+            {this.props.dataPreviewError}
+          </EmptyState>
+      );
+    }
+
+    if (!this.props.tableExists || !this.isDataPreview()) {
+      return (
+        <EmptyState>
+          No Data.
+        </EmptyState>
+      );
+    }
+    const {table} = this.props;
+    const columns = table.get('columns');
+
+    const headerRow = this.renderHeaderRow();
+
+    const columnsRows = columns.map((c) => {
+      const values = this.getColumnValues(c);
+      let result = values.filter((val) => val !== '').join(', ');
+      return this.renderBodyRow(c, this.renderNameColumnCell(c), result);
+    });
+
+    return (
+      <div>
+        <Table responsive className="table table-striped">
+          {headerRow}
+          <tbody>
+            {columnsRows}
+          </tbody>
+        </Table>
+      </div>
+    );
+  },
+
+  renderNameColumnCell(column) {
+    const {table} = this.props,
+      indexed = table.get('indexedColumns'),
+      primary = table.get('primaryKey');
+    return (
+      <span>
+        {column}
+        <div>
+          {indexed.indexOf(column) > -1 ? ( <small><span className="label label-info">index</span></small>) : '' }
+          {primary.indexOf(column) > -1 ? ( <small><span className="label label-info">PK</span></small>) : '' }
+        </div>
+      </span>
+    );
+  },
+
+  renderHeaderRow() {
+    const simpleHeader = (
+      <thead>
+        <tr>
+          <th>
+            Column
+          </th>
+          <th>
+            Sample Values
+          </th>
+        </tr>
+      </thead>
+    );
+
+    if (!this.props.isRedshift) {
+      return simpleHeader;
+    }
+
+    const enhancedHeader = this.getEnahncedHeader().filter(h => !h.skip).map((header) => {
+      return (
+        <th>
+          {header.label}
+          <Tooltip
+            tooltip={header.desc}
+            placement="top">
+            <i className="fa fa-fw fa-question-circle" />
+          </Tooltip>
+        </th>
+      );
+    });
+
+    return (
+      <thead>
+        <tr>
+          <th />
+          <th />
+          <td colSpan="4">
+            <EnhancedAnalysisRunControl
+              enhancedAnalysis={this.props.enhancedAnalysis}
+              table={this.props.table}
+              onRunAnalysis={this.props.onRunAnalysis}
+              isCallingRunAnalysis={this.props.isCallingRunAnalysis}
+              loadingProfilerData={this.props.loadingProfilerData}
+            />
+
+          </td>
+        </tr>
+        <tr>
+          <th>
+            Column
+          </th>
+          <th>
+            Sample Values
+          </th>
+          {enhancedHeader}
+        </tr>
+      </thead>
+    );
+  },
+
+  getEnahncedHeader() {
+    let dataHeader = null;
+    if (this.hasEnhancedData()) {
+      dataHeader = this.props.enhancedAnalysis.get('data').first();
+    }
+    return _.map(_.keys(enhancedColumnsTemplate), (key) => {
+      const h = enhancedColumnsTemplate[key];
+      return {
+        name: key,
+        label: h.name,
+        desc: h.desc,
+        idx: dataHeader ? dataHeader.indexOf(key) : 0,
+        formatFn: h.formatFn,
+        skip: h.skip
+      };
+    });
+  },
+
+
+  renderBodyRow(columnName, columnNameCell, value) {
+    let enhancedCells = [];
+    if (this.props.isRedshift) {
+      if (this.hasEnhancedData()) {
+        const varNameIndex = this.props.enhancedAnalysis.get('data').first().indexOf('var_name');
+        const header = this.getEnahncedHeader();
+        const rows = this.props.enhancedAnalysis.get('data').rest();
+        const rowToRender = rows.find((row) => {
+          return row.get(varNameIndex).toUpperCase() === columnName.toUpperCase();
+        });
+        if (!rowToRender) {
+          return (
+            <tr>
+              <td>
+                {columnNameCell}
+              </td>
+              <td>
+                {value}
+              </td>
+            </tr>
+          );
+        }
+        const rowValuesMap = header.map(h => {
+          h.value = rowToRender.get(h.idx);
+          return h;
+        });
+
+        enhancedCells = header.filter(h => !h.skip).map(h => {
+          let cellValue = h.value;
+          if (h.formatFn) {
+            cellValue = h.formatFn(cellValue, rowValuesMap);
+          }
+          return (
+            <td>
+              {cellValue}
+            </td>
+          );
+        });
+      } else {
+        const header = this.getEnahncedHeader();
+        enhancedCells = header.filter(h => !h.skip).map(() => {
+          return (
+            <td>
+              -
+            </td>
+          );
+        });
+      }
+    }
+
+    return (
+      <tr>
+        <td>
+          {columnNameCell}
+        </td>
+        <td>
+          {value}
+        </td>
+        {enhancedCells}
+      </tr>
+    );
+  },
+
+  getColumnValues(columnName) {
+    const data = this.props.dataPreview;
+    const columnIndex = data.first().indexOf(columnName);
+    const result = data
+    .shift()
+    .map( (row) => {
+      return row.get(columnIndex);
+    });
+    return result;
+  },
+
+  isDataPreview() {
+    return !_.isEmpty(this.props.dataPreview.toJS());
+  },
+
+  hasEnhancedAnalysis() {
+    return this.props.enhancedAnalysis &&
+           !_.isEmpty(this.props.enhancedAnalysis.toJS());
+  },
+
+  hasEnhancedData() {
+    return this.hasEnhancedAnalysis() && !_.isEmpty(this.props.enhancedAnalysis.toJS().data);
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/DataProfilerUtils.js
+++ b/src/scripts/modules/table-browser/react/components/DataProfilerUtils.js
@@ -1,0 +1,65 @@
+import _ from 'underscore';
+import Promise from 'bluebird';
+
+import InstalledComponentsActionCreators from '../../../components/InstalledComponentsActionCreators';
+
+import storageApi from '../../../components/StorageApi';
+import jobsApi from '../../../jobs/JobsApi';
+import string from '../../../../utils/string';
+
+const dataProfilerBucketPrefix = 'in.c-lg-rcp-data-profiler_';
+
+const unwantedJobs = ['terminating', 'canceled', 'terminated', 'cancelled', 'error'];
+
+export function getDataProfilerJob(jobId) {
+  return jobsApi.getJobDetail(jobId);
+}
+
+export function startDataProfilerJob(tableId) {
+  const profilerConfigId = string.webalize(tableId);
+  const params = {
+    component: 'rcp-data-profiler',
+    method: 'run',
+    notify: false,
+    data: {
+      config: profilerConfigId,
+      configData: {
+        datatable: tableId
+      }
+    }
+  };
+  return InstalledComponentsActionCreators.runComponent(params);
+}
+
+export function fetchProfilerData(tableId) {
+  const profilerConfigId = string.webalize(tableId);
+  const unwantedJobsQuery = unwantedJobs.map(j => `status:${j}`).join(' OR ');
+  const jobQuery = `config:${profilerConfigId} AND recipeId:rcp-data-profiler AND NOT(${unwantedJobsQuery})`;
+
+  return jobsApi.getJobsParametrized(jobQuery, 10, 0).then((jobs) =>{
+    const resultsTableId = `${dataProfilerBucketPrefix}${profilerConfigId}.VAI__1`;
+
+    // if table has analysis job than load its results
+    if (!_.isEmpty(jobs)) {
+      const okJob = _.find(jobs, j => j.status === 'success');
+      const runningJob = _.find(jobs, j => j.status !== 'success');
+
+      return storageApi.tableDataPreview(resultsTableId).then((data) =>{
+        const analysis = {
+          okJob: okJob,
+          runningJob: runningJob,
+          data: data
+        };
+        return analysis;
+      }).catch( () => {
+        return {
+          okJob: null,
+          runningJob: runningJob,
+          data: null
+        };
+      });
+    } else {
+      return Promise.resolve();
+    }
+  });
+}

--- a/src/scripts/modules/table-browser/react/components/DataSampleTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/DataSampleTab.jsx
@@ -1,0 +1,68 @@
+import React, {PropTypes} from 'react';
+
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+import EmptyState from '../../../components/react/components/ComponentEmptyState';
+import {Table} from 'react-bootstrap';
+
+export default React.createClass({
+  propTypes: {
+    dataPreview: PropTypes.object,
+    dataPreviewError: PropTypes.string
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    const {dataPreview, dataPreviewError} = this.props;
+
+    if (dataPreviewError) {
+      return (
+        <EmptyState>
+          {dataPreviewError}
+        </EmptyState>
+      );
+    }
+
+    if (dataPreview.count() === 0) {
+      return (
+        <EmptyState>
+          No Data.
+        </EmptyState>
+      );
+    }
+
+    const header = dataPreview.first().map( (c) => {
+      return (
+        <th>
+          {c}
+        </th>
+      );
+    }).toArray();
+    const rows = dataPreview.rest().map( (row) => {
+      const cols = row.map( (c) => {
+        return (<td> {c} </td>);
+      });
+
+      return (
+        <tr>
+          {cols}
+        </tr>);
+    });
+
+    return (
+      <div>
+        <Table responsive className="table table-striped">
+          <thead>
+            <tr>
+              {header}
+            </tr>
+          </thead>
+          <tbody>
+            {rows}
+          </tbody>
+        </Table>
+      </div>
+    );
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/DataType.jsx
+++ b/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/DataType.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import Tooltip from '../../../../../react/common/Tooltip';
+import _ from 'underscore';
+import Label from './Label';
+
+export default {
+  name: 'Data Type',
+  formatFn: (value, rowValues) => {
+    const format = _.find(rowValues, r => r.name === 'format').value;
+    const ists = _.find(rowValues, r => r.name === 'is_ts').value;
+    const result = format ? `${value} (${format})` : `${value}`;
+    const tsTooltip = 'Can be interpreted as a time series.';
+    const tsRender = (
+      <small>
+        <Label caption="Timeseries" />
+      </small>
+    );
+
+    if (ists === '1') {
+      return (<span><div>{result}</div><Tooltip tooltip={tsTooltip} placement="top">
+        {tsRender}</Tooltip></span>);
+    } else {
+      return result;
+    }
+  },
+  desc: (
+    <span>
+      The type of data present in the column.  Possible values are:
+      <div>String - alphanumeric characters</div>
+      <div>Integer - whole numbers without decimals</div>
+      <div>float - numbers with decimals</div>
+      <div>bool - logical (true/false, 0/1)</div>
+      <div>date or datetime</div>
+    </span>
+  )
+};

--- a/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/Label.jsx
+++ b/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/Label.jsx
@@ -1,0 +1,13 @@
+import React, {PropTypes} from 'react';
+
+export default React.createClass({
+  propTypes: {
+    caption: PropTypes.string.isRequired
+  },
+
+  render() {
+    return (
+      <span className="label label-info">{this.propTypes.caption}</span>
+    );
+  }
+});

--- a/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/Uniqueness.jsx
+++ b/src/scripts/modules/table-browser/react/components/EnhancedAnalysis/Uniqueness.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Tooltip from '../../../../../react/common/Tooltip';
+import Label from './Label';
+import _ from 'underscore';
+
+export default {
+  name: 'Uniqueness(%)',
+  desc: `If every value in the column is distinct, the uniqueness will be 100%.
+Columns that have few distinct values repeatedly (such as categories) will have lower uniqueness value. If every row contains the same value, the uniqueness will be 0%.`,
+  formatFn: (value, rowValues) => {
+    const isid = _.find(rowValues, r => r.name === 'is_identity').value;
+    const val = ((parseFloat(value)) * 100).toFixed(4);
+    if (isid === 'no') {
+      return val;
+    } else {
+      const idLabel = isid === 'yes' ? 'id' : 'id?';
+      const tooltip = isid === 'yes' ? 'Identifying the table row' : 'Probably identifying the table row';
+      return (
+        <span>
+            <div>{val}</div>
+            <Tooltip tooltip={tooltip} placement="top">
+              <Label caption={idLabel} />
+            </Tooltip>
+          </span>
+      );
+    }
+  }
+};

--- a/src/scripts/modules/table-browser/react/components/EnhancedAnalysisRunControl.jsx
+++ b/src/scripts/modules/table-browser/react/components/EnhancedAnalysisRunControl.jsx
@@ -1,0 +1,103 @@
+import React, {PropTypes} from 'react';
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+import {Loader} from 'kbc-react-components';
+import {Button} from 'react-bootstrap';
+import {Link} from 'react-router';
+
+export default React.createClass({
+  propTypes: {
+    table: PropTypes.object,
+    enhancedAnalysis: PropTypes.object,
+    onRunAnalysis: PropTypes.func,
+    isCallingRunAnalysis: PropTypes.bool,
+    loadingProfilerData: PropTypes.bool
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    let profilerInfo = (<span><Loader /></span>);
+    if (!this.props.loadingProfilerData) {
+      profilerInfo = [
+        (<span style={{'padding': 0}} className="col-xs-3">
+            { this.renderResultsStatus()}
+        </span>)
+        ,
+        (<span style={{'padding': 0}} className="col-xs-4">
+        {this.renderRunStatus()}
+         </span>)
+      ];
+    }
+    return (
+      <span className="col-xs-12" style={{'padding': 0}}>
+        <span style={{'padding': 0}}
+              className="col-xs-5">
+          Enhanced Analysis:
+        </span>
+        {profilerInfo}
+      </span>
+    );
+  },
+
+  renderResultsStatus() {
+    let status = 'No results';
+    const enhancedAnalysis = this.props.enhancedAnalysis;
+    const okJob = enhancedAnalysis ? enhancedAnalysis.get('okJob') : null;
+    if (okJob) {
+      const finished = okJob.get('endTime');
+      const tableChange = this.props.table.get('lastChangeDate');
+      if (finished < tableChange) {
+        status = (<span className="label label-warning">Outdated</span>);
+      } else {
+        status = (<span className="label label-success">Up-to-date</span>);
+      }
+    }
+    return (<span>{status}</span>);
+  },
+
+  renderRunStatus() {
+    const enhancedAnalysis = this.props.enhancedAnalysis;
+    const runningJob = enhancedAnalysis ? enhancedAnalysis.get('runningJob') : null;
+    if (runningJob) {
+      return (
+        <span> <Loader />{' '}
+          <Link to="jobDetail"
+                params={{jobId: runningJob.get('id')}}>
+            Analyzing...
+          </Link>
+        </span>
+      );
+    } else if (this.isShowRunButton()) {
+      if (this.props.isCallingRunAnalysis) {
+        return (<Loader />);
+      } else {
+        return (
+          <Button style={{padding: 0}}
+                  className="btn btn-link"
+                  onClick={this.props.onRunAnalysis}>
+            Run Analysis
+          </Button>
+        );
+      }
+    } else {
+      return null;
+    }
+  },
+
+  // Show if there are no results yet or analysis is outdated
+  isShowRunButton() {
+    const enhancedAnalysis = this.props.enhancedAnalysis;
+    const okJob = enhancedAnalysis ? enhancedAnalysis.get('okJob') : null;
+    if (!okJob) {
+      return true;
+    }
+    const finished = okJob.get('endTime');
+    const tableChange = this.props.table.get('lastChangeDate');
+    if (finished < tableChange) {
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/EnhancedComlumnsTemplate.jsx
+++ b/src/scripts/modules/table-browser/react/components/EnhancedComlumnsTemplate.jsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import EnhancedAnalysisDataType from './EnhancedAnalysis/DataType';
+import EnhancedAnalysisUniqueness from './EnhancedAnalysis/Uniqueness';
+
+export default {
+  'data_type': EnhancedAnalysisDataType,
+
+  // merged to data_type
+  'format': {
+    name: 'Format',
+    skip: true
+  },
+
+  // merged to data_type
+  'is_ts': {
+    name: 'Is ts',
+    skip: true
+  },
+
+  'val_ratio': EnhancedAnalysisUniqueness,
+
+  'is_identity': {
+    name: 'Identifying Column',
+    desc: 'Can the values of this column be used as an identifier for each row?',
+    skip: true
+  },
+
+  'mode': {
+    name: 'Mode',
+    desc: (<span>
+            <div>Continuous - Highly distinctive values (Time series are continuous)</div>
+            <div>Categories - Many rows contain the same values and there are finite possibilities.</div>
+            <div>Useless - Almost all rows contain fewer than 2 distinct values</div></span>)
+  },
+
+  'monotonic': {
+    name: 'Change Direction',
+    desc: 'Possible values: increasing, decreasing, variable.  For numeric values and dates, if the values are neither increasing or decreasing, they will be variable.  String columns will be blank.'
+  }
+
+};

--- a/src/scripts/modules/table-browser/react/components/EventsTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/EventsTab.jsx
@@ -1,0 +1,193 @@
+import React, {PropTypes} from 'react';
+import moment from 'moment';
+import date from '../../../../utils/date';
+import string from 'underscore.string';
+import {Table} from 'react-bootstrap';
+import EmptyState from '../../../components/react/components/ComponentEmptyState';
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+import EventDetail from '../../../sapi-events/react/EventDetail';
+
+export default React.createClass({
+
+  propTypes: {
+    tableExists: PropTypes.bool.isRequired,
+    tableId: PropTypes.string.isRequired,
+    events: PropTypes.object.isRequired,
+    omitFetches: PropTypes.bool,
+    omitExports: PropTypes.bool,
+    filterIOEvents: PropTypes.bool,
+    onShowEventDetail: PropTypes.func,
+    detailEventId: PropTypes.number,
+    onFilterIOEvents: PropTypes.func,
+    onOmitFetchesFn: PropTypes.func,
+    onOmitExportsFn: PropTypes.func
+
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    if (!this.props.tableExists) {
+      return (
+        <EmptyState>
+          No Data.
+        </EmptyState>
+      );
+    }
+    const rows = this.renderTableRows();
+    return (
+      <div>
+        <div>
+          <div className="row">
+            <div className="col-xs-3">
+              <div className="checkbox">
+                <label>
+                  <input
+                    disabled={this.props.filterIOEvents || this.props.detailEventId}
+                    checked={this.props.omitFetches}
+                    onClick={this.props.onOmitFetchesFn}
+                    type="checkbox"/>
+                  <span className={this.props.filterIOEvents ? 'text-muted' : ''}>
+                    Ignore table fetches
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div className="col-xs-3">
+              <div className="checkbox">
+                <label>
+                  <input
+                    disabled={this.props.filterIOEvents || this.props.detailEventId}
+                    checked={this.props.omitExports}
+                    onClick={this.props.onOmitExportsFn}
+                    type="checkbox"/>
+                  <span className={this.props.filterIOEvents ? 'text-muted' : ''}>
+                    Ignore table exports
+                  </span>
+                </label>
+              </div>
+            </div>
+            <div className="col-xs-3">
+              <div className="checkbox">
+                <label>
+                  <input
+                    disabled={this.props.detailEventId}
+                    checked={this.props.filterIOEvents}
+                    onClick={this.props.onFilterIOEvents}
+                    type="checkbox"/> Import/Exports only
+                </label>
+              </div>
+            </div>
+          </div>
+        </div>
+        {this.props.detailEventId ? this.renderDetail()
+         :
+         <Table responsive className="table table-striped table-hover">
+           <thead className="thead">
+             <tr className="tr">
+               <th className="th">
+                 Created
+               </th>
+               <th className="th">
+                 Event
+               </th>
+               <th className="th">
+                 Creator
+               </th>
+             </tr>
+           </thead>
+           <tbody className="tbody">
+             {rows}
+           </tbody>
+         </Table>
+        }
+      </div>
+    );
+  },
+
+  renderTableRows() {
+    return this.props.events.map( (e) => {
+      const event = e.get('event');
+      let info = this.eventsTemplates[event];
+      if (!info) {
+        info = {
+          className: '',
+          message: e.get('message')
+        };
+      }
+      const cl = `tr ${info.className}`;
+      const agoTime = moment(e.get('created')).fromNow();
+      const incElement = <p><small><strong>incremental</strong></small></p>;
+      info.message = string.replaceAll(info.message, this.props.tableId, '');
+      const incremental = e.getIn(['params', 'incremental']) ? incElement : <span />;
+      return (
+        <tr className={cl} onClick={() => this.setDetailEventId(e.get('id'))}>
+          <td className="td">
+            {date.format(e.get('created'))}
+            <small> {agoTime} </small>
+          </td>
+          <td className="td">
+            {info.message}
+            {incremental}
+          </td>
+          <td className="td">
+            {e.getIn(['token', 'name'])}
+          </td>
+        </tr>
+      );
+    }
+    );
+  },
+
+  setDetailEventId(eventId) {
+    this.props.onShowEventDetail(eventId);
+  },
+
+  resetDetail() {
+    this.setDetailEventId(null);
+  },
+
+  renderDetail() {
+    const event = this.props.events.find(e => e.get('id') === this.props.detailEventId);
+    const backButton = (
+      <span role="button" className="kbc-sapi-table-link"
+        onClick={this.resetDetail}>
+        <i className="fa fa-chevron-left" />
+        {' '}
+        Back
+      </span>
+    );
+
+    return (
+      <div>
+        <EventDetail
+          event={event}
+          backButton={backButton} />
+      </div>
+    );
+  },
+
+  eventsTemplates: {
+    'storage.tableImportStarted': {
+      'message': 'Import started',
+      'className': ''
+    },
+
+    'storage.tableImportDone': {
+      'message': 'Successfully imported ',
+      'className': 'success'
+    },
+
+    'storage.tableImportError': {
+      'message': 'Error on table import',
+      'className': 'error'
+    },
+
+    'storage.tableExported': {
+      'message': 'Exported to a csv file',
+      'className': 'info'
+    }
+
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/EventsTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/EventsTab.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
                   <input
                     disabled={this.props.filterIOEvents || this.props.detailEventId}
                     checked={this.props.omitFetches}
-                    onClick={this.props.onOmitFetchesFn}
+                    onChange={this.props.onOmitFetchesFn}
                     type="checkbox"/>
                   <span className={this.props.filterIOEvents ? 'text-muted' : ''}>
                     Ignore table fetches
@@ -59,7 +59,7 @@ export default React.createClass({
                   <input
                     disabled={this.props.filterIOEvents || this.props.detailEventId}
                     checked={this.props.omitExports}
-                    onClick={this.props.onOmitExportsFn}
+                    onChange={this.props.onOmitExportsFn}
                     type="checkbox"/>
                   <span className={this.props.filterIOEvents ? 'text-muted' : ''}>
                     Ignore table exports
@@ -73,7 +73,7 @@ export default React.createClass({
                   <input
                     disabled={this.props.detailEventId}
                     checked={this.props.filterIOEvents}
-                    onClick={this.props.onFilterIOEvents}
+                    onChange={this.props.onFilterIOEvents}
                     type="checkbox"/> Import/Exports only
                 </label>
               </div>

--- a/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
@@ -1,0 +1,106 @@
+import React, {PropTypes} from 'react';
+
+import date from '../../../../utils/date';
+import moment from 'moment';
+import _ from 'underscore';
+import {Table} from 'react-bootstrap';
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+import EmptyState from '../../../components/react/components/ComponentEmptyState';
+import filesize from 'filesize';
+
+export default React.createClass({
+
+  propTypes: {
+    isLoading: PropTypes.bool,
+    table: PropTypes.object,
+    tableExists: PropTypes.bool.isRequired
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    if (!this.props.tableExists) {
+      let msg = 'Table does not exist.';
+      if (this.props.isLoading) {
+        msg = 'Loading...';
+      }
+      return (
+        <EmptyState key="emptytable">
+          {msg}
+        </EmptyState>
+      );
+    }
+    const table = this.props.table;
+    const primaryKey = table.get('primaryKey').toJS();
+    const indexes = table.get('indexedColumns').toJS();
+    const backend = table.getIn(['bucket', 'backend']);
+    return (
+      <div>
+        <Table responsive className="table">
+          <thead>
+            <tr>
+              <td style={{width: '20%'}}>
+                ID
+              </td>
+              <td>
+                {table.get('id')}
+              </td>
+            </tr>
+          </thead>
+          <tbody>
+            {this.renderTableRow('Storage', (<span className="label label-info">{backend}</span>))}
+            {this.renderTableRow('Created', this.renderTimefromNow(table.get('created')))}
+            {this.renderTableRow('Primary Key', _.isEmpty(primaryKey) ? 'N/A' : primaryKey.join(', '))}
+            {this.renderTableRow('Last Import', this.renderTimefromNow(table.get('lastImportDate')))}
+            {this.renderTableRow('Last Change', this.renderTimefromNow(table.get('lastChangeDate')))}
+
+            {this.renderTableRow('Rows Count', this.renderRowsCount(table.get('rowsCount')))}
+            {this.renderTableRow('Data Size', this.renderDataSize(table.get('dataSizeBytes')))}
+            {this.renderTableRow('Indexed Column(s)', _.isEmpty(indexes) ? 'N/A' : indexes.join(', '))}
+            {this.renderTableRow('Columns', table.get('columns').count() + ' columns: ' + table.get('columns').join(', '))}
+          </tbody>
+        </Table>
+      </div>
+    );
+  },
+
+  renderRowsCount(value) {
+    if (value === null) {
+      return 'N/A';
+    }
+    return value + ' rows';
+  },
+
+  renderDataSize(value) {
+    if (value === null) {
+      return 'N/A';
+    }
+    return filesize(value);
+  },
+
+  renderTimefromNow(value) {
+    if (value === null) {
+      return 'N/A';
+    }
+    const fromNow = moment(value).fromNow();
+    return (
+      <span> {date.format(value)}
+        <small> {fromNow} </small>
+      </span>
+    );
+  },
+
+  renderTableRow(name, value) {
+    return (
+      <tr>
+        <td>
+          {name}
+        </td>
+        <td>
+          {value}
+        </td>
+      </tr>
+    );
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -63,10 +63,11 @@ export default React.createClass({
       <Modal.Dialog
         className="kbc-table-browser"
         bsSize="large"
-        onHide={this.props.onHideFn}
         onKeyDown={this.onKeyDown}
       >
-        <Modal.Header closeButton>
+        <Modal.Header>
+          <button onClick={this.props.onHideFn}
+            type="button" className="close" data-dismiss="modal">&times;</button>
           <Modal.Title>
             {this.props.tableId}
             {tableLink}

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -122,7 +122,7 @@ export default React.createClass({
 
   renderModalBody() {
     return (
-      <div style={{'max-height': '75vh'}} className="pre-scrollable">
+      <div>
         <TabbedArea defaultActiveKey="general" animation={false} id={'modal' + this.props.tableId}>
           <TabPane eventKey="general" title="General Info">
             {this.renderGeneralInfo()}

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -1,0 +1,211 @@
+import React, {PropTypes} from 'react';
+import TablesPaginator from './TablesPaginator';
+import EventsTab from './EventsTab';
+import GeneralInfoTab from './GeneralInfoTab';
+import DataSampleTab from './DataSampleTab';
+import ColumnsInfoTab from './ColumnsInfoTab';
+import TableDescriptionTab from './TableDescriptionTab';
+
+import SapiTableLink from '../../../components/react/components/StorageApiTableLink';
+import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
+
+import {TabbedArea, TabPane} from './../../../../react/common/KbcBootstrap';
+import {Modal} from 'react-bootstrap';
+import {RefreshIcon} from 'kbc-react-components';
+
+
+export default React.createClass({
+
+  propTypes: {
+    moreTables: React.PropTypes.object,
+    show: PropTypes.bool.isRequired,
+    tableId: PropTypes.string.isRequired,
+    reload: PropTypes.func.isRequired,
+    tableExists: PropTypes.bool.isRequired,
+    omitFetches: PropTypes.bool,
+    events: PropTypes.object.isRequired,
+    omitExports: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    loadingProfilerData: PropTypes.bool,
+    table: PropTypes.object,
+    dataPreview: PropTypes.object,
+    dataPreviewError: PropTypes.string,
+    enhancedAnalysis: PropTypes.object,
+    onOmitFetchesFn: PropTypes.func,
+    onOmitExportsFn: PropTypes.func,
+    onHideFn: PropTypes.func,
+    isRedshift: PropTypes.bool,
+    onRunAnalysis: PropTypes.func,
+    onChangeTable: PropTypes.func,
+    filterIOEvents: PropTypes.bool,
+    onFilterIOEvents: PropTypes.func,
+    onShowEventDetail: PropTypes.func,
+    detailEventId: PropTypes.number,
+    isCallingRunAnalysis: PropTypes.bool
+  },
+
+  mixins: [immutableMixin],
+
+  render() {
+    const modalBody = this.renderModalBody();
+    let tableLink = (<small className="disabled btn btn-link"> Explore in Console</small>);
+    if (this.props.tableExists) {
+      tableLink =
+        (
+          <SapiTableLink
+            tableId={this.props.tableId}>
+            <small className="btn btn-link">
+              Explore in Console
+            </small>
+          </SapiTableLink>);
+    }
+    return (
+      <Modal
+        bsSize="large"
+        show={this.props.show}
+        onHide={this.props.onHideFn}
+        onKeyDown={this.onKeyDown}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>
+            {this.props.tableId}
+            {tableLink}
+            <RefreshIcon
+              isLoading={this.props.isLoading}
+              onClick={this.props.reload}
+            />
+          </Modal.Title>
+          {/* this.renderPaginator() */}
+        </Modal.Header>
+        <Modal.Body>
+          {modalBody}
+        </Modal.Body>
+      </Modal>
+    );
+  },
+
+  renderPaginator() {
+    if (this.props.moreTables.length - 1 > 0) {
+      return (
+        <TablesPaginator
+          nextTable={this.getNextTable()}
+          previousTable={this.getPreviousTable()}
+          onChangeTable={this.props.onChangeTable} />
+      );
+    }
+  },
+
+  getNextTable() {
+    const tables = this.props.moreTables;
+    const position = tables.indexOf(this.props.tableId);
+    return position + 1 < tables.length ? tables[position + 1] : null;
+  },
+
+  getPreviousTable() {
+    const tables = this.props.moreTables;
+    const position = tables.indexOf(this.props.tableId);
+    return position - 1 >= 0 ? tables[position - 1] : null;
+  },
+
+  onKeyDown(e) {
+    return e;
+    /* const arrowRight = e.key === 'ArrowRight';
+     * const arrowLeft = e.key === 'ArrowLeft';
+     * if (arrowRight && this.getNextTable()) {
+     *   return this.props.onChangeTable(this.getNextTable());
+     * }
+     * if (arrowLeft && this.getPreviousTable()) {
+     *   return this.props.onChangeTable(this.getPreviousTable());
+     * }*/
+  },
+
+  renderModalBody() {
+    return (
+      <div style={{'max-height': '75vh'}} className="pre-scrollable">
+        <TabbedArea defaultActiveKey="general" animation={false} id={'modal' + this.props.tableId}>
+          <TabPane eventKey="general" title="General Info">
+            {this.renderGeneralInfo()}
+          </TabPane>
+          <TabPane eventKey="description" title="Description">
+            {this.renderTableDescription()}
+          </TabPane>
+          <TabPane eventKey="columns" title="Columns">
+            {this.renderColumnsInfo()}
+          </TabPane>
+          <TabPane eventKey="datasample" title="Data Sample">
+            {this.renderDataSample()}
+          </TabPane>
+          <TabPane eventKey="events" title="Events">
+            {this.renderEvents()}
+          </TabPane>
+        </TabbedArea>
+      </div>
+    );
+  },
+
+  renderGeneralInfo() {
+    return (
+      <GeneralInfoTab
+        isLoading={this.props.isLoading}
+        table={this.props.table}
+        tableExists={this.props.tableExists}
+      />
+    );
+  },
+
+  renderTableDescription() {
+    return (
+      <TableDescriptionTab
+        isLoading={this.props.isLoading}
+        tableId={this.props.tableId}
+        tableExists={this.props.tableExists}
+      />
+    );
+  },
+
+  renderEvents() {
+    return (
+      <EventsTab
+        tableExists={this.props.tableExists}
+        tableId={this.props.tableId}
+        events={this.props.events}
+        omitFetches={this.props.omitFetches}
+        omitExports={this.props.omitExports}
+        onOmitFetchesFn={this.props.onOmitFetchesFn}
+        onOmitExportsFn={this.props.onOmitExportsFn}
+        filterIOEvents={this.props.filterIOEvents}
+        onFilterIOEvents={this.props.onFilterIOEvents}
+        onShowEventDetail={this.props.onShowEventDetail}
+        detailEventId={this.props.detailEventId}
+
+      />
+
+    );
+  },
+
+  renderDataSample() {
+    return (
+      <DataSampleTab
+        dataPreview={this.props.dataPreview}
+        dataPreviewError={this.props.dataPreviewError}
+      />
+    );
+  },
+
+  renderColumnsInfo() {
+    return (
+      <ColumnsInfoTab
+        tableExists={this.props.tableExists}
+        table={this.props.table}
+        dataPreview={this.props.dataPreview}
+        dataPreviewError={this.props.dataPreviewError}
+        isRedshift={this.props.isRedshift}
+        isCallingRunAnalysis={this.props.isCallingRunAnalysis}
+        onRunAnalysis={this.props.onRunAnalysis}
+        loadingProfilerData={this.props.loadingProfilerData}
+        enhancedAnalysis={this.props.enhancedAnalysis}
+      />
+    );
+  }
+
+});

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -18,7 +18,6 @@ export default React.createClass({
 
   propTypes: {
     moreTables: React.PropTypes.object,
-    show: PropTypes.bool.isRequired,
     tableId: PropTypes.string.isRequired,
     reload: PropTypes.func.isRequired,
     tableExists: PropTypes.bool.isRequired,
@@ -60,9 +59,8 @@ export default React.createClass({
           </SapiTableLink>);
     }
     return (
-      <Modal
+      <Modal.Dialog
         bsSize="large"
-        show={this.props.show}
         onHide={this.props.onHideFn}
         onKeyDown={this.onKeyDown}
       >
@@ -80,7 +78,7 @@ export default React.createClass({
         <Modal.Body>
           {modalBody}
         </Modal.Body>
-      </Modal>
+      </Modal.Dialog>
     );
   },
 

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -12,6 +12,7 @@ import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
 import {TabbedArea, TabPane} from './../../../../react/common/KbcBootstrap';
 import {Modal} from 'react-bootstrap';
 import {RefreshIcon} from 'kbc-react-components';
+import './ModalDialog.less';
 
 
 export default React.createClass({
@@ -60,6 +61,7 @@ export default React.createClass({
     }
     return (
       <Modal.Dialog
+        className="kbc-table-browser"
         bsSize="large"
         onHide={this.props.onHideFn}
         onKeyDown={this.onKeyDown}

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -18,7 +18,7 @@ import './ModalDialog.less';
 export default React.createClass({
 
   propTypes: {
-    moreTables: React.PropTypes.object,
+    moreTables: React.PropTypes.array,
     tableId: PropTypes.string.isRequired,
     reload: PropTypes.func.isRequired,
     tableExists: PropTypes.bool.isRequired,

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.less
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.less
@@ -1,0 +1,12 @@
+.kbc-table-browser .modal-dialog {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+}
+
+.kbc-table-browser .modal-content {
+  height: auto;
+  min-height: 100%;
+  border-radius: 0;
+}

--- a/src/scripts/modules/table-browser/react/components/TableDescriptionEditor.jsx
+++ b/src/scripts/modules/table-browser/react/components/TableDescriptionEditor.jsx
@@ -1,0 +1,32 @@
+import React, {PropTypes} from 'react';
+import InlineEditArea  from '../../../../react/common/InlineEditArea';
+import MetadataEditField from '../../../components/react/components/MetadataEditField';
+
+export default React.createClass({
+  displayName: 'TableDescriptionEditor',
+
+  propTypes: {
+    tableId: PropTypes.string.isRequired,
+    placeholder: PropTypes.string
+  },
+
+  getDefaultProps: function() {
+    return {
+      placeholder: 'Describe this table'
+    };
+  },
+
+  render() {
+    return (
+      <div className="kbc-metadata-description">
+        <MetadataEditField
+          objectType="table"
+          objectId={this.props.tableId}
+          metadataKey="KBC.description"
+          editElement={InlineEditArea}
+          placeholder={this.props.placeholder}
+        />
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
@@ -1,0 +1,33 @@
+import React, {PropTypes} from 'react';
+
+import EmptyState from '../../../components/react/components/ComponentEmptyState';
+import TableDescriptionEditor from './TableDescriptionEditor';
+
+export default React.createClass({
+
+  propTypes: {
+    isLoading: PropTypes.bool,
+    tableId: PropTypes.string.isRequired,
+    tableExists: PropTypes.bool.isRequired
+  },
+
+  render() {
+    if (!this.props.tableExists) {
+      let msg = 'Table does not exist.';
+      if (this.props.isLoading) {
+        msg = 'Loading...';
+      }
+      return (
+        <EmptyState key="emptytable">
+          {msg}
+        </EmptyState>
+      );
+    }
+    const tableId = this.props.tableId;
+    return (
+      <div>
+        <TableDescriptionEditor tableId={tableId}/>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/table-browser/react/components/TablesPaginator.jsx
+++ b/src/scripts/modules/table-browser/react/components/TablesPaginator.jsx
@@ -1,0 +1,31 @@
+import React, {PropTypes} from 'react';
+
+export default React.createClass({
+
+  propTypes: {
+    previousTable: PropTypes.string.isRequired,
+    nextTable: PropTypes.string.isRequired,
+    onChangeTable: PropTypes.func.isRequired
+  },
+
+  render() {
+    const {nextTable, previousTable} = this.props;
+    return (
+      <div>
+        {previousTable &&
+         <span className="btn btn-link pull-left" role="button"
+           onClick={() => this.props.onChangeTable(previousTable)}>
+           {'<<'} {previousTable}
+         </span>
+        }
+
+        {nextTable &&
+         <span className="btn btn-link pull-right" role="button"
+           onClick={() => this.props.onChangeTable(nextTable)}>
+           {nextTable} {'>>'}
+         </span>
+        }
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/table-browser/routes.js
+++ b/src/scripts/modules/table-browser/routes.js
@@ -1,6 +1,14 @@
 import Index from './react/Index';
 export const PATH_PREFIX = 'tables';
 
+export const createTablesRoute = (parentRouteName) => {
+  return {
+    name: `${parentRouteName}-tables`,
+    path: `${PATH_PREFIX}/:tableId`,
+    handler: Index
+  };
+};
+
 export default {
   name: 'tables',
   path: `${PATH_PREFIX}/:tableId`,

--- a/src/scripts/modules/table-browser/routes.js
+++ b/src/scripts/modules/table-browser/routes.js
@@ -1,0 +1,11 @@
+import Index from './react/Index';
+import storageActions from '../components/StorageActionCreators';
+
+export default {
+  name: 'tables',
+  path: 'tables/:tableId',
+  defaultRouteHandler: Index,
+  requireData: [
+    () => storageActions.loadTables()
+  ]
+};

--- a/src/scripts/modules/table-browser/routes.js
+++ b/src/scripts/modules/table-browser/routes.js
@@ -1,7 +1,8 @@
 import Index from './react/Index';
+export const PATH_PREFIX = 'tables';
 
 export default {
   name: 'tables',
-  path: 'tables/:tableId',
+  path: `${PATH_PREFIX}/:tableId`,
   defaultRouteHandler: Index
 };

--- a/src/scripts/modules/table-browser/routes.js
+++ b/src/scripts/modules/table-browser/routes.js
@@ -1,11 +1,7 @@
 import Index from './react/Index';
-import storageActions from '../components/StorageActionCreators';
 
 export default {
   name: 'tables',
   path: 'tables/:tableId',
-  defaultRouteHandler: Index,
-  requireData: [
-    () => storageActions.loadTables()
-  ]
+  defaultRouteHandler: Index
 };

--- a/src/scripts/modules/tde-exporter/tdeRoutes.coffee
+++ b/src/scripts/modules/tde-exporter/tdeRoutes.coffee
@@ -19,6 +19,7 @@ RouterStore = require('../../stores/RoutesStore')
 componentId = 'tde-exporter'
 {fromJS} = require 'immutable'
 VersionsActionCreators = require '../components/VersionsActionCreators'
+{createTablesRoute} = require '../table-browser/routes'
 
 # return first non empty(aka authorized) writer account
 findNonEmptyAccount = (configData) ->
@@ -103,6 +104,8 @@ module.exports =
     InstalledComponentsStore.getConfig(componentId, configId).get('name')
 
   childRoutes: [
+    createTablesRoute(componentId)
+  ,
     #isComponent: true
     name: "tde-exporter-table"
     path: 'table/:tableId'

--- a/src/scripts/modules/transformations/Routes.coffee
+++ b/src/scripts/modules/transformations/Routes.coffee
@@ -20,6 +20,7 @@ TransformationNameEdit = require './react/components/TransformationNameEditField
 ApplicationsStore = require '../../stores/ApplicationStore'
 JobsActionCreators = require '../jobs/ActionCreators'
 injectProps = require('../components/react/injectProps').default
+{createTablesRoute} = require '../table-browser/routes'
 Immutable = require('immutable')
 
 routes =
@@ -87,6 +88,8 @@ routes =
               StorageActionCreators.loadBuckets()
           ]
           childRoutes: [
+            createTablesRoute('transformationDetail')
+          ,
             name: 'transformationDetailGraph'
             path: 'graph'
             title: (routerState) ->

--- a/src/scripts/modules/wr-db/routes.coffee
+++ b/src/scripts/modules/wr-db/routes.coffee
@@ -9,6 +9,7 @@ CredentialsHeader = require './react/components/CredentialsHeaderButtons'
 storageActionCreators = require '../components/StorageActionCreators'
 JobsActionCreators = require '../jobs/ActionCreators'
 DockerProxyApi = require('./templates/dockerProxyApi').default
+{createTablesRoute} = require '../table-browser/routes'
 #driver = 'mysql'
 #componentId = 'wr-db'
 
@@ -43,6 +44,8 @@ createRoute = (componentId, driver, isProvisioning) ->
 
   ]
   childRoutes: [
+    createTablesRoute(componentId)
+  ,
     #isComponent: true
     name: "#{componentId}-table"
     path: 'table/:tableId'

--- a/src/scripts/modules/wr-dropbox/routes.coffee
+++ b/src/scripts/modules/wr-dropbox/routes.coffee
@@ -10,6 +10,7 @@ RouterStore = require('../../stores/RoutesStore')
 ApplicationActionCreators = require('../../actions/ApplicationActionCreators')
 JobsActionCreators = require '../jobs/ActionCreators'
 VersionsActionCreators = require '../components/VersionsActionCreators'
+{createTablesRoute} = require '../table-browser/routes'
 
 module.exports = (componentId) ->
   name: componentId
@@ -31,6 +32,8 @@ module.exports = (componentId) ->
       JobsActionCreators.loadComponentConfigurationLatestJobs(componentId, params.config)
   defaultRouteHandler: IndexPage(componentId)
   childRoutes: [
+    createTablesRoute(componentId)
+  ,
     name: 'wr-dropbox-oauth-redirect' + componentId
     path: 'oauth-redirect'
     title: ''

--- a/src/scripts/modules/wr-google-drive-old/wrGdriveRoutes.coffee
+++ b/src/scripts/modules/wr-google-drive-old/wrGdriveRoutes.coffee
@@ -4,6 +4,7 @@ authorizePage = require './react/pages/authorize/Authorize'
 InstalledComponentsStore = require '../components/stores/InstalledComponentsStore'
 JobsActionCreators = require '../jobs/ActionCreators'
 storageActionCreators = require '../components/StorageActionCreators'
+{createTablesRoute} = require '../table-browser/routes'
 
 module.exports =
   name: 'wr-google-drive'
@@ -26,6 +27,8 @@ module.exports =
         storageActionCreators.loadTables()
     ]
   childRoutes: [
+    createTablesRoute('wr-google-drive')
+  ,
     name: 'wr-google-drive-authorize'
     path: 'authorize'
     handler: authorizePage

--- a/src/scripts/modules/wr-google-drive/routes.js
+++ b/src/scripts/modules/wr-google-drive/routes.js
@@ -4,6 +4,7 @@ import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
 import * as oauthUtils from '../oauth-v2/OauthUtils';
+import {createTablesRoute} from '../table-browser/routes';
 
 const COMPONENT_ID = 'keboola.wr-google-drive';
 
@@ -22,5 +23,6 @@ export default {
   poll: {
     interval: 5,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(COMPONENT_ID, params.config)
-  }
+  },
+  childRoutes: [ createTablesRoute(COMPONENT_ID)]
 };

--- a/src/scripts/modules/wr-google-sheets/routes.js
+++ b/src/scripts/modules/wr-google-sheets/routes.js
@@ -4,6 +4,7 @@ import storageActions from '../components/StorageActionCreators';
 import jobsActionCreators from '../jobs/ActionCreators';
 import versionsActions from '../components/VersionsActionCreators';
 import * as oauthUtils from '../oauth-v2/OauthUtils';
+import {createTablesRoute} from '../table-browser/routes';
 
 const COMPONENT_ID = 'keboola.wr-google-sheets';
 
@@ -22,5 +23,6 @@ export default {
   poll: {
     interval: 5,
     action: (params) => jobsActionCreators.loadComponentConfigurationLatestJobs(COMPONENT_ID, params.config)
-  }
+  },
+  childRoutes: [ createTablesRoute(COMPONENT_ID)]
 };

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -10,6 +10,7 @@ import orchestrationRoutes  from './modules/orchestrations/Routes';
 import transformationRoutes from './modules/transformations/Routes';
 import jobRoutes from './modules/jobs/Routes';
 import trashRoutes from './modules/trash/routes';
+import tables from './modules/table-browser/routes';
 
 
 export default {
@@ -28,6 +29,7 @@ export default {
     jobRoutes,
     billingRoutes,
     transformationRoutes,
+    tables,
     trashRoutes,
     {
       name: 'data-takeout',


### PR DESCRIPTION
riesenie zhruba popisane ako 1. PR tu https://github.com/keboola/connection/issues/995
- [x] zkopirovany cely modul StorageApiTableLinkEx.jsx a vsetky jeho komponenty 
- [x] vytvorena stranka ktora renderuje to co StorageApiTableLinkEx na full screen
- [x] vytvorena routa `/tables/:tableId` ktora ukazuje na stranku ^^
- ~zmigrovat pouzitie setState na flux store/actions(mozno pouzit local state)~ poriesim v dalsom PR 
- [x] na zavretie stranky vratit spat o jednu urovne nizsie tj z `/x/y/z/tables/:tableId` skoci na `/x/y/z` s fallbackom na `/`
- ~refaktoring~ poriesim v dalsom PR
- ~style refinements?~ poriesim v dalsom PR

