### PR TITLE
better naming of buttons in refresh token modal

### DIFF
--- a/src/scripts/modules/tokens/react/Index/RefreshTokenModal.jsx
+++ b/src/scripts/modules/tokens/react/Index/RefreshTokenModal.jsx
@@ -45,6 +45,8 @@ export default React.createClass({
             onCancel={this.handleClose}
             placement="right"
             saveLabel="Refresh"
+            showSave={!this.state.newToken}
+            cancelLabel="Close"
           />
         </Modal.Footer>
       </Modal>


### PR DESCRIPTION
Fixes #1432 

Proposed changes:
- rename Cancel button to Close
- hide Refresh button after refresh

before refresh:
![image](https://user-images.githubusercontent.com/1412120/34868581-950cae0e-f784-11e7-80c6-05959f7f675a.png)

after refresh:
![image](https://user-images.githubusercontent.com/1412120/34868607-a4ae6ee2-f784-11e7-8541-043e90bf40d9.png)


