### PR TITLE
add support for object rest spread operator syntax

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["es2015", "react"]
+  "presets": ["es2015", "react"],
+  "plugins": [["transform-object-rest-spread"]]
 }

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
   },
   "devDependencies": {
     "babel-eslint": "7.0.0",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "cross-env": "^1.0.7",
     "enzyme": "^2.6.0",
     "enzyme-to-json": "^1.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,6 +459,10 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
 
+babel-plugin-syntax-object-rest-spread@^6.8.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
 babel-plugin-transform-es2015-arrow-functions@^6.3.13:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.8.0.tgz#5b63afc3181bdc9a8c4d481b5a4f3f7d7fef3d9d"
@@ -635,6 +639,13 @@ babel-plugin-transform-flow-strip-types@^6.3.13:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.0.0"
 
+babel-plugin-transform-object-rest-spread@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
+  dependencies:
+    babel-plugin-syntax-object-rest-spread "^6.8.0"
+    babel-runtime "^6.26.0"
+
 babel-plugin-transform-react-display-name@^6.3.13:
   version "6.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.8.0.tgz#f7a084977383d728bdbdc2835bba0159577f660e"
@@ -741,6 +752,13 @@ babel-runtime@^6.0.0, babel-runtime@^6.11.6, babel-runtime@^6.18.0, babel-runtim
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.14.0, babel-template@^6.15.0, babel-template@^6.16.0, babel-template@^6.8.0:
   version "6.16.0"
@@ -4955,6 +4973,10 @@ regenerate@^1.2.1:
 regenerator-runtime@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.10.1.tgz#257f41961ce44558b18f7814af48c17559f9faeb"
+
+regenerator-runtime@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
 
 regenerator-transform@0.9.8:
   version "0.9.8"


### PR DESCRIPTION
Neni nato ziadna issue ale ma napadlo ze by sa to mohlo hodit minimalne ako darcek pod stromcek :))
### Funkcionalita
Rozsirenie pouzitia tzv `object spread operatoru` o rest syntax - tj ide hlavne o zprehladnenie  syntaxe. 
viac infa tu https://developers.google.com/web/updates/2017/06/object-rest-spread

### Priklad

```js
const object1 = {a: 'a', b: 'b'};
const object1UpdatedCopy = {...object1, 'a': 111, 'c': 42};
object1.a = 888;
console.log(object1);
{a: 888, b: "b"}
console.log(object1UpdatedCopy);
{a: 111, b: "b", c: 42}
```
### Setup
podpora cez instalaciu a pridanie babel pluginu:
https://babeljs.io/docs/plugins/transform-object-rest-spread/
ten to preklada to do volania `extend` funkcie.

Tym ako pouzivame immutable tak sa to az tak casto nebude vyuzivat ale mohlo by sa to dobre vyuzit napr tu:
https://github.com/keboola/kbc-ui/blob/config-rows-ex-s3/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx#L57
=>
https://github.com/keboola/kbc-ui/blob/config-rows-ex-s3/src/scripts/modules/ex-aws-s3/react/pages/Row.jsx#L231