### PR TITLE
fix (oauth): custom auth info text padding

### DIFF
--- a/src/scripts/modules/oauth-v2/react/CustomAuthorizationFields.jsx
+++ b/src/scripts/modules/oauth-v2/react/CustomAuthorizationFields.jsx
@@ -14,10 +14,9 @@ export default React.createClass({
   render() {
     return (
       <div>
-        <p>
+        <p className="bottom-margin-20px">
           Provide your own OAuth 2.0 credentials from <a href="https://console.developers.google.com" target="_blank">Google API Console</a>.
-        </p>
-        <p>
+          <br />
           Follow these <a href="https://help.keboola.com/extractors/marketing-sales/google-analytics/#custom-oauth-credentials" target="_blank">instructions</a> to set up an application and obtain a pair of credentials.
         </p>
         <div className="form-group">

--- a/src/styles/app.less
+++ b/src/styles/app.less
@@ -340,3 +340,7 @@ a .kbcComponentIcon-3rdParty-64px {
     }
   }
 }
+// universal margin classes
+.bottom-margin-20px {
+  margin-bottom: 20px;
+}


### PR DESCRIPTION
@ujovlado dobre to uz vyzera, len este tento text na vrchu mi nedal. Chcelo to viac paddingu.
https://monosnap.com/file/cUJSBcaDGS0Nm3KJEaNncuu7hh99sU

A tu pouzitie `.row` uz dava zmysel, kedze to nie je vo `.form-group` (v tom si mal pravdu :)). 
A ma to takto pekny vertikalny flow :)