### PR TITLE
feat: update keboola.ex-aws-s3

### DIFF
--- a/src/scripts/modules/ex-aws-s3/adapters/credentials.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/credentials.js
@@ -1,5 +1,6 @@
-var Immutable = require('immutable');
-function createConfiguration(localState) {
+import Immutable from 'immutable';
+
+export function createConfiguration(localState) {
   const config = Immutable.fromJS({
     parameters: {
       accessKeyId: localState.get('awsAccessKeyId', ''),
@@ -9,19 +10,14 @@ function createConfiguration(localState) {
   return config;
 }
 
-function parseConfiguration(configuration) {
+export function parseConfiguration(configuration) {
   return Immutable.fromJS({
     awsAccessKeyId: configuration.getIn(['parameters', 'accessKeyId'], ''),
     awsSecretAccessKey: configuration.getIn(['parameters', '#secretAccessKey'], '')
   });
 }
 
-function isComplete(configuration) {
+export function isComplete(configuration) {
   return configuration.getIn(['parameters', 'accessKeyId'], '') !== '' && configuration.getIn(['parameters', '#secretAccessKey'], '') !== '';
 }
 
-module.exports = {
-  createConfiguration: createConfiguration,
-  parseConfiguration: parseConfiguration,
-  isComplete: isComplete
-};

--- a/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.def.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.def.js
@@ -1,4 +1,4 @@
-const cases = {
+export const cases = {
   emptyWithDefaults: {
     localState: {
       awsAccessKeyId: '',
@@ -24,8 +24,4 @@ const cases = {
       }
     }
   }
-};
-
-module.exports = {
-  cases: cases
 };

--- a/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.js
@@ -1,9 +1,7 @@
-var assert = require('assert');
-var Immutable = require('immutable');
-var createConfiguration = require('./credentials').createConfiguration;
-var parseConfiguration = require('./credentials').parseConfiguration;
-var isComplete = require('./credentials').isComplete;
-var cases = require('./credentials.spec.def').cases;
+import assert from 'assert';
+import Immutable from 'immutable';
+import { createConfiguration, parseConfiguration, isComplete } from './credentials';
+import { cases } from './credentials.spec.def';
 
 describe('credentials', function() {
   describe('createConfiguration()', function() {

--- a/src/scripts/modules/ex-aws-s3/adapters/row.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.js
@@ -1,6 +1,6 @@
-var Immutable = require('immutable');
+import Immutable from 'immutable';
 
-function createConfiguration(localState) {
+export function createConfiguration(localState) {
   let skipLinesProcessor;
   let decompressProcessor;
   let flattenFoldersProcessor;
@@ -118,7 +118,7 @@ function createConfiguration(localState) {
   return config;
 }
 
-function parseConfiguration(configuration) {
+export function parseConfiguration(configuration) {
   const key = configuration.getIn(['parameters', 'key'], '');
   const isWildcard = key.slice(-1) === '*' ? true : false;
   const processorCreateManifest = configuration.getIn(['processors', 'after'], Immutable.List()).find(function(processor) {
@@ -155,12 +155,6 @@ function parseConfiguration(configuration) {
   });
 }
 
-function createEmptyConfiguration(name, webalizedName) {
+export function createEmptyConfiguration(name, webalizedName) {
   return createConfiguration(Immutable.fromJS({name: webalizedName}));
 }
-
-module.exports = {
-  createConfiguration: createConfiguration,
-  parseConfiguration: parseConfiguration,
-  createEmptyConfiguration: createEmptyConfiguration
-};

--- a/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
@@ -21,7 +21,6 @@ export const cases = {
       parameters: {
         bucket: '',
         key: '',
-        saveAs: '',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -33,7 +32,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: ''
             }
           },
           {
@@ -74,7 +74,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -86,7 +85,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -127,7 +127,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey*',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -139,7 +138,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -180,7 +180,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: true,
         newFilesOnly: false
       },
@@ -192,7 +191,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -233,7 +233,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -245,7 +244,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -286,7 +286,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: true
       },
@@ -298,7 +297,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -339,7 +339,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -351,7 +350,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -392,7 +392,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -404,7 +403,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -445,7 +445,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -457,7 +456,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -498,7 +498,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -510,7 +509,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -551,7 +551,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -563,7 +562,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -604,7 +604,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -616,7 +615,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -658,7 +658,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -670,7 +669,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -720,7 +720,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -733,19 +732,20 @@ export const cases = {
           },
           {
             definition: {
-              component: 'keboola.processor-flatten-folders'
-            },
-            parameters: {
-              starting_depth: 1
-            }
-          },
-          {
-            definition: {
               component: 'keboola.processor-move-files'
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-flatten-folders'
+            },
+            parameters: {
+              starting_depth: 1
             }
           },
           {
@@ -795,7 +795,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -807,7 +806,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {
@@ -866,7 +866,6 @@ export const cases = {
       parameters: {
         bucket: 'mybucket',
         key: 'mykey',
-        saveAs: 'mytable',
         includeSubfolders: false,
         newFilesOnly: false
       },
@@ -878,7 +877,8 @@ export const cases = {
             },
             parameters: {
               direction: 'tables',
-              addCsvSuffix: true
+              addCsvSuffix: true,
+              folder: 'mytable'
             }
           },
           {

--- a/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
@@ -1,4 +1,4 @@
-const cases = {
+export const cases = {
   emptyWithDefaults: {
     localState: {
       bucket: '',
@@ -916,8 +916,4 @@ const cases = {
 
   }
 
-};
-
-module.exports = {
-  cases: cases
 };

--- a/src/scripts/modules/ex-aws-s3/adapters/row.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.spec.js
@@ -1,9 +1,7 @@
-var assert = require('assert');
-var Immutable = require('immutable');
-var createConfiguration = require('./row').createConfiguration;
-var parseConfiguration = require('./row').parseConfiguration;
-var createEmptyConfiguration = require('./row').createEmptyConfiguration;
-var cases = require('./row.spec.def').cases;
+import assert from 'assert';
+import Immutable from 'immutable';
+import { createConfiguration, parseConfiguration, createEmptyConfiguration } from './row';
+import { cases } from './row.spec.def';
 
 describe('row', function() {
   describe('createConfiguration()', function() {


### PR DESCRIPTION
- use `keboola.processor-move-files` instead of `saveAs` (https://github.com/keboola/aws-s3-extractor/issues/18, https://github.com/keboola/http-extractor/issues/11)