### PR TITLE
jobs - cleanup of useless info

### DIFF
--- a/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
+++ b/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
@@ -28,6 +28,9 @@ JobNavRow = React.createClass
           JobStatusCircle status: @props.job.get('status')
         span className: 'td',
           div null,
+            strong null,
+              @props.job.get('id')
+          div null,
             @props.job.getIn ['token', 'description']
           div null,
             small className: 'pull-left',

--- a/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
+++ b/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
@@ -28,9 +28,6 @@ JobNavRow = React.createClass
           JobStatusCircle status: @props.job.get('status')
         span className: 'td',
           div null,
-            strong null,
-              @props.job.get('id')
-          div null,
             @props.job.getIn ['token', 'description']
           div null,
             small className: 'pull-left',

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -245,20 +245,10 @@ module.exports = React.createClass
               renderDate(job.get('startTime'))
           div {className: 'row'},
             span {className: 'col-md-3'},
-              'Initialized'
-            strong className: 'col-md-9',
-              job.getIn(['token', 'description'])
-          div {className: 'row'},
-            span {className: 'col-md-3'},
               'RunId'
             strong {className: 'col-md-9'},
               JobRunId {runId: job.get('runId')}
         div {className: 'td'},
-          div {className: 'row'},
-            span {className: 'col-md-3'},
-              'Command'
-            strong {className: 'col-md-9'},
-              span {className: 'label label-info'},job.get('command')
           div className: 'row',
             span className: 'col-md-3', 'Status '
             span className: 'col-md-9', JobStatusLabel status: job.get('status')
@@ -266,7 +256,7 @@ module.exports = React.createClass
             span className: 'col-md-3', 'End '
             strong className: 'col-md-9', renderDate(job.get('endTime'))
           div className: 'row',
-            span className: 'col-md-3', 'Token '
+            span className: 'col-md-3', 'Creator '
             strong className: 'col-md-9', job.getIn(['token', 'description'])
           div {className: 'row'},
             span {className: 'col-md-3'},

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -235,7 +235,7 @@ module.exports = React.createClass
               configurationLink
           div {className: 'row'},
             span {className: 'col-md-3'},
-              'Created'
+              'Created At'
             strong {className: 'col-md-9'},
               date.format(job.get('createdTime'))
           div {className: 'row'},
@@ -253,11 +253,11 @@ module.exports = React.createClass
             span className: 'col-md-3', 'Status '
             span className: 'col-md-9', JobStatusLabel status: job.get('status')
           div className: 'row',
+            span className: 'col-md-3', 'Created By '
+            strong className: 'col-md-9', job.getIn(['token', 'description'])
+          div className: 'row',
             span className: 'col-md-3', 'End '
             strong className: 'col-md-9', renderDate(job.get('endTime'))
-          div className: 'row',
-            span className: 'col-md-3', 'Creator '
-            strong className: 'col-md-9', job.getIn(['token', 'description'])
           div {className: 'row'},
             span {className: 'col-md-3'},
               'Duration'

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
@@ -24,9 +24,6 @@ export default React.createClass({
     return (
       <Link className="tr" to="jobDetail" params={this.linkParams()} query={this.linkQuery()}>
         <div className="td">
-          {this.props.job.get('id')}
-        </div>
-        <div className="td">
           <JobStatusLabel status={this.props.job.get('status')}/>
         </div>
         <div className="td">
@@ -34,9 +31,6 @@ export default React.createClass({
         </div>
         <div className="td">
           { this.jobConfiguration() }
-        </div>
-        <div className="td">
-          {this.props.job.get('command')}
         </div>
         <div className="td">
           {this.props.job.getIn(['token', 'description'])}

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
@@ -24,6 +24,9 @@ export default React.createClass({
     return (
       <Link className="tr" to="jobDetail" params={this.linkParams()} query={this.linkQuery()}>
         <div className="td">
+          {this.props.job.get('id')}
+        </div>
+        <div className="td">
           <JobStatusLabel status={this.props.job.get('status')}/>
         </div>
         <div className="td">

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.coffee
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.coffee
@@ -40,19 +40,15 @@ module.exports = React.createClass
     div {className: 'thead' },
       div className: 'tr',
         span {className: 'th'},
-          strong null, 'ID'
-        span {className: 'th'},
           strong null, 'Status'
         span {className: 'th'},
           strong null, 'Component'
         span {className: 'th'},
           strong null, 'Configuration'
         span {className: 'th'},
-          strong null, 'Action'
+          strong null, 'Creator'
         span {className: 'th'},
-          strong null, 'Token'
-        span {className: 'th'},
-          strong null, 'Created time'
+          strong null, 'Created'
         span {className: 'th'},
           strong null, 'Duration'
 

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.coffee
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.coffee
@@ -40,15 +40,17 @@ module.exports = React.createClass
     div {className: 'thead' },
       div className: 'tr',
         span {className: 'th'},
+          strong null, 'ID'
+        span {className: 'th'},
           strong null, 'Status'
         span {className: 'th'},
           strong null, 'Component'
         span {className: 'th'},
           strong null, 'Configuration'
         span {className: 'th'},
-          strong null, 'Creator'
+          strong null, 'Created By'
         span {className: 'th'},
-          strong null, 'Created'
+          strong null, 'Created At'
         span {className: 'th'},
           strong null, 'Duration'
 

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/JobsTable.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/JobsTable.coffee
@@ -36,9 +36,8 @@ JobsTable = React.createClass(
         (tr {},
           (th {}, "ID"),
           (th {}, "Status"),
-          (th {}, "Created time"),
-          (th {}, "Initialized"),
-          (th {}, "Creator"),
+          (th {}, "Created At"),
+          (th {}, "Created By"),
           (th {}, "Duration"),
           (th {className: 'text-right kbc-last-column-header'},
             RefreshIcon(

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/JobsTableRow.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/JobsTableRow.coffee
@@ -49,7 +49,6 @@ JobRow = React.createClass(
       (td {}, @props.job.get('id')),
       (td {}, JobStatusLabel({status: @props.job.get('status')})),
       (td {}, date.format(@props.job.get('createdTime'))),
-      (td {}, @props.job.get('initializedBy')),
       (td {}, @props.job.getIn(['initiatorToken', 'description'])),
       (td {}, (Duration
         startTime: @props.job.get('startTime')

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/Overview.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/Overview.coffee
@@ -16,30 +16,25 @@ JobDetailOverview = React.createClass
         div className: 'tr',
           div className: 'td',
             div className: 'row',
-              span className: 'col-md-3', 'Created '
-              strong className: 'col-md-9', date.format(@props.job.get('createdTime'))
+              span className: 'col-md-4', 'Created At '
+              strong className: 'col-md-8', date.format(@props.job.get('createdTime'))
             div className: 'row',
-              span className: 'col-md-3', 'Start '
-              strong className: 'col-md-9', @_getValidStartTime()
-            div className: 'row',
-              span className: 'col-md-3', 'Initialized '
-              strong
-                className: 'col-md-9',
-                "#{@props.job.get('initializedBy')} (#{@props.job.getIn(['initiatorToken', 'description'])})"
+              span className: 'col-md-4', 'Start '
+              strong className: 'col-md-8', @_getValidStartTime()
           div className: 'td',
             div className: 'row',
-              span className: 'col-md-3', 'Status '
-              span className: 'col-md-9', JobStatusLabel status: @props.job.get('status')
+              span className: 'col-md-4', 'Status '
+              span className: 'col-md-8', JobStatusLabel status: @props.job.get('status')
             div className: 'row',
-              span className: 'col-md-3', 'End '
-              strong className: 'col-md-9',
+              span className: 'col-md-4', 'End '
+              strong className: 'col-md-8',
                 if @props.job.get('endTime')
                   date.format(@props.job.get('endTime'))
                 else
                   'N/A'
             div className: 'row',
-              span className: 'col-md-3', 'Token '
-              strong className: 'col-md-9', @props.job.getIn(['token', 'description'])
+              span className: 'col-md-4', 'Created By '
+              strong className: 'col-md-8', @props.job.getIn(['initiatorToken', 'description'])
 
       h2 null,
         'Tasks',


### PR DESCRIPTION
Jsem si tak hral a zkusil vyhazet veci ktere nejsou pro uzivatele dulezite. 
Byly tam fakt blbosti, napr `Initialized By` u jobu ktere vzdy ukazovalo stejnou hodnotu jako `Token` :)
Asi by se to same dalo udelat pro orchestrace.

Ten seznam jobu by chtel asi trochu poladit jackem, ty statusy jak jsou v tech labelech ruzne dlouhe vypadaji divne.

Nechavam tady na hrani.

![image](https://user-images.githubusercontent.com/903531/31011021-25872c36-a50d-11e7-8996-3640def87a71.png)

![image](https://user-images.githubusercontent.com/903531/31011027-2c0a2a36-a50d-11e7-9229-bfdbb576e430.png)
