### PR TITLE
Remove my older CSS workaround

### DIFF
--- a/src/scripts/modules/csv-import/react/Index/Index.jsx
+++ b/src/scripts/modules/csv-import/react/Index/Index.jsx
@@ -127,17 +127,17 @@ export default React.createClass({
     return (
       <div className="container-fluid">
         <div className="col-md-9 kbc-main-content">
-          <div className="kbc-header kbc-header-without-row-fix">
+          <div className="kbc-inner-content-padding-fix with-bottom-border">
             <ComponentDescription
               componentId={COMPONENT_ID}
               configId={this.state.configId}
             />
           </div>
-          <div className="kbc-header kbc-header-without-row-fix">
+          <div className="kbc-inner-content-padding-fix with-bottom-border">
             <h3>Upload CSV File</h3>
             {this.renderUploader()}
           </div>
-          <div className="kbc-header kbc-header-without-row-fix">
+          <div className="kbc-inner-content-padding-fix with-bottom-border">
             <h3 style={{lineHeight: '32px'}}>
               CSV Upload Settings
               <span className="pull-right">

--- a/src/scripts/modules/csv-import/react/Index/Index.less
+++ b/src/scripts/modules/csv-import/react/Index/Index.less
@@ -1,11 +1,4 @@
 
-.kbc-main .kbc-header.kbc-header-without-row-fix {
-  // because original class already has !important we cannot fight with specificity
-  padding: 22px 44px 15px !important;
-  // same as row, but without junk
-  border-bottom: 1px solid #e8e8ef;
-}
-
 .subform {
   margin-left: 40px;
 }

--- a/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
@@ -119,13 +119,13 @@ export default React.createClass({
     return (
       <div className="container-fluid">
         <div className="col-md-9 kbc-main-content">
-          <div className="kbc-header kbc-header-without-row-fix">
+          <div className="kbc-inner-content-padding-fix with-bottom-border">
             <ComponentDescription
               componentId={COMPONENT_ID}
               configId={this.state.configId}
             />
           </div>
-          <div className="kbc-header kbc-header-without-row-fix">
+          <div className="kbc-inner-content-padding-fix with-bottom-border">
             {this.renderButtons()}
             {this.renderSettings()}
           </div>

--- a/src/scripts/modules/ex-s3/react/pages/Index/Index.less
+++ b/src/scripts/modules/ex-s3/react/pages/Index/Index.less
@@ -1,9 +1,3 @@
-.kbc-main .kbc-header.kbc-header-without-row-fix {
-  // because original class already has !important we cannot fight with specificity
-  padding: 22px 44px 15px !important;
-  // same as row, but without junk
-  border-bottom: 1px solid #e8e8ef;
-}
 
 .kbc-main .tab-pane {
   padding-top: 15px;

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -328,4 +328,7 @@ a .kbcComponentIcon-3rdParty-64px {
 // to add padding without incorrect "row" usage and not break anything
 .kbc-inner-content-padding-fix {
   padding: 22px 22px 15px;
+  &.with-bottom-border {
+    border-bottom: 1px solid #e8e8ef;
+  }
 }

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -324,3 +324,8 @@ a .kbcComponentIcon-3rdParty-64px {
 .table > .tbody > .tr .td span{
   word-break: break-word;
 }
+
+// to add padding without incorrect "row" usage and not break anything
+.kbc-inner-content-padding-fix {
+  padding: 22px 22px 15px;
+}


### PR DESCRIPTION
I added additional class in #1195 and remembered that there was already similar solution in s3 an csv import extractors. This will remove those 2 hacks and use that class instead.