### PR TITLE
Add configId suffix to bucket for new configurations

### DIFF
--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -192,15 +192,18 @@ export function createStore(componentId, configId) {
       const bucketName = string.sanitizeKbcTableIdString(componentId);
       const fullBucketName = `in.c-${bucketName}`;
       const fullBucketNameWithConfigSuffix = `${fullBucketName}-${configId}`;
-      if (this.shouldDestinationHaveNewFormat(fullBucketNameWithConfigSuffix)) {
-        return `${fullBucketNameWithConfigSuffix}.${qname}`;
+      if (this.shouldDestinationHaveOldFormat(fullBucketName)) {
+        return `${fullBucketName}.${qname}`;
       }
-      return `${fullBucketName}.${qname}`;
+      return `${fullBucketNameWithConfigSuffix}.${qname}`;
     },
 
-    shouldDestinationHaveNewFormat(fullBucketNameWithConfigSuffix) {
+    shouldDestinationHaveOldFormat(fullBucketName) {
+      if (data.parameters.get('tables', List()).count() === 0) {
+        return false;
+      }
       return data.parameters.get('tables', List()).filter((table) => {
-        return table.get('outputTable').indexOf(fullBucketNameWithConfigSuffix + '.') === 0;
+        return table.get('outputTable').indexOf(fullBucketName + '.') === 0;
       }).count() === data.parameters.get('tables', List()).count();
     },
 

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -190,7 +190,18 @@ export function createStore(componentId, configId) {
       }
       const qname = string.sanitizeKbcTableIdString(name);
       const bucketName = string.sanitizeKbcTableIdString(componentId);
-      return `in.c-${bucketName}.${qname}`;
+      const fullBucketName = `in.c-${bucketName}`;
+      const fullBucketNameWithConfigSuffix = `${fullBucketName}-${configId}`;
+      if (this.shouldDestinationHaveNewFormat(fullBucketNameWithConfigSuffix)) {
+        return `${fullBucketNameWithConfigSuffix}.${qname}`;
+      }
+      return `${fullBucketName}.${qname}`;
+    },
+
+    shouldDestinationHaveNewFormat(fullBucketNameWithConfigSuffix) {
+      return data.parameters.get('tables', List()).filter((table) => {
+        return table.get('outputTable').indexOf(fullBucketNameWithConfigSuffix + '.') === 0;
+      }).count() === data.parameters.get('tables', List()).count();
     },
 
     getQueriesPendingActions() {

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
@@ -1,0 +1,31 @@
+let assert = require('assert');
+
+jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
+  const Immutable = require('immutable');
+  const data = Immutable.fromJS({
+    parameters: {
+      tables: []
+    }
+  });
+  return {
+    getConfigData: () => {
+      return data;
+    },
+    getLocalState: () => {
+      return data;
+    }
+  };
+});
+
+const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+
+describe('shouldDestinationHaveOldFormat test 1', function() {
+  describe('shouldDestinationHaveOldFormat', function() {
+    it('it should have new format (no tables)', function() {
+      assert.equal(
+        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
+        false
+      );
+    });
+  });
+});

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
@@ -1,0 +1,38 @@
+let assert = require('assert');
+
+jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
+  const Immutable = require('immutable');
+  const data = Immutable.fromJS({
+    parameters: {
+      tables: [
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql.test1'
+        },
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql.test2'
+        }
+      ]
+    }
+  });
+  return {
+    getConfigData: () => {
+      return data;
+    },
+    getLocalState: () => {
+      return data;
+    }
+  };
+});
+
+const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+
+describe('shouldDestinationHaveOldFormat test 2', function() {
+  describe('shouldDestinationHaveOldFormat', function() {
+    it('it should have old format (only old tables)', function() {
+      assert.equal(
+        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
+        true
+      );
+    });
+  });
+});

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
@@ -1,0 +1,35 @@
+let assert = require('assert');
+
+jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
+  const Immutable = require('immutable');
+  const data = Immutable.fromJS({
+    parameters: {
+      tables: [
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql-custom.test1'
+        }
+      ]
+    }
+  });
+  return {
+    getConfigData: () => {
+      return data;
+    },
+    getLocalState: () => {
+      return data;
+    }
+  };
+});
+
+const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+
+describe('shouldDestinationHaveOldFormat test 3', function() {
+  describe('shouldDestinationHaveOldFormat', function() {
+    it('it should have new format (custom destination)', function() {
+      assert.equal(
+        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
+        false
+      );
+    });
+  });
+});


### PR DESCRIPTION
Proposed changes:

- for new configurations, configId suffix will be added to bucket (simulates default bucket behavior)
- for old configurations bucket will remain the same (with one exception - if all tables already have configId suffix, new table will have this suffix too)