### PR TITLE
table-broser: fix scrolling for events and datasample tab

### DIFF
--- a/src/scripts/modules/table-browser/react/components/ColumnsInfoTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/ColumnsInfoTab.jsx
@@ -54,7 +54,7 @@ export default React.createClass({
     });
 
     return (
-      <div>
+      <div style={{'max-height': '80vh', overflow: 'auto'}}>
         <Table responsive className="table table-striped">
           {headerRow}
           <tbody>

--- a/src/scripts/modules/table-browser/react/components/DataSampleTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/DataSampleTab.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
     });
 
     return (
-      <div>
+      <div style={{'max-height': '80vh', overflow: 'auto'}}>
         <Table responsive className="table table-striped">
           <thead>
             <tr>

--- a/src/scripts/modules/table-browser/react/components/EventsTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/EventsTab.jsx
@@ -36,7 +36,7 @@ export default React.createClass({
     }
     const rows = this.renderTableRows();
     return (
-      <div>
+      <div style={{'max-height': '80vh', overflow: 'auto'}}>
         <div>
           <div className="row">
             <div className="col-xs-3">

--- a/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
@@ -35,7 +35,7 @@ export default React.createClass({
     const indexes = table.get('indexedColumns').toJS();
     const backend = table.getIn(['bucket', 'backend']);
     return (
-      <div>
+      <div style={{'max-height': '80vh', overflow: 'auto'}}>
         <Table responsive className="table">
           <thead>
             <tr>

--- a/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
@@ -25,7 +25,7 @@ export default React.createClass({
     }
     const tableId = this.props.tableId;
     return (
-      <div>
+      <div style={{'max-height': '80vh', overflow: 'auto'}}>
         <TableDescriptionEditor tableId={tableId}/>
       </div>
     );


### PR DESCRIPTION
Fixes #1333 

Proposed changes:

- uprava sa tyka Tabuliek v Data Sample a Events taboch
- upravi styl divu nad tabulkou na `style={{'max-height': '80vh', overflow: 'auto'}}`

