### PR TITLE
Switch docker sandbox api

### DIFF
--- a/src/scripts/modules/provisioning/ActionCreators.js
+++ b/src/scripts/modules/provisioning/ActionCreators.js
@@ -429,11 +429,11 @@ module.exports = {
     });
   },
 
-  createRStudioSandboxCredentials: function(data) {
+  createRStudioSandboxCredentials: function(data, isTransformation) {
     dispatcher.handleViewAction({
       type: constants.ActionTypes.CREDENTIALS_RSTUDIO_SANDBOX_CREATE_JOB
     });
-    return provisioningApi.createCredentialsAsync('docker', 'rstudio', data).then(function(response) {
+    return provisioningApi.createCredentialsAsync('docker', 'rstudio', data, isTransformation).then(function(response) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.CREDENTIALS_RSTUDIO_SANDBOX_CREATE_JOB_SUCCESS,
         touch: response.touch,
@@ -524,11 +524,11 @@ module.exports = {
     });
   },
 
-  createJupyterSandboxCredentials: function(data) {
+  createJupyterSandboxCredentials: function(data, isTransformation) {
     dispatcher.handleViewAction({
       type: constants.ActionTypes.CREDENTIALS_JUPYTER_SANDBOX_CREATE_JOB
     });
-    return provisioningApi.createCredentialsAsync('docker', 'jupyter', data).then(function(response) {
+    return provisioningApi.createCredentialsAsync('docker', 'jupyter', data, isTransformation).then(function(response) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.CREDENTIALS_JUPYTER_SANDBOX_CREATE_JOB_SUCCESS,
         touch: response.touch,

--- a/src/scripts/modules/provisioning/ActionCreators.js
+++ b/src/scripts/modules/provisioning/ActionCreators.js
@@ -429,11 +429,11 @@ module.exports = {
     });
   },
 
-  createRStudioSandboxCredentials: function(data, isTransformation) {
+  createRStudioSandboxCredentials: function(data, options) {
     dispatcher.handleViewAction({
       type: constants.ActionTypes.CREDENTIALS_RSTUDIO_SANDBOX_CREATE_JOB
     });
-    return provisioningApi.createCredentialsAsync('docker', 'rstudio', data, isTransformation).then(function(response) {
+    return provisioningApi.createCredentialsAsync('docker', 'rstudio', data, options).then(function(response) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.CREDENTIALS_RSTUDIO_SANDBOX_CREATE_JOB_SUCCESS,
         touch: response.touch,
@@ -524,11 +524,11 @@ module.exports = {
     });
   },
 
-  createJupyterSandboxCredentials: function(data, isTransformation) {
+  createJupyterSandboxCredentials: function(data, options) {
     dispatcher.handleViewAction({
       type: constants.ActionTypes.CREDENTIALS_JUPYTER_SANDBOX_CREATE_JOB
     });
-    return provisioningApi.createCredentialsAsync('docker', 'jupyter', data, isTransformation).then(function(response) {
+    return provisioningApi.createCredentialsAsync('docker', 'jupyter', data, options).then(function(response) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.CREDENTIALS_JUPYTER_SANDBOX_CREATE_JOB_SUCCESS,
         touch: response.touch,

--- a/src/scripts/modules/provisioning/ProvisioningApi.js
+++ b/src/scripts/modules/provisioning/ProvisioningApi.js
@@ -65,14 +65,17 @@ const ProvisioningApi = {
       });
   },
 
-  createCredentialsAsync: function(backend, credentialsType, data) {
+  createCredentialsAsync: function(backend, credentialsType, data, isTransformation) {
     var requestData = data;
     if (!requestData) {
       requestData = {};
     }
-    requestData.type = credentialsType;
+    const pathSuffix = isTransformation ? '/transformation' : '';
+    if (!isTransformation) {
+      requestData.type = credentialsType;
+    }
     const sapiToken = ApplicationStore.getSapiTokenString();
-    return createRequest('POST', 'async/' + backend)
+    return createRequest('POST', 'async/' + backend + pathSuffix)
       .send(requestData)
       .promise()
       .then(function(response) {

--- a/src/scripts/modules/provisioning/ProvisioningApi.js
+++ b/src/scripts/modules/provisioning/ProvisioningApi.js
@@ -65,13 +65,13 @@ const ProvisioningApi = {
       });
   },
 
-  createCredentialsAsync: function(backend, credentialsType, data, isTransformation) {
+  createCredentialsAsync: function(backend, credentialsType, data, options) {
     var requestData = data;
     if (!requestData) {
       requestData = {};
     }
-    const pathSuffix = isTransformation ? '/transformation' : '';
-    if (!isTransformation) {
+    const pathSuffix = options && options.source ? '/' + options.source : '';
+    if (!options) {
       requestData.type = credentialsType;
     }
     const sapiToken = ApplicationStore.getSapiTokenString();

--- a/src/scripts/modules/transformations/react/components/TransformationRow.coffee
+++ b/src/scripts/modules/transformations/react/components/TransformationRow.coffee
@@ -20,6 +20,7 @@ TransformationRow = React.createClass(
   mixins: [ImmutableRenderMixin]
   propTypes:
     transformation: React.PropTypes.object
+    latestVersionId: React.PropTypes.number
     bucket: React.PropTypes.object
     pendingActions: React.PropTypes.object
     hideButtons: React.PropTypes.bool
@@ -43,7 +44,8 @@ TransformationRow = React.createClass(
         transformationType: @props.transformation.get('type')
         backend: @props.transformation.get('backend')
         mode: "button"
-        runParams: sandboxUtils.generateRunParameters(@props.transformation, @props.bucket.get('id'))
+        runParams: sandboxUtils.generateRunParameters(@props.transformation,
+        @props.bucket.get('id'), @props.latestVersionId)
     )
 
     buttons.push(RunComponentButton(

--- a/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
+++ b/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
@@ -86,7 +86,7 @@ export default React.createClass({
       progressStatus: null
     });
     const createCredentialsAction = this.isPythonTransformation() ? provisioningActions.createJupyterSandboxCredentials : provisioningActions.createRStudioSandboxCredentials;
-    const createSandboxPromise = createCredentialsAction(this.props.runParams.toJS());
+    const createSandboxPromise = createCredentialsAction(this.props.runParams.toJS(), true);
     return createSandboxPromise.then(() =>
       this.setState({
         isRunning: false,

--- a/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
+++ b/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
@@ -86,7 +86,7 @@ export default React.createClass({
       progressStatus: null
     });
     const createCredentialsAction = this.isPythonTransformation() ? provisioningActions.createJupyterSandboxCredentials : provisioningActions.createRStudioSandboxCredentials;
-    const createSandboxPromise = createCredentialsAction(this.props.runParams.toJS(), true);
+    const createSandboxPromise = createCredentialsAction(this.props.runParams.toJS(), {source: 'transformation'});
     return createSandboxPromise.then(() =>
       this.setState({
         isRunning: false,

--- a/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.coffee
+++ b/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.coffee
@@ -31,12 +31,16 @@ TransformationBucket = React.createClass
 
   getStateFromStores: ->
     bucketId = RoutesStore.getCurrentRouteParam 'config'
+    latestVersions = VersionsStore.getVersions('transformation', bucketId)
+    latestVersionId = latestVersions.map((v) -> v.get('version')).max()
+
     bucketId: bucketId
     transformations: TransformationsStore.getTransformations(bucketId)
     bucket: TransformationBucketsStore.get(bucketId)
     pendingActions: TransformationsStore.getPendingActions(bucketId)
     latestJobs: LatestJobsStore.getJobs('transformation', bucketId),
-    latestVersions: VersionsStore.getVersions('transformation', bucketId),
+    latestVersions: latestVersions
+    latestVersionId: latestVersionId
 
   componentWillReceiveProps: ->
     @setState(@getStateFromStores())
@@ -95,6 +99,7 @@ TransformationBucket = React.createClass
       span {className: 'tbody'},
         @_getSortedTransformations().map((transformation) ->
           TransformationRow
+            latestVersionId: @state.latestVersionId
             transformation: transformation
             bucket: @state.bucket
             pendingActions: @state.pendingActions.get transformation.get('id'), Immutable.Map()


### PR DESCRIPTION
FIXES #1217 
Momentalne sa do vytvarania sandbox api callu predava cely script co niekedy moze spadnut na limite jeho dlzky(viac infa https://github.com/keboola/provisioning-bundle/issues/66). 
Pripravil som upravu api callu pre vytvaranie docker sandboxu(python/R) z transformacie na tento api call:
http://docs.provisioningapi.apiary.io/#reference/credentials-async-actions/transformation-sandbox-credentials-async/create-credentials

Ako dosledok je pre vytvorenie docker sandboxu potrebne dodat `config_version` takze sa vyberie vzdy posledna/max verze z `getVersions('transformation', bucketId)` a preda sa do api callu. 

Vytvaranie plain sandboxu je nedotknute tj funguje po starom.