### PR TITLE
Pass scriptsBasePath to Guide mode Wizard component

### DIFF
--- a/index-storage.html
+++ b/index-storage.html
@@ -264,7 +264,8 @@
       var ReactDOM = kbcApp.helpers.ReactDOM;
       console.log('guide mode', kbcApp.parts.GuideMode.Wizard);
       var element = React.createElement(kbcApp.parts.GuideMode.Wizard, {
-        projectBaseUrl: 'project-base-url' // no effect
+        projectBaseUrl: 'project-base-url',
+        scriptsBasePath: ''
       });
       ReactDOM.render(element, document.getElementById("guide-mode-container"));
 

--- a/src/scripts/modules/guide-mode/react/GuideModeImage.jsx
+++ b/src/scripts/modules/guide-mode/react/GuideModeImage.jsx
@@ -4,10 +4,10 @@ import {Image} from 'react-bootstrap';
 export default React.createClass({
   propTypes: {
     scriptsBasePath: React.PropTypes.string.isRequired,
-    imgageName: React.PropTypes.string
+    imageName: React.PropTypes.string
   },
   getImagePath() {
-    return this.props.scriptsBasePath + require('../media/' + this.props.imgageName);
+    return this.props.scriptsBasePath + require('../media/' + this.props.imageName);
   },
   render() {
     return (

--- a/src/scripts/modules/guide-mode/react/GuideModeImage.jsx
+++ b/src/scripts/modules/guide-mode/react/GuideModeImage.jsx
@@ -1,20 +1,19 @@
 import React from 'react';
 import {Image} from 'react-bootstrap';
-import ApplicationStore from '../../../stores/ApplicationStore';
 
 export default React.createClass({
   propTypes: {
+    scriptsBasePath: React.PropTypes.string.isRequired,
     imgageName: React.PropTypes.string
   },
   getImagePath() {
-    return ApplicationStore.getScriptsBasePath() + require('../media/' + this.props.imgageName);
+    return this.props.scriptsBasePath + require('../media/' + this.props.imgageName);
   },
   render() {
     return (
-        <span>
-         <Image className="center-block" responsive
-                src={this.getImagePath()}/>
-       </span>
+      <span>
+         <Image className="center-block" src={this.getImagePath()} responsive />
+      </span>
     );
   }
 });

--- a/src/scripts/modules/guide-mode/react/Wizard.jsx
+++ b/src/scripts/modules/guide-mode/react/Wizard.jsx
@@ -8,7 +8,8 @@ export default React.createClass({
   displayName: 'Wizard',
 
   propTypes: {
-    projectBaseUrl: React.PropTypes.string.isRequired
+    projectBaseUrl: React.PropTypes.string.isRequired,
+    scriptsBasePath: React.PropTypes.string.isRequired
   },
 
   mixins: [createStoreMixin(WizardStore)],
@@ -56,6 +57,7 @@ export default React.createClass({
           position="aside"
           lesson={this.state.currentLesson}
           backdrop={true}
+          scriptsBasePath={this.props.scriptsBasePath}
         />
       );
     }

--- a/src/scripts/modules/guide-mode/react/WizardModal.jsx
+++ b/src/scripts/modules/guide-mode/react/WizardModal.jsx
@@ -184,7 +184,7 @@ export default React.createClass({
     return (
       <GuideModeImage
         scriptsBasePath={this.props.scriptsBasePath}
-        imgageName={this.getStepMedia()}
+        imageName={this.getStepMedia()}
       />
     );
   },

--- a/src/scripts/modules/guide-mode/react/WizardModal.jsx
+++ b/src/scripts/modules/guide-mode/react/WizardModal.jsx
@@ -25,7 +25,8 @@ export default React.createClass({
     step: React.PropTypes.number.isRequired,
     achievedStep: React.PropTypes.number.isRequired,
     lesson: React.PropTypes.object.isRequired,
-    projectBaseUrl: React.PropTypes.string.isRequired
+    projectBaseUrl: React.PropTypes.string.isRequired,
+    scriptsBasePath: React.PropTypes.string.isRequired
   },
 
   getProjectPageUrlHref(path) {
@@ -180,7 +181,12 @@ export default React.createClass({
     }
   },
   getImageLink() {
-    return <GuideModeImage imgageName={this.getStepMedia()}/>;
+    return (
+      <GuideModeImage
+        scriptsBasePath={this.props.scriptsBasePath}
+        imgageName={this.getStepMedia()}
+      />
+    );
   },
   getVideoEmbed() {
     return (

--- a/src/scripts/react/layout/App.coffee
+++ b/src/scripts/react/layout/App.coffee
@@ -42,6 +42,7 @@ App = React.createClass
     homeUrl: ApplicationStore.getUrlTemplates().get 'home'
     projectFeatures: ApplicationStore.getCurrentProjectFeatures()
     projectBaseUrl: ApplicationStore.getProjectBaseUrl()
+    scriptsBasePath: ApplicationStore.getScriptsBasePath()
   render: ->
     div null,
       if @state.projectHasGuideModeOn == true
@@ -87,5 +88,6 @@ App = React.createClass
             if @state.projectHasGuideModeOn == true
               Wizard
                 projectBaseUrl: @state.projectBaseUrl
+                scriptsBasePath: @state.scriptsBasePath
 
 module.exports = App


### PR DESCRIPTION
Fixes #1386 

Proposed changes:

- Pass `scriptsBasePath` to `Wizard`
- Create image path from props, no directly from `ApplicationStore`