### PR TITLE
feat: (ex-db-generic|snowflake) make connection schema optional

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -36,6 +36,7 @@ export default React.createClass({
     getPKColumns: React.PropTypes.func.isRequired,
     queryNameExists: React.PropTypes.bool.isRequired,
     credentialsHasDatabase: React.PropTypes.bool,
+    credentialsHasSchema: React.PropTypes.bool,
     refreshMethod: React.PropTypes.func.isRequired
   },
 
@@ -443,6 +444,13 @@ export default React.createClass({
         <div className="help-block">
           <i className="fa fa-exclamation-triangle"/> This connection does not have a database specified so please be sure to prefix table names with the schema
           <br/>(e.g. `schemaName`.`tableName`)
+        </div>
+      );
+    } else if (this.props.componentId === 'keboola.ex-db-snowflake' && !this.props.credentialsHasSchema) {
+      return (
+        <div className="help-block">
+          <i className="fa fa-exclamation-triangle"/> This connection does not have a schema specified so please be sure to prefix table names with the schema
+          <br/>(e.g. "schemaName"."tableName")
         </div>
       );
     }

--- a/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
@@ -56,6 +56,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
         queryNameExists: ExDbStore.queryNameExists(editingQuery),
         localState: ExDbStore.getLocalState(),
         credentialsHasDatabase: !!credentials.get('database'),
+        credentialsHasSchema: !!credentials.get('schema'),
         isTestingConnection: ExDbStore.isTestingConnection(),
         validConnection: ExDbStore.isConnectionValid()
       };
@@ -103,6 +104,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
           getPKColumns={ExDbActionCreators.getPKColumnsFromSourceTable}
           queryNameExists={this.state.queryNameExists}
           credentialsHasDatabase={this.state.credentialsHasDatabase}
+          credentialsHasSchema={this.state.credentialsHasSchema}
           refreshMethod={this.handleRefreshSourceTables}
         />
       );

--- a/src/scripts/modules/ex-db-generic/templates/credentials.jsx
+++ b/src/scripts/modules/ex-db-generic/templates/credentials.jsx
@@ -38,7 +38,7 @@ const snowflakeFields = [
   ['Username', 'user', 'text', false, true],
   ['Password', '#password', 'password', true, true],
   ['Database', 'database', 'text', false, true],
-  ['Schema', 'schema', 'text', false, true],
+  ['Schema', 'schema', 'text', false, false],
   ['Warehouse', 'warehouse', 'text', false, false]
 ];
 


### PR DESCRIPTION
Fixes #1491 

Proposed changes:

- make snowflake connection `schema` be an optional parameter
- add help block to advanced query mode when no schema is defined in the connection
