### PR TITLE
Ex-db: incremental always default off

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -302,7 +302,6 @@ export function createActions(componentId) {
           query = query.set('primaryKey', pkCols.map((column) => {
             return column.get('name');
           }).toJS());
-          query = query.set('incremental', true);
         }
         query = query.set('outputTable', store.getDefaultOutputTableId(table.get('tableName')));
         return query;

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -176,7 +176,6 @@ export default React.createClass({
         .set('table', (newValue === '') ? newValue : Immutable.fromJS(newValue))
         .set('name', newName ? newName : '')
         .set('primaryKey', primaryKeys)
-        .set('incremental', !!primaryKeys)
     );
   },
 


### PR DESCRIPTION
It doesn't make sense to have incremental = true if PK is present.
