### PR TITLE
Move styles for Guide Mode to prevent rewrite

### DIFF
--- a/src/scripts/modules/guide-mode/react/Wizard.jsx
+++ b/src/scripts/modules/guide-mode/react/Wizard.jsx
@@ -3,7 +3,6 @@ import WizardModal from './WizardModal';
 import WizardStore from '../stores/WizardStore';
 import { setStep, hideWizardModalFn } from '../stores/ActionCreators';
 import createStoreMixin from '../../../react/mixins/createStoreMixin';
-import './Guide.less';
 
 export default React.createClass({
   displayName: 'Wizard',

--- a/src/scripts/react/layout/App.coffee
+++ b/src/scripts/react/layout/App.coffee
@@ -21,6 +21,7 @@ classnames = require('classnames')
 {div, a, i, p} = React.DOM
 
 require '../../../styles/app.less'
+require '../../modules/guide-mode/react/Guide.less'
 
 App = React.createClass
   displayName: 'App'


### PR DESCRIPTION
This will prevent "rewrite" of `bundle.min.css` by CSS exported for `parts` entry.

