### PR TITLE
mysql ex incremental

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -773,32 +773,6 @@ module.exports = {
       field: field
     });
   },
-  createConfigurationRow: function(componentId, configurationId, data, changeDescription) {
-    dispatcher.handleViewAction({
-      type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_START,
-      componentId: componentId,
-      configurationId: configurationId,
-      data: data
-    });
-    return installedComponentsApi.createConfigurationRow(componentId, configurationId, data, changeDescription)
-      .then(function(response) {
-        VersionActionCreators.loadVersionsForce(componentId, configurationId);
-        return dispatcher.handleViewAction({
-          type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_SUCCESS,
-          componentId: componentId,
-          configurationId: configurationId,
-          data: response
-        });
-      }).catch(function(e) {
-        dispatcher.handleViewAction({
-          type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_ERROR,
-          componentId: componentId,
-          configurationId: configurationId,
-          error: e
-        });
-        throw e;
-      });
-  },
   saveConfigurationRowEdit: function(componentId, configurationId, rowId, field) {
     var calledFunction, data, newValue;
     dispatcher.handleViewAction({
@@ -842,6 +816,32 @@ module.exports = {
       throw e;
     });
   },
+  createConfigurationRow: function(componentId, configurationId, data, changeDescription) {
+    dispatcher.handleViewAction({
+      type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_START,
+      componentId: componentId,
+      configurationId: configurationId,
+      data: data
+    });
+    return installedComponentsApi.createConfigurationRow(componentId, configurationId, data, changeDescription)
+      .then(function(response) {
+        VersionActionCreators.loadVersionsForce(componentId, configurationId);
+        return dispatcher.handleViewAction({
+          type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_SUCCESS,
+          componentId: componentId,
+          configurationId: configurationId,
+          data: response
+        });
+      }).catch(function(e) {
+        dispatcher.handleViewAction({
+          type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_ERROR,
+          componentId: componentId,
+          configurationId: configurationId,
+          error: e
+        });
+        throw e;
+      });
+  },
   deleteConfigurationRow: function(componentId, configurationId, rowId, changeDescription) {
     dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_DELETE_CONFIGURATION_ROW_START,
@@ -861,6 +861,35 @@ module.exports = {
       }).catch(function(e) {
         dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_DELETE_CONFIGURATION_ROW_ERROR,
+          componentId: componentId,
+          configurationId: configurationId,
+          rowId: rowId,
+          error: e
+        });
+        throw e;
+      });
+  },
+  updateConfigurationRow: function(componentId, configurationId, rowId, data, changeDescription) {
+    dispatcher.handleViewAction({
+      type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_START,
+      componentId: componentId,
+      configurationId: configurationId,
+      rowId: rowId,
+      data: data
+    });
+    return installedComponentsApi.updateConfigurationRow(componentId, configurationId, rowId, data, changeDescription)
+      .then(function(response) {
+        VersionActionCreators.loadVersionsForce(componentId, configurationId);
+        return dispatcher.handleViewAction({
+          type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_SUCCESS,
+          componentId: componentId,
+          configurationId: configurationId,
+          rowId: rowId,
+          data: response
+        });
+      }).catch(function(e) {
+        dispatcher.handleViewAction({
+          type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_ERROR,
           componentId: componentId,
           configurationId: configurationId,
           rowId: rowId,

--- a/src/scripts/modules/components/stores/InstalledComponentsStore.coffee
+++ b/src/scripts/modules/components/stores/InstalledComponentsStore.coffee
@@ -971,7 +971,9 @@ Dispatcher.register (payload) ->
           'configRowsData', action.componentId, action.configurationId, action.data.id
         ],
           fromJSOrdered(action.data.configuration)
-
+        .deleteIn [
+          'creatingConfigurationRows', action.componentId, action.configurationId
+        ]
       InstalledComponentsStore.emitChange()
 
     when constants.ActionTypes.INSTALLED_COMPONENTS_DELETE_CONFIGURATION_ROW_START

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -462,9 +462,8 @@ export function createActions(componentId) {
 
     getSourceTables(configId) {
       const store = getStore(configId);
-      const credentials = store.getCredentials();
-      updateLocalState(configId, storeProvisioning.loadingSourceTablesPath, true);
-      if (store.hasValidCredentials(credentials)) {
+      if (store.isConnectionValid()) {
+        updateLocalState(configId, storeProvisioning.loadingSourceTablesPath, true);
         let runData = store.configData.setIn(['parameters', 'db'], store.getCredentials());
         runData = runData.setIn(['parameters', 'tables'], List());
         const params = {

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -158,6 +158,20 @@ export function createActions(componentId) {
     }, List());
   }
 
+  function rowDataFromQuery(query) {
+    const queryState = query.has('state') ? query.get('state').toJS() : {};
+    const paramsQuery = query.delete('state');
+    return {
+      'rowId': query.get('id'),
+      'name': query.get('name'),
+      'isDisabled': !query.get('enabled'),
+      'configuration': JSON.stringify({
+        'parameters': paramsQuery.toJS()
+      }),
+      'state': JSON.stringify(queryState)
+    };
+  }
+
   return {
     // Credentials Actions start
     editCredentials(configId) {
@@ -384,7 +398,7 @@ export function createActions(componentId) {
 
       if (store.isRowConfiguration()) {
         const isNewQuery = store.isNewQuery(queryId);
-        const rowData = this.rowDataFromQuery(newQuery);
+        const rowData = rowDataFromQuery(newQuery);
         if (isNewQuery) {
           createConfigRow(configId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
@@ -430,7 +444,7 @@ export function createActions(componentId) {
       const diffMsg = 'Quickstart config creation';
       if (store.isRowConfiguration()) {
         queries.map(function(query) {
-          const data = this.rowDataFromQuery(query);
+          const data = rowDataFromQuery(query);
           createConfigRow(configId, data, ['quickstartSaving', query.get('id')], diffMsg).then(() => {
             removeFromLocalState(configId, ['quickstartSaving', query.get('id')]);
           });
@@ -489,7 +503,7 @@ export function createActions(componentId) {
       const store = getStore(configId);
       const queries = store.getQueries();
       queries.map((query) => {
-        const rowData = this.rowDataFromQuery(query);
+        const rowData = rowDataFromQuery(query);
         const diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
         updateLocalState(configId, ['migration', 'pending'], true);
         createConfigRow(configId, rowData, ['migration', 'processing', query.get('id').toString()], diffMsg).then(() => {
@@ -506,20 +520,6 @@ export function createActions(componentId) {
 
     dismissMigrationAlert(configId) {
       removeFromLocalState(configId, ['migration']);
-    },
-
-    rowDataFromQuery(query) {
-      const queryState = query.has('state') ? query.get('state').toJS() : {};
-      const paramsQuery = query.delete('state');
-      return {
-        'rowId': query.get('id'),
-        'name': query.get('name'),
-        'isDisabled': !query.get('enabled'),
-        'configuration': JSON.stringify({
-          'parameters': paramsQuery.toJS()
-        }),
-        'state': JSON.stringify(queryState)
-      };
     }
   };
 }

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -149,7 +149,7 @@ export function createActions(componentId) {
       if (qualifyingColumns.count() > 0) {
         return memo.push(Map({
           tableName: table.get('name'),
-          schemaName: table.get('schema'),
+          schema: table.get('schema'),
           candidates: qualifyingColumns
         }));
       } else {

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -515,6 +515,8 @@ export function createActions(componentId) {
       return saveConfigData(configId, newData, ['migration', 'saving'], diffMsg).then(() => {
         updateLocalState(configId, ['migration', 'pending'], false);
         updateLocalState(configId, ['migration', 'completed'], true);
+        const candidates = getIncrementalCandidates(store.getSourceTables(configId));
+        updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
       });
     },
 

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -491,13 +491,19 @@ export function createActions(componentId) {
       queries.map((query) => {
         let rowData = storeProvisioning.rowDataFromQuery(query);
         let diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
-        createConfigRow(configId, rowData, ['migrationSaving', query.get('id').toString()], diffMsg).then(() => {
-          removeFromLocalState(configId, ['migrationSaving', query.get('id').toString()]);
+        createConfigRow(configId, rowData, ['migration', 'processing', query.get('id').toString()], diffMsg).then(() => {
+          removeFromLocalState(configId, ['migration', 'processing', query.get('id').toString()]);
         });
       });
       const newData = store.configData.deleteIn(['parameters', 'tables']);
       const diffMsg = 'Migrating configuration to rows ';
-      return saveConfigData(configId, newData, ['migrationPending'], diffMsg);
+      return saveConfigData(configId, newData, ['migration', 'saving'], diffMsg).then(() => {
+        updateLocalState(configId, ['migration', 'completed'], true);
+      });
+    },
+
+    dismissMigrationAlert(configId) {
+      removeFromLocalState(configId, ['migration']);
     }
   };
 }

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -372,31 +372,31 @@ export function createActions(componentId) {
       newQuery = newQuery.delete('advancedMode');
       newQuery = this.checkTableName(newQuery, store);
 
+      var newQueries, diffMsg;
+      if (store.getQueries().find((q) => q.get('id') === newQuery.get('id') )) {
+        newQueries = store.getQueries().map((q) => q.get('id') === queryId ? newQuery : q);
+        diffMsg = 'Edit query '  + newQuery.get('name');
+      } else {
+        newQueries = store.getQueries().push(newQuery);
+        diffMsg = 'Create query ' + newQuery.get('name');
+      }
+      store.setQueries(newQueries);
+      removeFromLocalState(configId, ['isDestinationEditing', queryId]);
+      const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
       if (store.isRowConfiguration()) {
         let isNewQuery = store.isNewQuery(queryId);
         const rowData = storeProvisioning.rowDataFromQuery(newQuery);
         if (isNewQuery) {
-          createConfigRow(configId, rowData, ['isSaving', queryId], 'Creating row query').then(() => {
+          createConfigRow(configId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
             removeFromLocalState(configId, ['newQueries', queryId]);
           });
         } else {
-          updateConfigRow(configId, queryId, rowData, ['isSaving', queryId], 'Saving row query').then(() => {
+          updateConfigRow(configId, queryId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
           });
         }
       } else {
-        var newQueries, diffMsg;
-        if (store.getQueries().find((q) => q.get('id') === newQuery.get('id') )) {
-          newQueries = store.getQueries().map((q) => q.get('id') === queryId ? newQuery : q);
-          diffMsg = 'Edit query '  + newQuery.get('name');
-        } else {
-          newQueries = store.getQueries().push(newQuery);
-          diffMsg = 'Create query ' + newQuery.get('name');
-        }
-        const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
-        removeFromLocalState(configId, ['isDestinationEditing', queryId]);
-
         saveConfigData(configId, newData, ['isSaving', queryId], diffMsg).then(() => {
           removeFromLocalState(configId, ['editingQueries', queryId]);
           removeFromLocalState(configId, ['isSaving', queryId]);

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -17,9 +17,9 @@ export function loadSourceTables(componentId, configId) {
   const store = storeProvisioning.createStore(componentId, configId);
   if (store.hasValidCredentials(store.getCredentials()) && (!store.hasConnectionBeenTested() || !store.getSourceTables())) {
     if (!store.hasConnectionBeenTested()) {
-      actions.updateLocalState(configId, storeProvisioning.testingConnectionPath, true);
+      actions.updateLocalState(configId, storeProvisioning.TESTING_CONNECTION_PATH, true);
       return actions.testSavedCredentials(configId).then((connectionValid) => {
-        actions.updateLocalState(configId, storeProvisioning.testingConnectionPath, false);
+        actions.updateLocalState(configId, storeProvisioning.TESTING_CONNECTION_PATH, false);
         if (connectionValid && componentSupportsSimpleSetup(componentId)) {
           return createActions(componentId).getSourceTables(configId);
         }
@@ -33,7 +33,7 @@ export function loadSourceTables(componentId, configId) {
 
 export function reloadSourceTables(componentId, configId) {
   if (componentSupportsSimpleSetup(componentId)) {
-    createActions(componentId).updateLocalState(configId, storeProvisioning.loadingSourceTablesPath, true);
+    createActions(componentId).updateLocalState(configId, storeProvisioning.LOADING_SOURCE_TABLES_PATH, true);
     return createActions(componentId).getSourceTables(configId);
   }
 }
@@ -178,7 +178,7 @@ export function createActions(componentId) {
     updateEditingCredentials(configId, newCredentials) {
       updateLocalState(configId, 'editingCredentials', newCredentials);
       if (!getLocalState(configId).get('isChangedCredentials', false)) {
-        updateLocalState(configId, storeProvisioning.connectionTestedPath, false);
+        updateLocalState(configId, storeProvisioning.CONNECTION_TESTED_PATH, false);
         updateLocalState(configId, ['isChangedCredentials'], true);
       }
     },
@@ -202,7 +202,7 @@ export function createActions(componentId) {
       const diffMsg = 'Save new credentials';
       return saveConfigData(configId, newData, ['isSavingCredentials'], diffMsg).then(() => {
         this.resetNewCredentials(configId);
-        this.updateLocalState(configId, storeProvisioning.connectionTestedPath, false);
+        this.updateLocalState(configId, storeProvisioning.CONNECTION_TESTED_PATH, false);
         RoutesStore.getRouter().transitionTo(componentId, {config: configId});
       });
     },
@@ -218,7 +218,7 @@ export function createActions(componentId) {
       const diffMsg = 'Update credentials';
       return saveConfigData(configId, newConfigData, ['isSavingCredentials'], diffMsg).then(() => {
         this.cancelCredentialsEdit(configId);
-        this.updateLocalState(configId, storeProvisioning.connectionTestedPath, false);
+        this.updateLocalState(configId, storeProvisioning.CONNECTION_TESTED_PATH, false);
         RoutesStore.getRouter().transitionTo(componentId, {config: configId});
       });
     },
@@ -239,15 +239,15 @@ export function createActions(componentId) {
       return this.testCredentials(configId, store.getCredentials()).then(function(data) {
         var connectionValid = false;
         if (data.status === 'error') {
-          updateLocalState(configId, storeProvisioning.connectionErrorPath, fromJS(data.message));
-          updateLocalState(configId, storeProvisioning.connectionValidPath, false);
+          updateLocalState(configId, storeProvisioning.CONNECTION_ERROR_PATH, fromJS(data.message));
+          updateLocalState(configId, storeProvisioning.CONNECTION_VALID_PATH, false);
         } else if (data.status === 'success') {
-          updateLocalState(configId, storeProvisioning.connectionValidPath, true);
-          updateLocalState(configId, storeProvisioning.connectionErrorPath, null);
+          updateLocalState(configId, storeProvisioning.CONNECTION_VALID_PATH, true);
+          updateLocalState(configId, storeProvisioning.CONNECTION_ERROR_PATH, null);
           connectionValid = true;
         }
-        updateLocalState(configId, storeProvisioning.testingConnectionPath, false);
-        updateLocalState(configId, storeProvisioning.connectionTestedPath, true);
+        updateLocalState(configId, storeProvisioning.TESTING_CONNECTION_PATH, false);
+        updateLocalState(configId, storeProvisioning.CONNECTION_TESTED_PATH, true);
         return connectionValid;
       });
     },
@@ -463,7 +463,7 @@ export function createActions(componentId) {
     getSourceTables(configId) {
       const store = getStore(configId);
       if (store.isConnectionValid()) {
-        updateLocalState(configId, storeProvisioning.loadingSourceTablesPath, true);
+        updateLocalState(configId, storeProvisioning.LOADING_SOURCE_TABLES_PATH, true);
         let runData = store.configData.setIn(['parameters', 'db'], store.getCredentials());
         runData = runData.setIn(['parameters', 'tables'], List());
         const params = {
@@ -471,16 +471,16 @@ export function createActions(componentId) {
         };
         return callDockerAction(componentId, 'getTables', params).then(function(data) {
           if (data.status === 'error') {
-            updateLocalState(configId, storeProvisioning.sourceTablesErrorPath, fromJS(data.message));
+            updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, fromJS(data.message));
           } else if (data.status === 'success') {
-            updateLocalState(configId, storeProvisioning.sourceTablesErrorPath, null);
+            updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, null);
           }
-          updateLocalState(configId, storeProvisioning.sourceTablesPath, fromJS(data.tables));
+          updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, fromJS(data.tables));
           if (store.isRowConfiguration()) {
             let candidates = getIncrementalCandidates(fromJS(data.tables));
-            updateLocalState(configId, storeProvisioning.incrementalCandidatesPath, candidates);
+            updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
           }
-          updateLocalState(configId, storeProvisioning.loadingSourceTablesPath, false);
+          updateLocalState(configId, storeProvisioning.LOADING_SOURCE_TABLES_PATH, false);
         });
       }
     },

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -384,7 +384,7 @@ export function createActions(componentId) {
 
       if (store.isRowConfiguration()) {
         const isNewQuery = store.isNewQuery(queryId);
-        const rowData = storeProvisioning.rowDataFromQuery(newQuery);
+        const rowData = this.rowDataFromQuery(newQuery);
         if (isNewQuery) {
           createConfigRow(configId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
@@ -430,7 +430,7 @@ export function createActions(componentId) {
       const diffMsg = 'Quickstart config creation';
       if (store.isRowConfiguration()) {
         queries.map(function(query) {
-          const data = storeProvisioning.rowDataFromQuery(query);
+          const data = this.rowDataFromQuery(query);
           createConfigRow(configId, data, ['quickstartSaving', query.get('id')], diffMsg).then(() => {
             removeFromLocalState(configId, ['quickstartSaving', query.get('id')]);
           });
@@ -489,7 +489,7 @@ export function createActions(componentId) {
       const store = getStore(configId);
       const queries = store.getQueries();
       queries.map((query) => {
-        const rowData = storeProvisioning.rowDataFromQuery(query);
+        const rowData = this.rowDataFromQuery(query);
         const diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
         createConfigRow(configId, rowData, ['migration', 'processing', query.get('id').toString()], diffMsg).then(() => {
           removeFromLocalState(configId, ['migration', 'processing', query.get('id').toString()]);
@@ -504,6 +504,20 @@ export function createActions(componentId) {
 
     dismissMigrationAlert(configId) {
       removeFromLocalState(configId, ['migration']);
+    },
+
+    rowDataFromQuery(query) {
+      const queryState = query.has('state') ? query.get('state').toJS() : {};
+      const paramsQuery = query.delete('state');
+      return {
+        'rowId': query.get('id'),
+        'name': query.get('name'),
+        'isDisabled': !query.get('enabled'),
+        'configuration': JSON.stringify({
+          'parameters': paramsQuery.toJS()
+        }),
+        'state': JSON.stringify(queryState)
+      };
     }
   };
 }

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -519,8 +519,10 @@ export function createActions(componentId) {
       return saveConfigData(configId, newData, ['migration', 'saving'], diffMsg).then(() => {
         updateLocalState(configId, ['migration', 'pending'], false);
         updateLocalState(configId, ['migration', 'completed'], true);
-        const candidates = getIncrementalCandidates(store.getSourceTables(configId));
-        updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
+        if (store.getSourceTables(configId)) {
+          const candidates = getIncrementalCandidates(store.getSourceTables(configId));
+          updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
+        }
       });
     },
 

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -125,7 +125,7 @@ export function createActions(componentId) {
   }
 
   function getPKColumsFromSourceTable(targetTable, sourceTables) {
-    var matchedTable = sourceTables.find((table) =>
+    const matchedTable = sourceTables.find((table) =>
       table.get('schema') === targetTable.get('schema')
       && table.get('name') === targetTable.get('tableName')
     );
@@ -141,7 +141,7 @@ export function createActions(componentId) {
 
   function getIncrementalCandidates(sourceTables) {
     return sourceTables.reduce((memo, table) => {
-      let qualifyingColumns = table.get('columns').filter((column) => {
+      const qualifyingColumns = table.get('columns').filter((column) => {
         if (column.has('autoIncrement') || column.get('type') === 'timestamp') {
           return column;
         }
@@ -287,7 +287,7 @@ export function createActions(componentId) {
 
     createQuery(configId) {
       const store = getStore(configId);
-      let newQuery = this.checkTableName(store.generateNewQuery(null, componentSupportsSimpleSetup(componentId)), store);
+      const newQuery = this.checkTableName(store.generateNewQuery(null, componentSupportsSimpleSetup(componentId)), store);
       updateLocalState(configId, ['newQueries', newQuery.get('id')], newQuery);
       updateLocalState(configId, ['newQueriesIdsList'], store.getNewQueriesIdsList().unshift(newQuery.get('id')));
       this.changeQueryEdit(configId, newQuery);
@@ -383,7 +383,7 @@ export function createActions(componentId) {
       removeFromLocalState(configId, ['isDestinationEditing', queryId]);
 
       if (store.isRowConfiguration()) {
-        let isNewQuery = store.isNewQuery(queryId);
+        const isNewQuery = store.isNewQuery(queryId);
         const rowData = storeProvisioning.rowDataFromQuery(newQuery);
         if (isNewQuery) {
           createConfigRow(configId, rowData, ['isSaving', queryId], diffMsg).then(() => {
@@ -414,7 +414,7 @@ export function createActions(componentId) {
 
     quickstart(configId, tableList) {
       const store = getStore(configId);
-      let queries = tableList.map(function(table) {
+      const queries = tableList.map(function(table) {
         let query = store.generateNewQuery(null, componentSupportsSimpleSetup(componentId));
         query = query.set('table', table);
         query = query.set('name', table.get('tableName'));
@@ -477,7 +477,7 @@ export function createActions(componentId) {
           }
           updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, fromJS(data.tables));
           if (store.isRowConfiguration()) {
-            let candidates = getIncrementalCandidates(fromJS(data.tables));
+            const candidates = getIncrementalCandidates(fromJS(data.tables));
             updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
           }
           updateLocalState(configId, storeProvisioning.LOADING_SOURCE_TABLES_PATH, false);
@@ -489,8 +489,8 @@ export function createActions(componentId) {
       const store = getStore(configId);
       const queries = store.getQueries();
       queries.map((query) => {
-        let rowData = storeProvisioning.rowDataFromQuery(query);
-        let diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
+        const rowData = storeProvisioning.rowDataFromQuery(query);
+        const diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
         createConfigRow(configId, rowData, ['migration', 'processing', query.get('id').toString()], diffMsg).then(() => {
           removeFromLocalState(configId, ['migration', 'processing', query.get('id').toString()]);
         });

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -491,6 +491,7 @@ export function createActions(componentId) {
       queries.map((query) => {
         const rowData = this.rowDataFromQuery(query);
         const diffMsg = 'Migrating query ' + query.get('name') + ' to configuration row';
+        updateLocalState(configId, ['migration', 'pending'], true);
         createConfigRow(configId, rowData, ['migration', 'processing', query.get('id').toString()], diffMsg).then(() => {
           removeFromLocalState(configId, ['migration', 'processing', query.get('id').toString()]);
         });
@@ -498,6 +499,7 @@ export function createActions(componentId) {
       const newData = store.configData.deleteIn(['parameters', 'tables']);
       const diffMsg = 'Migrating configuration to rows ';
       return saveConfigData(configId, newData, ['migration', 'saving'], diffMsg).then(() => {
+        updateLocalState(configId, ['migration', 'pending'], false);
         updateLocalState(configId, ['migration', 'completed'], true);
       });
     },

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -98,13 +98,13 @@ export function createActions(componentId) {
 
   function updateConfigRow(configId, rowId, data, waitingPath, changeDescription) {
     updateLocalState(configId, waitingPath, true);
-    return componentsActions.updateConfigurationRow(componentId, configId, rowId, data, changeDescription)
+    return componentsActions.updateConfigurationRow(componentId, configId, rowId.toString(), data, changeDescription)
       .then(() => updateLocalState(configId, waitingPath, false));
   }
 
   function deleteConfigRow(configId, rowId, waitingPath, changeDescription) {
     updateLocalState(configId, waitingPath, true);
-    return componentsActions.deleteConfigurationRow(componentId, configId, rowId, changeDescription)
+    return componentsActions.deleteConfigurationRow(componentId, configId, rowId.toString(), changeDescription)
       .then(() => updateLocalState(configId, waitingPath, false));
   }
 
@@ -380,9 +380,8 @@ export function createActions(componentId) {
         newQueries = store.getQueries().push(newQuery);
         diffMsg = 'Create query ' + newQuery.get('name');
       }
-      store.setQueries(newQueries);
       removeFromLocalState(configId, ['isDestinationEditing', queryId]);
-      const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
+
       if (store.isRowConfiguration()) {
         let isNewQuery = store.isNewQuery(queryId);
         const rowData = storeProvisioning.rowDataFromQuery(newQuery);
@@ -390,13 +389,18 @@ export function createActions(componentId) {
           createConfigRow(configId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
             removeFromLocalState(configId, ['newQueries', queryId]);
+            removeFromLocalState(configId, ['isSaving', queryId]);
+            removeFromLocalState(configId, ['isChanged', queryId]);
           });
         } else {
           updateConfigRow(configId, queryId, rowData, ['isSaving', queryId], diffMsg).then(() => {
             removeFromLocalState(configId, ['editingQueries', queryId]);
+            removeFromLocalState(configId, ['isSaving', queryId]);
+            removeFromLocalState(configId, ['isChanged', queryId]);
           });
         }
       } else {
+        const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
         saveConfigData(configId, newData, ['isSaving', queryId], diffMsg).then(() => {
           removeFromLocalState(configId, ['editingQueries', queryId]);
           removeFromLocalState(configId, ['isSaving', queryId]);

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -328,6 +328,8 @@ export function createActions(componentId) {
         if (runQuery.get('advancedMode')) {
           runQuery = runQuery.delete('table');
           runQuery = runQuery.delete('columns');
+          runQuery = runQuery.delete('incrementalFetchingColumn');
+          runQuery = runQuery.delete('incrementalFetchingLimit');
         } else {
           runQuery = runQuery.delete('query');
         }
@@ -380,6 +382,8 @@ export function createActions(componentId) {
       if (newQuery.get('advancedMode')) {
         newQuery = newQuery.delete('table');
         newQuery = newQuery.delete('columns');
+        newQuery = newQuery.delete('incrementalFetchingColumn');
+        newQuery = newQuery.delete('incrementalFetchingLimit');
       } else {
         newQuery = newQuery.delete('query');
       }

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,9 +1,8 @@
 import React from 'react';
 
 export default React.createClass({
-  displayName: 'MigrateToRowsButton',
   propTypes: {
-    componentId: React.PropTypes.string,
+    componentId: React.PropTypes.string.isRequired,
     configId: React.PropTypes.string.isRequired,
     actionsProvisioning: React.PropTypes.object.isRequired
   },

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -18,6 +18,7 @@ export default React.createClass({
       <button
         className="btn btn-success"
         onClick={this.migrateConfig}
+        disabled={this.props.pending}
       >
         Migrate Configuration
       </button>

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import {Loader} from '@keboola/indigo-ui';
+
+export default React.createClass({
+  displayName: 'MigrateToRowsButton',
+  propTypes: {
+    componentId: React.PropTypes.string,
+    configId: React.PropTypes.string.isRequired,
+    actionsProvisioning: React.PropTypes.object.isRequired,
+    isPending: React.PropTypes.bool
+  },
+
+  migrateConfig() {
+    const ExDbActionCreators = this.props.actionsProvisioning.createActions(this.props.componentId);
+    ExDbActionCreators.migrateConfig(this.props.configId);
+  },
+
+  render() {
+    if (this.props.isPending) {
+      return (
+        <span className="btn">
+          <Loader/>
+        </span>
+      );
+    } else {
+      return (
+          <button
+            className="btn"
+            onClick={this.migrateConfig}
+          >
+            Migrate configuration
+          </button>
+      );
+    }
+  }
+});

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import {Loader} from '@keboola/indigo-ui';
 
 export default React.createClass({
   propTypes: {
     componentId: React.PropTypes.string.isRequired,
     configId: React.PropTypes.string.isRequired,
+    pending: React.PropTypes.bool.isRequired,
     actionsProvisioning: React.PropTypes.object.isRequired
   },
 
@@ -12,14 +14,19 @@ export default React.createClass({
     ExDbActionCreators.migrateConfig(this.props.configId);
   },
 
+  dismissAlert() {
+    const ExDbActionCreators = this.props.actionsProvisioning.createActions(this.props.componentId);
+    ExDbActionCreators.dismissMigrationAlert(this.props.configId);
+  },
+
   render() {
     return (
-        <button
-          className="btn btn-success"
-          onClick={this.migrateConfig}
-        >
-          Migrate configuration
-        </button>
+      <button
+        className="btn btn-success"
+        onClick={this.migrateConfig}
+      >
+        {this.props.pending ? <Loader /> : 'Migrate Configuration'}
+      </button>
     );
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -4,6 +4,7 @@ export default React.createClass({
   propTypes: {
     componentId: React.PropTypes.string.isRequired,
     configId: React.PropTypes.string.isRequired,
+    pending: React.PropTypes.bool.isRequired,
     actionsProvisioning: React.PropTypes.object.isRequired
   },
 

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Loader} from '@keboola/indigo-ui';
 
 export default React.createClass({
   propTypes: {
@@ -21,7 +20,7 @@ export default React.createClass({
         onClick={this.migrateConfig}
         disabled={this.props.pending}
       >
-        {this.props.pending ? <Loader/> : 'Migrate Configuration'}
+        Migrate Configuration
       </button>
     );
   }

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Loader} from '@keboola/indigo-ui';
 
 export default React.createClass({
   propTypes: {
@@ -14,18 +13,13 @@ export default React.createClass({
     ExDbActionCreators.migrateConfig(this.props.configId);
   },
 
-  dismissAlert() {
-    const ExDbActionCreators = this.props.actionsProvisioning.createActions(this.props.componentId);
-    ExDbActionCreators.dismissMigrationAlert(this.props.configId);
-  },
-
   render() {
     return (
       <button
         className="btn btn-success"
         onClick={this.migrateConfig}
       >
-        {this.props.pending ? <Loader /> : 'Migrate Configuration'}
+        Migrate Configuration
       </button>
     );
   }

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,13 +1,11 @@
 import React from 'react';
-import {Loader} from '@keboola/indigo-ui';
 
 export default React.createClass({
   displayName: 'MigrateToRowsButton',
   propTypes: {
     componentId: React.PropTypes.string,
     configId: React.PropTypes.string.isRequired,
-    actionsProvisioning: React.PropTypes.object.isRequired,
-    isPending: React.PropTypes.bool
+    actionsProvisioning: React.PropTypes.object.isRequired
   },
 
   migrateConfig() {
@@ -16,21 +14,13 @@ export default React.createClass({
   },
 
   render() {
-    if (this.props.isPending) {
-      return (
-        <span className="btn">
-          <Loader/>
-        </span>
-      );
-    } else {
-      return (
-          <button
-            className="btn"
-            onClick={this.migrateConfig}
-          >
-            Migrate configuration
-          </button>
-      );
-    }
+    return (
+        <button
+          className="btn btn-success"
+          onClick={this.migrateConfig}
+        >
+          Migrate configuration
+        </button>
+    );
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -4,7 +4,6 @@ export default React.createClass({
   propTypes: {
     componentId: React.PropTypes.string.isRequired,
     configId: React.PropTypes.string.isRequired,
-    pending: React.PropTypes.bool.isRequired,
     actionsProvisioning: React.PropTypes.object.isRequired
   },
 

--- a/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/MigrateToRowsButton.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Loader} from '@keboola/indigo-ui';
 
 export default React.createClass({
   propTypes: {
@@ -20,7 +21,7 @@ export default React.createClass({
         onClick={this.migrateConfig}
         disabled={this.props.pending}
       >
-        Migrate Configuration
+        {this.props.pending ? <Loader/> : 'Migrate Configuration'}
       </button>
     );
   }

--- a/src/scripts/modules/ex-db-generic/react/components/QueryActionButtons.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryActionButtons.jsx
@@ -73,10 +73,7 @@ export default function(
     },
 
     runParams() {
-      return {
-        config: this.state.configId,
-        configData: actionCreators.prepareSingleQueryRunData(this.state.configId, this.state.query, 'detail')
-      };
+      return actionCreators.prepareSingleQueryRunData(this.state.configId, this.state.query, 'detail');
     },
 
     handleActiveChange(newValue) {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import Immutable from 'immutable';
 import _ from 'underscore';
+import {Alert} from 'react-bootstrap';
 
 import {CodeEditor} from '../../../../react/common/common';
 import Select from '../../../../react/common/Select';
@@ -358,26 +359,37 @@ export default React.createClass({
               {this.isExistingTable() && this.primaryKeyHelp()}
             </div>
           </div>
-          <div className="form-group">
-            <div className="col-md-9 col-md-offset-3 checkbox">
-              <label>
-                <input
-                  type="checkbox"
-                  checked={this.props.query.get('incremental')}
-                  onChange={this.handleIncrementalChange}
-                  disabled={this.props.disabled}
-                />
-                Incremental Loading
-              </label>
-              <div className="help-block">
-                If incremental load is turned on, the table will be updated instead of rewritten.
-                Tables with primary keys will update rows, tables without primary keys will append rows.
-              </div>
-            </div>
-          </div>
+          {this.renderIncrementalLoadOption()}
           <h3>Advanced Mode</h3>
           {this.renderQueryToggle()}
           {this.renderQueryEditor()}
+        </div>
+      </div>
+    );
+  },
+
+  renderIncrementalLoadOption() {
+    let helpAlert = null;
+    if (this.props.query.get('incrementalFetchingColumn') && !this.props.query.get('incremental')) {
+      helpAlert = <Alert bsStyle="warning"><strong>Caution</strong>: Incremental Fetching is enabled.  Please be aware that each run will completely replace the destination table when incremental loading is disabled.</Alert>;
+    }
+    return (
+      <div className="form-group">
+        <div className="col-md-9 col-md-offset-3 checkbox">
+          <label>
+            <input
+              type="checkbox"
+              checked={this.props.query.get('incremental')}
+              onChange={this.handleIncrementalChange}
+              disabled={this.props.disabled}
+            />
+            Incremental Loading
+          </label>
+          <div className="help-block">
+            If incremental load is turned on, the table will be updated instead of rewritten.
+            Tables with primary keys will update rows, tables without primary keys will append rows.
+            {helpAlert}
+          </div>
         </div>
       </div>
     );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -221,6 +221,7 @@ export default React.createClass({
         .set('table', (newValue === '') ? newValue : Immutable.fromJS(newValue))
         .set('name', newName ? newName : '')
         .set('primaryKey', primaryKeys)
+        .set('incrementalFetchingColumn', '')
     );
   },
 

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -517,7 +517,7 @@ export default React.createClass({
   },
 
   renderIncrementalFetching() {
-    if (this.props.isConfigRow && this.incrementalFetchingOptions().length > 0) {
+    if (!this.props.query.get('advancedMode') && this.props.isConfigRow && this.incrementalFetchingOptions().length > 0) {
       return (
         <div className="form-group">
           <label className="col-md-3 control-label">Incremental Fetching</label>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -138,10 +138,11 @@ export default React.createClass({
     }
     let selectedTable = this.props.query.get('table');
     let candidateTable = this.props.incrementalCandidates.find((candidate) => {
-      return candidate.get('tableName') === selectedTable.get('tableName');
+      return candidate.get('name') === selectedTable.get('tableName')
+        && candidate.get('schema') === selectedTable.get('schema');
     });
     if (candidateTable) {
-      return candidateTable.get('candidates').map((candidate) => {
+      return candidateTable.get('columns').map((candidate) => {
         return {
           value: candidate.get('name'),
           label: candidate.get('name')

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -588,7 +588,6 @@ export default React.createClass({
                   isPending={false}
                   disabled={false}
                 >
-                  Delete the current stored state.
                   Resetting means that the next run will start from the lowest value of {fetchingColumn}
                 </ResetStateButton>
               </div>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -17,7 +17,6 @@ import {getQueryEditorPlaceholder, getQueryEditorHelpText} from '../../templates
 import editorMode from '../../templates/editorMode';
 
 export default React.createClass({
-  displayName: 'ExDbQueryEditor',
   propTypes: {
     query: React.PropTypes.object.isRequired,
     tables: React.PropTypes.object.isRequired,
@@ -167,14 +166,6 @@ export default React.createClass({
     }
   },
 
-  tableSelectOptions() {
-    return this.props.tables.map(function(table) {
-      return table.get('id');
-    }).sortBy(function(val) {
-      return val;
-    });
-  },
-
   getPksOnSourceTableChange(newValue) {
     const pkCols = this.props.getPKColumns(Immutable.fromJS(newValue), this.props.sourceTables);
     let sourctTablePks = pkCols.map((column) => {
@@ -269,12 +260,6 @@ export default React.createClass({
   getTableValue() {
     if (this.props.query.get('table')) {
       return this.props.query.get('table').get('tableName');
-    } else return '';
-  },
-
-  getTableLabel() {
-    if (this.props.query.get('table')) {
-      return this.props.query.get('table').get('name');
     } else return '';
   },
 
@@ -543,7 +528,7 @@ export default React.createClass({
 
   renderIncrementalFetchingForm() {
     return [
-      <div className="form-group">
+      <div className="form-group" key="column">
         <label className="col-md-3 control-label">Column</label>
         <div className="col-md-9">
           <Select
@@ -559,7 +544,7 @@ export default React.createClass({
           </div>
         </div>
       </div>,
-      <div className="form-group">
+      <div className="form-group" key="limit">
         <label className="col-md-3 control-label">Limit</label>
         <div className="col-md-9">
           <input
@@ -641,7 +626,7 @@ export default React.createClass({
         );
       }
       return (
-        <div className="form-group">
+        <div className="form-group" key="last-fetched-value">
           <label className="col-md-3 control-label">Last Fetched Value</label>
           <div className="col-md-8">
             {formElement}

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -168,6 +168,21 @@ export default React.createClass({
       } else {
         return 'Note: Using an update timestamp column means that only new and updated records will be fetched, not deletes.';
       }
+    } else {
+      return 'If enabled, only newly created or updated records since the last run will be fetched.';
+    }
+  },
+
+  renderlastFetchedInfo() {
+    if (this.props.query.get('incrementalFetchingColumn')) {
+      let queryState = this.props.query.get('state');
+      if (queryState.has('lastFetchedRow')) {
+        return (
+          <div>
+            Last fetched record had `{this.props.query.get('incrementalFetchingColumn')} = {queryState.get('lastFetchedRow')}`
+          </div>
+        );
+      }
     }
   },
 
@@ -540,8 +555,8 @@ export default React.createClass({
               disabled={this.props.disabled}
             />
             <div className="help-block">
-              Only newly created or updated records since the last run will be fetched.<br/>
               <span className="text-warning">{this.incrementalFetchingWarning()}</span>
+              {this.renderlastFetchedInfo()}
             </div>
           </div>
         </div>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -543,7 +543,7 @@ export default React.createClass({
                   className="form-control"
                   name="incrementalFetchingLimit"
                   type="number"
-                  default="0"
+                  value={this.props.query.get('incrementalFetchingLimit') ? this.props.query.get('incrementalFetchingLimit') : 0}
                   onChange={this.handleIncrementalFetchingLimitChange}
                   disabled={this.props.disabled}
                 />

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -643,19 +643,26 @@ export default React.createClass({
   },
 
   incrementalFetchingWarning() {
+    var infoMessage = 'If enabled, only newly created or updated records since the last run will be fetched.';
     if (this.props.query.get('incrementalFetchingColumn') && this.props.sourceTables.count() > 0) {
       let candidateTable = this.getCandidateTable();
-      let candidateColumn = candidateTable.get('candidates').find((column) =>
-        column.get('name') === this.props.query.get('incrementalFetchingColumn')
-      );
-      if (candidateColumn.get('autoIncrement')) {
-        return 'Using an autoIncrement ID means that only new records will be fetched, not updates or deletes.';
+      if (candidateTable) {
+        let candidateColumn = candidateTable.get('candidates').find((column) =>
+          column.get('name') === this.props.query.get('incrementalFetchingColumn')
+        );
+        if (candidateColumn.get('autoIncrement')) {
+          infoMessage = 'Using an autoIncrement ID means that only new records will be fetched, not updates or' +
+            ' deletes.';
+        } else {
+          infoMessage = 'Using an update timestamp column means that only new and updated records will be fetched,' +
+            ' not deletes.';
+        }
       } else {
-        return 'Using an update timestamp column means that only new and updated records will be fetched, not deletes.';
+        infoMessage = 'In order to enable incremental fetching the source table must contain a timestamp column or' +
+          ' an auto-incrementing primary key';
       }
-    } else {
-      return 'If enabled, only newly created or updated records since the last run will be fetched.';
     }
+    return infoMessage;
   },
 
   getLastFetchedRowValue() {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -537,14 +537,29 @@ export default React.createClass({
         <div className="form-group">
           <label className="col-md-3 control-label">Incremental Fetching</label>
           <div className="col-md-9">
-            <Select
-              name="incrementalFetching"
-              value={this.props.query.get('incrementalFetchingColumn') || ''}
-              placeholder="Select the column to be used for incremental fetching"
-              onChange={this.handleIncrementalFetchingChange}
-              options={this.incrementalFetchingOptions()}
-              disabled={this.props.disabled || this.getLastFetchedRowValue()}
-            />
+            <div className="row">
+              <div className="col-md-6">
+                <Select
+                  name="incrementalFetching"
+                  value={this.props.query.get('incrementalFetchingColumn') || ''}
+                  placeholder="Fetch by column"
+                  onChange={this.handleIncrementalFetchingChange}
+                  options={this.incrementalFetchingOptions()}
+                  disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
+                />
+              </div>
+              <label className="col-md-1 control-label">Limit</label>
+              <div className="col-md-5">
+                <input
+                  className="form-control"
+                  name="incrementalFetchingLimit"
+                  type="number"
+                  placeholder="# of records to fetch."
+                  onChange={this.handleIncrementalFetchingLimitChange}
+                  disabled={this.props.disabled}
+                />
+              </div>
+            </div>
             <div className="help-block">
               <span className="text-warning">{this.incrementalFetchingWarning()}</span>
               {this.renderlastFetchedInfo()}
@@ -583,7 +598,7 @@ export default React.createClass({
 
   getLastFetchedRowValue() {
     let queryState = this.props.query.get('state');
-    if (queryState.has('lastFetchedRow')) {
+    if (queryState && queryState.has('lastFetchedRow')) {
       return queryState.get('lastFetchedRow');
     } else {
       return false;

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -567,7 +567,8 @@ export default React.createClass({
       const fetchingHelpText = (
         <div className="form-group">
           <div className="col-md-8 col-md-offset-3 help-block">
-            Incremental fetching is available for this extractor but only for tables containing an auto incrementing primary key or a timestamp column.
+            Incremental fetching is available for this extractor
+            but only for tables containing an auto incrementing primary key or a timestamp column.
           </div>
         </div>
       );
@@ -575,7 +576,7 @@ export default React.createClass({
         <div>
           <h3>Incremental Fetching</h3>
           {
-            (this.incrementalFetchingOptions().length > 0)
+            (this.incrementalFetchingOptions().length > 0 || this.props.query.get('incrementalFetchingColumn'))
               ? this.renderIncrementalFetchingForm()
               : fetchingHelpText
           }
@@ -630,7 +631,7 @@ export default React.createClass({
   },
 
   incrementalFetchingWarning() {
-    if (this.props.query.get('incrementalFetchingColumn')) {
+    if (this.props.query.get('incrementalFetchingColumn') && this.props.sourceTables.length > 0) {
       let candidateTable = this.getCandidateTable();
       let candidateColumn = candidateTable.get('candidates').find((column) =>
         column.get('name') === this.props.query.get('incrementalFetchingColumn')

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -558,12 +558,7 @@ export default React.createClass({
           </div>
         </div>
       </div>,
-      <div className="form-group">
-        <label className="col-md-3 control-label">Last fetched value</label>
-        <div className="col-md-8">
-          {this.renderlastFetchedInfo()}
-        </div>
-      </div>
+      this.renderlastFetchedInfo()
     ];
   },
 
@@ -590,15 +585,16 @@ export default React.createClass({
   },
 
   renderlastFetchedInfo() {
-    let fetchingColumn = this.props.query.get('incrementalFetchingColumn');
+    var formElement;
+    const fetchingColumn = this.props.query.get('incrementalFetchingColumn');
     if (fetchingColumn) {
       let lastFetchedRowValue = this.getLastFetchedRowValue();
       if (lastFetchedRowValue) {
         const tooltip = 'Resetting means that the next run will start from the lowest value of ' + fetchingColumn;
-        return (
+        formElement = (
           <div className="form-control-static">
             <div>
-              <strong>{this.getLastFetchedRowValue()}</strong>
+              <strong>{lastFetchedRowValue}</strong>
             </div>
             <div className="help-block">
               To start from the beginning of the table you can
@@ -612,16 +608,25 @@ export default React.createClass({
             </div>
           </div>
         );
+      } else {
+        formElement = (
+          <div className="form-control-static">
+            There is no value stored.
+            <div className="help-block">
+              Either the component has not yet run, or it has been reset.
+            </div>
+          </div>
+        );
       }
-    }
-    return (
-      <div className="form-control-static">
-        There is no value stored.
-        <div className="help-block">
-          Either the component has not yet run, or it has been reset.
+      return (
+        <div className="form-group">
+          <label className="col-md-3 control-label">Last fetched value</label>
+          <div className="col-md-8">
+            {formElement}
+          </div>
         </div>
-      </div>
-    );
+      );
+    }
   },
 
   incrementalFetchingWarning() {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -173,19 +173,6 @@ export default React.createClass({
     }
   },
 
-  renderlastFetchedInfo() {
-    if (this.props.query.get('incrementalFetchingColumn')) {
-      let queryState = this.props.query.get('state');
-      if (queryState.has('lastFetchedRow')) {
-        return (
-          <div>
-            Last fetched record had `{this.props.query.get('incrementalFetchingColumn')} = {queryState.get('lastFetchedRow')}`
-          </div>
-        );
-      }
-    }
-  },
-
   tableSelectOptions() {
     return this.props.tables.map(function(table) {
       return table.get('id');
@@ -561,6 +548,19 @@ export default React.createClass({
           </div>
         </div>
       );
+    }
+  },
+
+  renderlastFetchedInfo() {
+    if (this.props.query.get('incrementalFetchingColumn')) {
+      let queryState = this.props.query.get('state');
+      if (queryState.has('lastFetchedRow')) {
+        return (
+          <div>
+            Last fetched record had <strong>{this.props.query.get('incrementalFetchingColumn')}</strong> = {queryState.get('lastFetchedRow')}`
+          </div>
+        );
+      }
     }
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -524,7 +524,7 @@ export default React.createClass({
   },
 
   renderIncrementalFetchingForm() {
-    return (
+    return [
       <div className="form-group">
         <label className="col-md-3 control-label">Column</label>
         <div className="col-md-9">
@@ -564,7 +564,7 @@ export default React.createClass({
           {this.renderlastFetchedInfo()}
         </div>
       </div>
-    );
+    ];
   },
 
   renderIncrementalFetchingSection() {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -138,11 +138,11 @@ export default React.createClass({
     }
     let selectedTable = this.props.query.get('table');
     let candidateTable = this.props.incrementalCandidates.find((candidate) => {
-      return candidate.get('name') === selectedTable.get('tableName')
+      return candidate.get('tableName') === selectedTable.get('tableName')
         && candidate.get('schema') === selectedTable.get('schema');
     });
     if (candidateTable) {
-      return candidateTable.get('columns').map((candidate) => {
+      return candidateTable.get('candidates').map((candidate) => {
         return {
           value: candidate.get('name'),
           label: candidate.get('name')

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -97,6 +97,10 @@ export default React.createClass({
     return this.props.onChange(this.props.query.set('incrementalFetchingColumn', newValue));
   },
 
+  handleIncrementalFetchingLimitChange(newValue) {
+    return this.props.onChange(this.props.query.set('incrementalFethcingLimit', newValue));
+  },
+
   handleStateReset() {
     return this.props.onChange(this.props.query.set('state', Immutable.fromJS({})));
   },

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -596,6 +596,15 @@ export default React.createClass({
         );
       }
     }
+    return (
+      <div className="form-control-static">
+        <div className="row">
+          <div className="col-md-12">
+            No state information available
+          </div>
+        </div>
+      </div>
+    );
   },
 
   incrementalFetchingWarning() {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -643,7 +643,7 @@ export default React.createClass({
   },
 
   incrementalFetchingWarning() {
-    if (this.props.query.get('incrementalFetchingColumn') && this.props.sourceTables.length > 0) {
+    if (this.props.query.get('incrementalFetchingColumn') && this.props.sourceTables.count() > 0) {
       let candidateTable = this.getCandidateTable();
       let candidateColumn = candidateTable.get('candidates').find((column) =>
         column.get('name') === this.props.query.get('incrementalFetchingColumn')

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -142,7 +142,10 @@ export default React.createClass({
   },
 
   getCandidateTable() {
-    let selectedTable = this.props.query.get('table');
+    const selectedTable = this.props.query.get('table');
+    if (!selectedTable) {
+      return null;
+    }
     return this.props.incrementalCandidates.find((candidate) => {
       return candidate.get('tableName') === selectedTable.get('tableName')
         && candidate.get('schema') === selectedTable.get('schema');

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -307,6 +307,7 @@ export default React.createClass({
           />
           {this.renderSimpleTable()}
           {this.renderSimpleColumns()}
+          <h3>General Settings</h3>
           <div className={(this.props.queryNameExists) ? 'form-group has-error' : 'form-group'}>
             <label className="col-md-3 control-label">Name</label>
             <div className="col-md-9">
@@ -337,6 +338,7 @@ export default React.createClass({
             />
           </div>
           {this.renderIncrementalFetching()}
+          <h3>Loading Options</h3>
           <div className="form-group">
             <label className="col-md-3 control-label">Primary Key</label>
             <div className="col-md-9">
@@ -373,6 +375,7 @@ export default React.createClass({
               </div>
             </div>
           </div>
+          <h3>Advanced Mode</h3>
           {this.renderQueryToggle()}
           {this.renderQueryEditor()}
         </div>
@@ -393,11 +396,8 @@ export default React.createClass({
                 checked={!!this.props.query.get('advancedMode')}
                 disabled={this.props.disabled}
                 onChange={this.handleToggleUseQueryEditor}/>
-              Advanced Mode
-            </label>
-            <div className="help-block">
               Create your own query using an SQL editor
-            </div>
+            </label>
           </div>
         </div>
       );
@@ -439,18 +439,21 @@ export default React.createClass({
       );
 
       return (
-        <div className="form-group">
-          <label className="col-md-3 control-label">Source Table</label>
-          <div className="col-md-9">
-            <TableLoader
-              componentId={this.props.componentId}
-              configId={this.props.configId}
-              isLoadingSourceTables={this.props.isLoadingSourceTables}
-              isTestingConnection={this.props.isTestingConnection}
-              validConnection={this.props.validConnection}
-              tableSelectorElement={tableSelector}
-              refreshMethod={this.props.refreshMethod}
-            />
+        <div>
+          <h3>Data Source</h3>
+          <div className="form-group">
+            <label className="col-md-3 control-label">Table</label>
+            <div className="col-md-9">
+              <TableLoader
+                componentId={this.props.componentId}
+                configId={this.props.configId}
+                isLoadingSourceTables={this.props.isLoadingSourceTables}
+                isTestingConnection={this.props.isTestingConnection}
+                validConnection={this.props.validConnection}
+                tableSelectorElement={tableSelector}
+                refreshMethod={this.props.refreshMethod}
+              />
+            </div>
           </div>
         </div>
       );
@@ -523,47 +526,45 @@ export default React.createClass({
   renderIncrementalFetching() {
     if (!this.props.query.get('advancedMode') && this.props.isConfigRow && this.incrementalFetchingOptions().length > 0) {
       return (
-        <div className="form-group">
-          <label className="col-md-3 control-label">Incremental Fetching</label>
-          <div className="col-md-9">
-            <div className="row">
-              <label className="col-md-2 control-label">Column</label>
-              <div className="col-md-10">
-                <Select
-                  name="incrementalFetching"
-                  value={this.props.query.get('incrementalFetchingColumn') || ''}
-                  placeholder="Fetch by column"
-                  onChange={this.handleIncrementalFetchingColumnChange}
-                  options={this.incrementalFetchingOptions()}
-                  disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
-                />
+        <div>
+          <h3>Incremental Fetching</h3>
+          <div className="form-group">
+            <label className="col-md-3 control-label">Column</label>
+            <div className="col-md-9">
+              <Select
+                name="incrementalFetching"
+                value={this.props.query.get('incrementalFetchingColumn') || ''}
+                placeholder="Fetch by column"
+                onChange={this.handleIncrementalFetchingColumnChange}
+                options={this.incrementalFetchingOptions()}
+                disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
+              />
+              <div className="help-block">
+                {this.incrementalFetchingWarning()}
               </div>
             </div>
-            <div className="help-block">
-              {this.incrementalFetchingWarning()}
-            </div>
-            <div className="row">
-              <label className="col-md-2 control-label">Limit</label>
-              <div className="col-md-10">
-                <input
-                  className="form-control"
-                  name="incrementalFetchingLimit"
-                  type="number"
-                  value={this.props.query.get('incrementalFetchingLimit') || 0}
-                  onChange={this.handleIncrementalFetchingLimitChange}
-                  disabled={this.props.disabled}
-                />
+          </div>
+          <div className="form-group">
+            <label className="col-md-3 control-label">Limit</label>
+            <div className="col-md-9">
+              <input
+                className="form-control"
+                name="incrementalFetchingLimit"
+                type="number"
+                value={this.props.query.get('incrementalFetchingLimit') || 0}
+                onChange={this.handleIncrementalFetchingLimitChange}
+                disabled={this.props.disabled}
+              />
+              <div className="help-block">
+                The number of records to fetch from the source per run.
+                Subsequent runs will start from the last record fetched. Note: 0 means unlimited.
               </div>
             </div>
-            <div className="help-block">
-              The number of records to fetch from the source per run.
-              Subsequent runs will start from the last record fetched. Note: 0 means unlimited.
-            </div>
-            <div className="row">
-              <label className="col-md-4 control-label">Last fetched value</label>
-              <div className="col-md-8">
-                {this.renderlastFetchedInfo()}
-              </div>
+          </div>
+          <div className="form-group">
+            <label className="col-md-3 control-label">Last fetched value</label>
+            <div className="col-md-8">
+              {this.renderlastFetchedInfo()}
             </div>
           </div>
         </div>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -153,7 +153,7 @@ export default React.createClass({
   },
 
   incrementalFetchingOptions() {
-    if (!this.props.incrementalCandidates || this.props.query.get('table') === '') {
+    if (!this.props.incrementalCandidates || !this.props.query.get('table')) {
       return [];
     }
     let candidateTable = this.getCandidateTable();
@@ -641,7 +641,11 @@ export default React.createClass({
 
   incrementalFetchingWarning() {
     var infoMessage = 'If enabled, only newly created or updated records since the last run will be fetched.';
-    if (this.props.query.get('incrementalFetchingColumn') && this.props.sourceTables.count() > 0) {
+    if (
+      this.props.query.get('incrementalFetchingColumn')
+      && this.props.sourceTables.count() > 0
+      && !!this.props.query.get('table')
+    ) {
       let candidateTable = this.getCandidateTable();
       if (candidateTable) {
         let candidateColumn = candidateTable.get('candidates').find((column) =>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -617,14 +617,16 @@ export default React.createClass({
             </div>
             <div className="help-block">
               To start from the beginning of the table you can
+              {' '}
               <a onClick={this.handleStateReset}>
                 <Tooltip
                   tooltip={tooltip}
                   placement="top"
                 >
-                  <span> clear the stored value</span>
+                  <span>clear the stored value</span>
                 </Tooltip>
               </a>
+              .
             </div>
           </div>
         );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -307,25 +307,6 @@ export default React.createClass({
           />
           {this.renderSimpleTable()}
           {this.renderSimpleColumns()}
-          <div className="form-group">
-            <label className="col-md-3 control-label">Primary Key</label>
-            <div className="col-md-9">
-              <Select
-                name="primaryKey"
-                value={this.getPkValue()}
-                multi={true}
-                disabled={this.props.disabled || this.isExistingTable()}
-                allowCreate={true}
-                delimiter=","
-                placeholder={this.primaryKeyPlaceholder()}
-                emptyStrings={false}
-                onChange={this.handlePrimaryKeyChange}
-                options={this.primaryKeyOptions()}
-                promptTextCreator={(label) => (label) ? 'Add column "' + label + '" as primary key' : ''}
-              />
-              {this.isExistingTable() && this.primaryKeyHelp()}
-            </div>
-          </div>
           <div className={(this.props.queryNameExists) ? 'form-group has-error' : 'form-group'}>
             <label className="col-md-3 control-label">Name</label>
             <div className="col-md-9">
@@ -356,6 +337,25 @@ export default React.createClass({
             />
           </div>
           {this.renderIncrementalFetching()}
+          <div className="form-group">
+            <label className="col-md-3 control-label">Primary Key</label>
+            <div className="col-md-9">
+              <Select
+                name="primaryKey"
+                value={this.getPkValue()}
+                multi={true}
+                disabled={this.props.disabled || this.isExistingTable()}
+                allowCreate={true}
+                delimiter=","
+                placeholder={this.primaryKeyPlaceholder()}
+                emptyStrings={false}
+                onChange={this.handlePrimaryKeyChange}
+                options={this.primaryKeyOptions()}
+                promptTextCreator={(label) => (label) ? 'Add column "' + label + '" as primary key' : ''}
+              />
+              {this.isExistingTable() && this.primaryKeyHelp()}
+            </div>
+          </div>
           <div className="form-group">
             <div className="col-md-9 col-md-offset-3 checkbox">
               <label>

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -615,9 +615,9 @@ export default React.createClass({
         column.get('name') === this.props.query.get('incrementalFetchingColumn')
       );
       if (candidateColumn.get('autoIncrement')) {
-        return 'Note: Using an autoIncrement ID means that only new records will be fetched, not updates or deletes.';
+        return 'Using an autoIncrement ID means that only new records will be fetched, not updates or deletes.';
       } else {
-        return 'Note: Using an update timestamp column means that only new and updated records will be fetched, not deletes.';
+        return 'Using an update timestamp column means that only new and updated records will be fetched, not deletes.';
       }
     } else {
       return 'If enabled, only newly created or updated records since the last run will be fetched.';

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -550,7 +550,7 @@ export default React.createClass({
             type="number"
             value={this.props.query.get('incrementalFetchingLimit') || 0}
             onChange={this.handleIncrementalFetchingLimitChange}
-            disabled={this.props.disabled}
+            disabled={this.props.disabled || !this.props.query.get('incrementalFetchingColumn')}
           />
           <div className="help-block">
             The number of records to fetch from the source per run.

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -96,6 +96,10 @@ export default React.createClass({
     return this.props.onChange(this.props.query.set('incrementalFetchingColumn', newValue));
   },
 
+  handleLastFetchedValueChange(event) {
+    return this.props.onChange(this.props.query.set('state', Immutable.fromJS({'lastFetchedRow': event.target.value})));
+  },
+
   handleQueryChange(data) {
     return this.props.onChange(this.props.query.set('query', data.value));
   },

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -93,12 +93,12 @@ export default React.createClass({
     return this.props.onChange(this.props.query.set('incremental', event.target.checked));
   },
 
-  handleIncrementalFetchingChange(newValue) {
+  handleIncrementalFetchingColumnChange(newValue) {
     return this.props.onChange(this.props.query.set('incrementalFetchingColumn', newValue));
   },
 
-  handleIncrementalFetchingLimitChange(newValue) {
-    return this.props.onChange(this.props.query.set('incrementalFethcingLimit', newValue));
+  handleIncrementalFetchingLimitChange(event) {
+    return this.props.onChange(this.props.query.set('incrementalFetchingLimit', parseInt(event.target.value, 10)));
   },
 
   handleStateReset() {
@@ -533,7 +533,7 @@ export default React.createClass({
                   name="incrementalFetching"
                   value={this.props.query.get('incrementalFetchingColumn') || ''}
                   placeholder="Fetch by column"
-                  onChange={this.handleIncrementalFetchingChange}
+                  onChange={this.handleIncrementalFetchingColumnChange}
                   options={this.incrementalFetchingOptions()}
                   disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
                 />
@@ -549,7 +549,7 @@ export default React.createClass({
                   className="form-control"
                   name="incrementalFetchingLimit"
                   type="number"
-                  value={this.props.query.get('incrementalFetchingLimit') ? this.props.query.get('incrementalFetchingLimit') : 0}
+                  value={this.props.query.get('incrementalFetchingLimit') || 0}
                   onChange={this.handleIncrementalFetchingLimitChange}
                   disabled={this.props.disabled}
                 />

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -7,12 +7,12 @@ import {Alert} from 'react-bootstrap';
 import {CodeEditor} from '../../../../react/common/common';
 import Select from '../../../../react/common/Select';
 import TableSelectorForm from '../../../../react/common/TableSelectorForm';
+import Tooltip from '../../../../react/common/Tooltip';
 
 import AsynchActionError from './AsynchActionError';
 import TableLoader from './TableLoaderQueryEditor';
 
 import {getQueryEditorPlaceholder, getQueryEditorHelpText} from '../../templates/helpAndHints';
-import ResetStateButton from '../../../configurations/react/components/ResetStateButton';
 
 import editorMode from '../../templates/editorMode';
 
@@ -611,13 +611,14 @@ export default React.createClass({
             </div>
             <div className="help-block">
               To start from the beginning of the table you can
-              <ResetStateButton
-                label="Clear the stored value"
-                onClick={this.handleStateReset}
-                isPending={false}
-                disabled={false}
-                tooltip={tooltip}
-              />
+              <a onClick={this.handleStateReset}>
+                <Tooltip
+                  tooltip={tooltip}
+                  placement="top"
+                >
+                  <span> clear the stored value</span>
+                </Tooltip>
+              </a>
             </div>
           </div>
         );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -576,7 +576,7 @@ export default React.createClass({
           </div>
         </div>
       </div>,
-      this.renderlastFetchedInfo()
+      this.renderLastFetchedInfo()
     ];
   },
 
@@ -603,7 +603,7 @@ export default React.createClass({
     }
   },
 
-  renderlastFetchedInfo() {
+  renderLastFetchedInfo() {
     var formElement;
     const fetchingColumn = this.props.query.get('incrementalFetchingColumn');
     if (fetchingColumn) {

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -594,21 +594,21 @@ export default React.createClass({
     if (fetchingColumn) {
       let lastFetchedRowValue = this.getLastFetchedRowValue();
       if (lastFetchedRowValue) {
+        const tooltip = 'Resetting means that the next run will start from the lowest value of ' + fetchingColumn;
         return (
           <div className="form-control-static">
-            <div className="row">
-              <div className="col-md-6">
-                <strong>{this.getLastFetchedRowValue()}</strong>
-              </div>
-              <div className="col-md-6">
-                <ResetStateButton
-                  onClick={this.handleStateReset}
-                  isPending={false}
-                  disabled={false}
-                >
-                  Resetting means that the next run will start from the lowest value of {fetchingColumn}
-                </ResetStateButton>
-              </div>
+            <div>
+              <strong>{this.getLastFetchedRowValue()}</strong>
+            </div>
+            <div className="help-block">
+              To start from the beginning of the table you can
+              <ResetStateButton
+                label="Clear the stored value"
+                onClick={this.handleStateReset}
+                isPending={false}
+                disabled={false}
+                tooltip={tooltip}
+              />
             </div>
           </div>
         );
@@ -616,10 +616,9 @@ export default React.createClass({
     }
     return (
       <div className="form-control-static">
-        <div className="row">
-          <div className="col-md-12">
-            No state information available
-          </div>
+        There is no value stored.
+        <div className="help-block">
+          Either the component has not yet run, or it has been reset.
         </div>
       </div>
     );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -357,8 +357,7 @@ export default React.createClass({
           </div>
           {this.renderIncrementalFetching()}
           <div className="form-group">
-            <label className="col-md-3 control-label">Incremental Loading</label>
-            <div className="col-md-9">
+            <div className="col-md-9 col-md-offset-3 checkbox">
               <label>
                 <input
                   type="checkbox"
@@ -366,9 +365,10 @@ export default React.createClass({
                   onChange={this.handleIncrementalChange}
                   disabled={this.props.disabled}
                 />
-                If incremental load is turned on, the table will be updated instead of rewritten.
+                Incremental Loading
               </label>
               <div className="help-block">
+                If incremental load is turned on, the table will be updated instead of rewritten.
                 Tables with primary keys will update rows, tables without primary keys will append rows.
               </div>
             </div>
@@ -384,8 +384,7 @@ export default React.createClass({
     if (this.props.showSimple) {
       return (
         <div className="form-group">
-          <label className="col-md-3 control-label">Advanced Mode</label>
-          <div className="col-md-9 checkbox form-control-static">
+          <div className="col-md-9 col-md-offset-3 checkbox">
             <label>
               <input
                 standalone={true}
@@ -394,8 +393,11 @@ export default React.createClass({
                 checked={!!this.props.query.get('advancedMode')}
                 disabled={this.props.disabled}
                 onChange={this.handleToggleUseQueryEditor}/>
-              Create your own query using an SQL editor
+              Advanced Mode
             </label>
+            <div className="help-block">
+              Create your own query using an SQL editor
+            </div>
           </div>
         </div>
       );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -539,7 +539,7 @@ export default React.createClass({
               placeholder="Select the column to be used for incremental fetching"
               onChange={this.handleIncrementalFetchingChange}
               options={this.incrementalFetchingOptions()}
-              disabled={this.props.disabled}
+              disabled={this.props.disabled || this.getLastFetchedRowValue()}
             />
             <div className="help-block">
               <span className="text-warning">{this.incrementalFetchingWarning()}</span>
@@ -553,14 +553,36 @@ export default React.createClass({
 
   renderlastFetchedInfo() {
     if (this.props.query.get('incrementalFetchingColumn')) {
-      let queryState = this.props.query.get('state');
-      if (queryState.has('lastFetchedRow')) {
+      let lastFetchedRowValue = this.getLastFetchedRowValue();
+      if (lastFetchedRowValue) {
         return (
           <div>
-            Last fetched record had <strong>{this.props.query.get('incrementalFetchingColumn')}</strong> = {queryState.get('lastFetchedRow')}`
+            Last fetched record had <strong>{this.props.query.get('incrementalFetchingColumn')}</strong> value
+            {this.renderLastFetchedInput()}
           </div>
         );
       }
+    }
+  },
+
+  renderLastFetchedInput() {
+    return (
+      <input
+        className="form-control"
+        type="text"
+        value={this.getLastFetchedRowValue()}
+        disabled={this.props.disabled}
+        onChange={this.handleLastFetchedValueChange}
+      />
+    );
+  },
+
+  getLastFetchedRowValue() {
+    let queryState = this.props.query.get('state');
+    if (queryState.has('lastFetchedRow')) {
+      return queryState.get('lastFetchedRow');
+    } else {
+      return false;
     }
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -353,7 +353,8 @@ export default React.createClass({
           </div>
           {this.renderIncrementalFetching()}
           <div className="form-group">
-            <div className="col-md-9 col-md-offset-3 checkbox">
+            <label className="col-md-3 control-label">Incremental Loading</label>
+            <div className="col-md-9">
               <label>
                 <input
                   type="checkbox"
@@ -361,10 +362,9 @@ export default React.createClass({
                   onChange={this.handleIncrementalChange}
                   disabled={this.props.disabled}
                 />
-                Incremental Loading
+                If incremental load is turned on, the table will be updated instead of rewritten.
               </label>
               <div className="help-block">
-                If incremental load is turned on, the table will be updated instead of rewritten.
                 Tables with primary keys will update rows, tables without primary keys will append rows.
               </div>
             </div>
@@ -380,7 +380,8 @@ export default React.createClass({
     if (this.props.showSimple) {
       return (
         <div className="form-group">
-          <div className="col-md-9 col-md-offset-3 checkbox">
+          <label className="col-md-3 control-label">Advanced Mode</label>
+          <div className="col-md-9 checkbox form-control-static">
             <label>
               <input
                 standalone={true}
@@ -389,11 +390,8 @@ export default React.createClass({
                 checked={!!this.props.query.get('advancedMode')}
                 disabled={this.props.disabled}
                 onChange={this.handleToggleUseQueryEditor}/>
-              Advanced Mode
-            </label>
-            <div className="help-block">
               Create your own query using an SQL editor
-            </div>
+            </label>
           </div>
         </div>
       );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -523,7 +523,8 @@ export default React.createClass({
           <label className="col-md-3 control-label">Incremental Fetching</label>
           <div className="col-md-9">
             <div className="row">
-              <div className="col-md-6">
+              <label className="col-md-2 control-label">Column</label>
+              <div className="col-md-10">
                 <Select
                   name="incrementalFetching"
                   value={this.props.query.get('incrementalFetchingColumn') || ''}
@@ -533,21 +534,32 @@ export default React.createClass({
                   disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
                 />
               </div>
-              <label className="col-md-1 control-label">Limit</label>
-              <div className="col-md-5">
+            </div>
+            <div className="help-block">
+              {this.incrementalFetchingWarning()}
+            </div>
+            <div className="row">
+              <label className="col-md-2 control-label">Limit</label>
+              <div className="col-md-10">
                 <input
                   className="form-control"
                   name="incrementalFetchingLimit"
                   type="number"
-                  placeholder="# of records to fetch."
+                  default="0"
                   onChange={this.handleIncrementalFetchingLimitChange}
                   disabled={this.props.disabled}
                 />
               </div>
             </div>
             <div className="help-block">
-              <span className="text-warning">{this.incrementalFetchingWarning()}</span>
-              {this.renderlastFetchedInfo()}
+              The number of records to fetch from the source per run.
+              Subsequent runs will start from the last record fetched. Note: 0 means unlimited.
+            </div>
+            <div className="row">
+              <label className="col-md-4 control-label">Last fetched value</label>
+              <div className="col-md-8">
+                {this.renderlastFetchedInfo()}
+              </div>
             </div>
           </div>
         </div>
@@ -561,17 +573,22 @@ export default React.createClass({
       let lastFetchedRowValue = this.getLastFetchedRowValue();
       if (lastFetchedRowValue) {
         return (
-          <div>
-            Last fetched record had <strong>{fetchingColumn}</strong>
-            value <strong>{this.getLastFetchedRowValue()}</strong>
-            <ResetStateButton
-              onClick={this.handleStateReset}
-              isPending={false}
-              disabled={false}
-            >
-              Delete the current stored state.
-              Resetting means that the next run will start from the lowest value of {fetchingColumn}
-            </ResetStateButton>
+          <div className="form-control-static">
+            <div className="row">
+              <div className="col-md-6">
+                <strong>{this.getLastFetchedRowValue()}</strong>
+              </div>
+              <div className="col-md-6">
+                <ResetStateButton
+                  onClick={this.handleStateReset}
+                  isPending={false}
+                  disabled={false}
+                >
+                  Delete the current stored state.
+                  Resetting means that the next run will start from the lowest value of {fetchingColumn}
+                </ResetStateButton>
+              </div>
+            </div>
           </div>
         );
       }

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -337,7 +337,7 @@ export default React.createClass({
               editing={this.props.destinationEditing}
             />
           </div>
-          {this.renderIncrementalFetching()}
+          {this.renderIncrementalFetchingSection()}
           <h3>Loading Options</h3>
           <div className="form-group">
             <label className="col-md-3 control-label">Primary Key</label>
@@ -523,50 +523,67 @@ export default React.createClass({
     return option.render;
   },
 
-  renderIncrementalFetching() {
-    if (!this.props.query.get('advancedMode') && this.props.isConfigRow && this.incrementalFetchingOptions().length > 0) {
+  renderIncrementalFetchingForm() {
+    return (
+      <div className="form-group">
+        <label className="col-md-3 control-label">Column</label>
+        <div className="col-md-9">
+          <Select
+            name="incrementalFetching"
+            value={this.props.query.get('incrementalFetchingColumn') || ''}
+            placeholder="Fetch by column"
+            onChange={this.handleIncrementalFetchingColumnChange}
+            options={this.incrementalFetchingOptions()}
+            disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
+          />
+          <div className="help-block">
+            {this.incrementalFetchingWarning()}
+          </div>
+        </div>
+      </div>,
+      <div className="form-group">
+        <label className="col-md-3 control-label">Limit</label>
+        <div className="col-md-9">
+          <input
+            className="form-control"
+            name="incrementalFetchingLimit"
+            type="number"
+            value={this.props.query.get('incrementalFetchingLimit') || 0}
+            onChange={this.handleIncrementalFetchingLimitChange}
+            disabled={this.props.disabled}
+          />
+          <div className="help-block">
+            The number of records to fetch from the source per run.
+            Subsequent runs will start from the last record fetched. Note: 0 means unlimited.
+          </div>
+        </div>
+      </div>,
+      <div className="form-group">
+        <label className="col-md-3 control-label">Last fetched value</label>
+        <div className="col-md-8">
+          {this.renderlastFetchedInfo()}
+        </div>
+      </div>
+    );
+  },
+
+  renderIncrementalFetchingSection() {
+    if (!this.props.query.get('advancedMode') && this.props.isConfigRow) {
+      const fetchingHelpText = (
+        <div className="form-group">
+          <div className="col-md-8 col-md-offset-3 help-block">
+            Incremental fetching is available for this extractor but only for tables containing an auto incrementing primary key or a timestamp column.
+          </div>
+        </div>
+      );
       return (
         <div>
           <h3>Incremental Fetching</h3>
-          <div className="form-group">
-            <label className="col-md-3 control-label">Column</label>
-            <div className="col-md-9">
-              <Select
-                name="incrementalFetching"
-                value={this.props.query.get('incrementalFetchingColumn') || ''}
-                placeholder="Fetch by column"
-                onChange={this.handleIncrementalFetchingColumnChange}
-                options={this.incrementalFetchingOptions()}
-                disabled={this.props.disabled || !!this.getLastFetchedRowValue()}
-              />
-              <div className="help-block">
-                {this.incrementalFetchingWarning()}
-              </div>
-            </div>
-          </div>
-          <div className="form-group">
-            <label className="col-md-3 control-label">Limit</label>
-            <div className="col-md-9">
-              <input
-                className="form-control"
-                name="incrementalFetchingLimit"
-                type="number"
-                value={this.props.query.get('incrementalFetchingLimit') || 0}
-                onChange={this.handleIncrementalFetchingLimitChange}
-                disabled={this.props.disabled}
-              />
-              <div className="help-block">
-                The number of records to fetch from the source per run.
-                Subsequent runs will start from the last record fetched. Note: 0 means unlimited.
-              </div>
-            </div>
-          </div>
-          <div className="form-group">
-            <label className="col-md-3 control-label">Last fetched value</label>
-            <div className="col-md-8">
-              {this.renderlastFetchedInfo()}
-            </div>
-          </div>
+          {
+            (this.incrementalFetchingOptions().length > 0)
+              ? this.renderIncrementalFetchingForm()
+              : fetchingHelpText
+          }
         </div>
       );
     }

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -371,7 +371,13 @@ export default React.createClass({
   renderIncrementalLoadOption() {
     let helpAlert = null;
     if (this.props.query.get('incrementalFetchingColumn') && !this.props.query.get('incremental')) {
-      helpAlert = <Alert bsStyle="warning"><strong>Caution</strong>: Incremental Fetching is enabled.  Please be aware that each run will completely replace the destination table when incremental loading is disabled.</Alert>;
+      helpAlert = (
+        <Alert bsStyle="warning">
+          It is recommended to enable incremental loading if using incremental fetching.
+          If incremental loading is <strong>not</strong> enabled,
+          the storage table will only ever contain the most recently fetched results.
+        </Alert>
+      );
     }
     return (
       <div className="form-group">

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -640,7 +640,7 @@ export default React.createClass({
       }
       return (
         <div className="form-group">
-          <label className="col-md-3 control-label">Last fetched value</label>
+          <label className="col-md-3 control-label">Last Fetched Value</label>
           <div className="col-md-8">
             {formElement}
           </div>

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -146,7 +146,7 @@ export default function(componentId) {
       } else if (
         actionsProvisioning.componentSupportsSimpleSetup(componentId)
         && this.state.hasCredentials
-        && !this.state.localState.getIn(storeProvisioning.sourceTablesErrorPath)
+        && !this.state.localState.getIn(storeProvisioning.SOURCE_TABLES_ERROR_PATH)
       ) {
         return (
           <div className="row component-empty-state text-center">
@@ -154,11 +154,11 @@ export default function(componentId) {
               <Quickstart
                 componentId={componentId}
                 configId={this.state.configId}
-                isLoadingSourceTables={this.state.localState.getIn(storeProvisioning.loadingSourceTablesPath) || false}
-                isTestingConnection={this.state.localState.getIn(storeProvisioning.testingConnectionPath) || false}
-                validConnection={this.state.localState.getIn(storeProvisioning.connectionValidPath) || false}
-                sourceTables={this.state.localState.getIn(storeProvisioning.sourceTablesPath)}
-                sourceTablesError={this.state.localState.getIn(storeProvisioning.sourceTablesErrorPath)}
+                isLoadingSourceTables={this.state.localState.getIn(storeProvisioning.LOADING_SOURCE_TABLES_PATH) || false}
+                isTestingConnection={this.state.localState.getIn(storeProvisioning.TESTING_CONNECTION_PATH) || false}
+                validConnection={this.state.localState.getIn(storeProvisioning.CONNECTION_VALID_PATH) || false}
+                sourceTables={this.state.localState.getIn(storeProvisioning.SOURCE_TABLES_PATH)}
+                sourceTablesError={this.state.localState.getIn(storeProvisioning.SOURCE_TABLES_ERROR_PATH)}
                 quickstart={this.state.localState.get('quickstart') || Map()}
                 onChange={actionsCreators.quickstartSelected}
                 onSubmit={actionsCreators.quickstart}
@@ -201,17 +201,17 @@ export default function(componentId) {
     },
 
     renderAsynchError() {
-      if (this.state.localState.getIn(storeProvisioning.connectionErrorPath) ||
-        this.state.localState.getIn(storeProvisioning.sourceTablesErrorPath)) {
+      if (this.state.localState.getIn(storeProvisioning.CONNECTION_ERROR_PATH) ||
+        this.state.localState.getIn(storeProvisioning.SOURCE_TABLES_ERROR_PATH)) {
         return (
           <div className="kbc-inner-padding">
             <AsynchActionError
               componentId={componentId}
               configId={this.state.configId}
-              connectionTesting={this.state.localState.getIn(storeProvisioning.testingConnectionPath, false)}
-              connectionError={this.state.localState.getIn(storeProvisioning.connectionErrorPath)}
-              sourceTablesLoading={this.state.localState.getIn(storeProvisioning.loadingSourceTablesPath, false)}
-              sourceTablesError={this.state.localState.getIn(storeProvisioning.sourceTablesErrorPath)}
+              connectionTesting={this.state.localState.getIn(storeProvisioning.TESTING_CONNECTION_PATH, false)}
+              connectionError={this.state.localState.getIn(storeProvisioning.CONNECTION_ERROR_PATH)}
+              sourceTablesLoading={this.state.localState.getIn(storeProvisioning.LOADING_SOURCE_TABLES_PATH, false)}
+              sourceTablesError={this.state.localState.getIn(storeProvisioning.SOURCE_TABLES_ERROR_PATH)}
             />
           </div>
         );

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -231,6 +231,7 @@ export default function(componentId) {
             <MigrateToRowsButton
               componentId={componentId}
               configId={this.state.configId}
+              pending={!!this.state.localState.getIn(['migration', 'pending'])}
               completed={!!this.state.localState.getIn(['migration', 'completed'])}
               actionsProvisioning={actionsProvisioning}
             />

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -154,9 +154,9 @@ export default function(componentId) {
               <Quickstart
                 componentId={componentId}
                 configId={this.state.configId}
-                isLoadingSourceTables={this.state.localState.getIn(storeProvisioning.loadingSourceTablesPath)}
-                isTestingConnection={this.state.localState.getIn(storeProvisioning.testingConnectionPath)}
-                validConnection={this.state.localState.getIn(storeProvisioning.connectionValidPath)}
+                isLoadingSourceTables={this.state.localState.getIn(storeProvisioning.loadingSourceTablesPath) || false}
+                isTestingConnection={this.state.localState.getIn(storeProvisioning.testingConnectionPath) || false}
+                validConnection={this.state.localState.getIn(storeProvisioning.connectionValidPath) || false}
                 sourceTables={this.state.localState.getIn(storeProvisioning.sourceTablesPath)}
                 sourceTablesError={this.state.localState.getIn(storeProvisioning.sourceTablesErrorPath)}
                 quickstart={this.state.localState.get('quickstart') || Map()}

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Map} from 'immutable';
 import classnames from 'classnames';
+import {Alert} from 'react-bootstrap';
 
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 
@@ -91,6 +92,10 @@ export default function(componentId) {
 
     handleRefreshSourceTables() {
       return actionsProvisioning.reloadSourceTables(componentId, this.state.configId);
+    },
+
+    handleDismissMigrationAlert() {
+      return actionsCreators.dismissMigrationAlert(this.state.configId);
     },
 
     renderNewQueryLink() {
@@ -222,12 +227,23 @@ export default function(componentId) {
       if (actionsProvisioning.componentSupportsConfigRows(componentId) && !this.state.isRowConfiguration) {
         return (
           <div className="row component-empty-state text-center">
-            <p>Please migrate the configuration to the newest version</p>
+            <p>Please migrate the configuration to the newest format to unlock the latest features.</p>
             <MigrateToRowsButton
               componentId={componentId}
               configId={this.state.configId}
+              pending={!!this.state.localState.getIn(['migration', 'pending'])}
+              completed={!!this.state.localState.getIn(['migration', 'completed'])}
               actionsProvisioning={actionsProvisioning}
             />
+          </div>
+        );
+      } else if (actionsProvisioning.componentSupportsConfigRows(componentId) &&
+        !!this.state.localState.getIn(['migration', 'completed'])) {
+        return (
+          <div className="row component-empty-state text-center">
+            <Alert bsStyle="success" closeLabel="X" onDismiss={this.handleDismissMigrationAlert}>
+              The configuration has been successfully migrated.
+            </Alert>
           </div>
         );
       }

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -11,6 +11,7 @@ import VersionsStore from '../../../../components/stores/VersionsStore';
 
 import QueryTable from './QueryTable';
 import CreateQueryElement from '../../components/CreateQueryElement';
+import MigrateToRowsButton from '../../components/MigrateToRowsButton';
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import SidebarVersions from '../../../../components/react/components/SidebarVersionsWrapper';
@@ -71,7 +72,8 @@ export default function(componentId) {
         validConnection: ExDbStore.isConnectionValid(),
         isTestingConnection: ExDbStore.isTestingConnection(),
         hasConnectionBeenTested: ExDbStore.hasConnectionBeenTested(),
-        localState: ExDbStore.getLocalState()
+        localState: ExDbStore.getLocalState(),
+        isRowConfiguration: ExDbStore.isRowConfiguration()
       };
     },
 
@@ -124,7 +126,9 @@ export default function(componentId) {
               queries={this.state.queriesFiltered}
               configurationId={this.state.configId}
               componentId={componentId}
-              pendingActions={this.state.pendingActions}/>
+              pendingActions={this.state.pendingActions}
+              isRowConfiguration={this.state.isRowConfiguration}
+            />
           );
         } else {
           return (
@@ -214,6 +218,21 @@ export default function(componentId) {
       }
     },
 
+    renderMigrationToRowsButton() {
+      if (actionsProvisioning.componentSupportsConfigRows(componentId) && !this.state.isRowConfiguration) {
+        return (
+          <div className="row component-empty-state text-center">
+            <p>Please migrate the configuration to the newest version</p>
+            <MigrateToRowsButton
+              componentId={componentId}
+              configId={this.state.configId}
+              actionsProvisioning={actionsProvisioning}
+            />
+          </div>
+        );
+      }
+    },
+
     render() {
       const configurationId = this.state.configId;
       return (
@@ -258,6 +277,7 @@ export default function(componentId) {
             </div>
             <ul className="nav nav-stacked">
               {this.renderCredentialsLink()}
+              {this.renderMigrationToRowsButton()}
               <li className={classnames({ disabled: !this.state.hasEnabledQueries })}>
                 <RunComponentButton
                   title="Run Extraction"

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -247,6 +247,7 @@ export default function(componentId) {
               </div>
             </div>
             {this.renderCredentialsSetup()}
+            {this.renderMigrationToRowsButton()}
             {this.renderAsynchError()}
             {
               this.state.queries.count() > 0 ? (
@@ -277,7 +278,6 @@ export default function(componentId) {
             </div>
             <ul className="nav nav-stacked">
               {this.renderCredentialsLink()}
-              {this.renderMigrationToRowsButton()}
               <li className={classnames({ disabled: !this.state.hasEnabledQueries })}>
                 <RunComponentButton
                   title="Run Extraction"

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -231,7 +231,6 @@ export default function(componentId) {
             <MigrateToRowsButton
               componentId={componentId}
               configId={this.state.configId}
-              pending={!!this.state.localState.getIn(['migration', 'pending'])}
               completed={!!this.state.localState.getIn(['migration', 'completed'])}
               actionsProvisioning={actionsProvisioning}
             />

--- a/src/scripts/modules/ex-db-generic/react/pages/index/QueryRow.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/QueryRow.jsx
@@ -17,7 +17,8 @@ export default React.createClass({
     query: React.PropTypes.object.isRequired,
     pendingActions: React.PropTypes.object.isRequired,
     configurationId: React.PropTypes.string.isRequired,
-    componentId: React.PropTypes.string.isRequired
+    componentId: React.PropTypes.string.isRequired,
+    isRowConfiguration: React.PropTypes.bool.isRequired
   },
 
   handleActiveChange(newValue) {
@@ -38,6 +39,7 @@ export default React.createClass({
   render() {
     const actionCreators = actionsProvisioning.createActions(this.props.componentId);
     const link = 'ex-db-generic-' + this.props.componentId + '-query';
+    const runParams = actionCreators.prepareSingleQueryRunData(this.props.configurationId, this.props.query, 'index');
     return (
       <Link
         className="tr"
@@ -71,10 +73,7 @@ export default React.createClass({
             title="Run Extraction"
             component={this.props.componentId}
             runParams={() => {
-              return {
-                config: this.props.configurationId,
-                configData: actionCreators.prepareSingleQueryRunData(this.props.configurationId, this.props.query, 'index')
-              };
+              return runParams;
             }}
           >You are about to run extraction</RunExtractionButton>
         </span>

--- a/src/scripts/modules/ex-db-generic/react/pages/index/QueryTable.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/QueryTable.jsx
@@ -12,7 +12,8 @@ export default React.createClass({
     queries: React.PropTypes.object,
     configurationId: React.PropTypes.string,
     componentId: React.PropTypes.string,
-    pendingActions: React.PropTypes.object
+    pendingActions: React.PropTypes.object,
+    isRowConfiguration: React.PropTypes.bool
   },
 
   render() {
@@ -24,6 +25,7 @@ export default React.createClass({
           pendingActions={this.props.pendingActions.get(query.get('id'), Map())}
           configurationId={this.props.configurationId}
           key={query.get('id')}
+          isRowConfiguration={this.props.isRowConfiguration}
         />
       );
     }, this).toArray();

--- a/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
@@ -7,9 +7,9 @@ import StorageTablesStore from '../../../../components/stores/StorageTablesStore
 import RoutesStore from '../../../../../stores/RoutesStore';
 
 import QueryEditor from '../../components/QueryEditor';
-import {connectionErrorPath, incrementalCandidatesPath, loadingSourceTablesPath} from '../../../storeProvisioning';
-import {sourceTablesPath} from '../../../storeProvisioning';
-import {sourceTablesErrorPath} from '../../../storeProvisioning';
+import {CONNECTION_ERROR_PATH, INCREMENTAL_CANDIDATES_PATH, LOADING_SOURCE_TABLES_PATH} from '../../../storeProvisioning';
+import {SOURCE_TABLES_PATH} from '../../../storeProvisioning';
+import {SOURCE_TABLES_ERROR_PATH} from '../../../storeProvisioning';
 
 import QueryNav from './QueryNav';
 import SaveButtons from '../../../../../react/common/SaveButtons';
@@ -95,12 +95,12 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
           configId={this.state.configId}
           componentId={componentId}
           getDefaultOutputTable={this.getDefaultOutputTableId}
-          isLoadingSourceTables={this.state.localState.getIn(loadingSourceTablesPath, false)}
+          isLoadingSourceTables={this.state.localState.getIn(LOADING_SOURCE_TABLES_PATH, false)}
           isTestingConnection={this.state.isTestingConnection}
           validConnection={this.state.validConnection}
-          connectionError={this.state.localState.getIn(connectionErrorPath)}
-          sourceTables={this.state.localState.getIn(sourceTablesPath) || List()}
-          sourceTablesError={this.state.localState.getIn(sourceTablesErrorPath)}
+          connectionError={this.state.localState.getIn(CONNECTION_ERROR_PATH)}
+          sourceTables={this.state.localState.getIn(SOURCE_TABLES_PATH) || List()}
+          sourceTablesError={this.state.localState.getIn(SOURCE_TABLES_ERROR_PATH)}
           destinationEditing={this.state.localState.getIn(['isDestinationEditing', this.state.queryId], false)}
           onDestinationEdit={ExDbActionCreators.destinationEdit}
           getPKColumns={ExDbActionCreators.getPKColumnsFromSourceTable}
@@ -109,7 +109,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
           credentialsHasSchema={this.state.credentialsHasSchema}
           refreshMethod={this.handleRefreshSourceTables}
           isConfigRow={this.state.isConfigRow}
-          incrementalCandidates={this.state.localState.getIn(incrementalCandidatesPath) || List()}
+          incrementalCandidates={this.state.localState.getIn(INCREMENTAL_CANDIDATES_PATH) || List()}
         />
       );
     },

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -48,6 +48,7 @@ export function queryFromRow(row) {
     primaryKey: rowConfig.get('primaryKey'),
     incremental: rowConfig.get('incremental'),
     incrementalFetchingColumn: rowConfig.get('incrementalFetchingColumn'),
+    incrementalFetchingLimit: rowConfig.get('incrementalFetchingLimit'),
     state: row.get('state')
   });
   if (rowConfig.get('query')) {

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -23,14 +23,16 @@ export const connectionValidPath = ['connection', 'valid'];
 export const connectionTestedPath = ['connection', 'tested'];
 
 export function rowDataFromQuery(query) {
+  let queryState = JSON.stringify(query.get('state').toJS());
+  let paramsQuery = query.delete('state');
   return {
     'rowId': query.get('id'),
     'name': query.get('name'),
     'isDisabled': !query.get('enabled'),
     'configuration': JSON.stringify({
-      'parameters': query.toJS()
+      'parameters': paramsQuery.toJS()
     }),
-    'state': JSON.stringify(query.get('state').toJS())
+    'state': queryState
   };
 }
 
@@ -296,6 +298,10 @@ export function createStore(componentId, configId) {
         }
         return q.set('primaryKey', pk);
       });
+    },
+
+    setQueries(queries) {
+      return data.parameters.setIn('tables', queries);
     },
 
     getQueriesFiltered() {

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -10,17 +10,17 @@ import {componentSupportsConfigRows} from './actionsProvisioning';
 
 const defaultSshPort = 22;
 
-export const rowConfigurationType = 'row';
-export const standardConfigurationType = 'standard';
+export const ROW_CONFIGURATION_TYPE = 'row';
+export const STANDARD_CONFIGURATION_TYPE = 'standard';
 
-export const sourceTablesPath = ['sourceTables', 'data'];
-export const incrementalCandidatesPath = ['sourceTables', 'incrementalCandidates'];
-export const sourceTablesErrorPath = ['sourceTables', 'error'];
-export const loadingSourceTablesPath = ['sourceTables', 'loading'];
-export const testingConnectionPath = ['connection', 'testing'];
-export const connectionErrorPath = ['connection', 'error'];
-export const connectionValidPath = ['connection', 'valid'];
-export const connectionTestedPath = ['connection', 'tested'];
+export const SOURCE_TABLES_PATH = ['sourceTables', 'data'];
+export const INCREMENTAL_CANDIDATES_PATH = ['sourceTables', 'incrementalCandidates'];
+export const SOURCE_TABLES_ERROR_PATH = ['sourceTables', 'error'];
+export const LOADING_SOURCE_TABLES_PATH = ['sourceTables', 'loading'];
+export const TESTING_CONNECTION_PATH = ['connection', 'testing'];
+export const CONNECTION_ERROR_PATH = ['connection', 'error'];
+export const CONNECTION_VALID_PATH = ['connection', 'valid'];
+export const CONNECTION_TESTED_PATH = ['connection', 'tested'];
 
 export function rowDataFromQuery(query) {
   let queryState = query.has('state') ? query.get('state').toJS() : {};
@@ -69,14 +69,14 @@ function fetch(componentId, configId) {
       parameters: config.get('parameters', Map()),
       queries: queries || List(),
       localState: store.getLocalState(componentId, configId) || Map(),
-      configurationType: rowConfigurationType
+      configurationType: ROW_CONFIGURATION_TYPE
     };
   }
   return {
     config: config || Map(),
     parameters: config.get('parameters', Map()),
     localState: store.getLocalState(componentId, configId) || Map(),
-    configurationType: standardConfigurationType
+    configurationType: STANDARD_CONFIGURATION_TYPE
   };
 }
 
@@ -176,19 +176,19 @@ export function createStore(componentId, configId) {
     },
 
     isTestingConnection() {
-      return data.localState.getIn(testingConnectionPath, false);
+      return data.localState.getIn(TESTING_CONNECTION_PATH, false);
     },
 
     isConnectionValid() {
-      return data.localState.getIn(connectionValidPath, false);
+      return data.localState.getIn(CONNECTION_VALID_PATH, false);
     },
 
     getConnectionError() {
-      return data.localState.getIn(connectionErrorPath, null);
+      return data.localState.getIn(CONNECTION_ERROR_PATH, null);
     },
 
     hasConnectionBeenTested() {
-      return data.localState.getIn(connectionTestedPath, false);
+      return data.localState.getIn(CONNECTION_TESTED_PATH, false);
     },
     // Credentials -- end --
 
@@ -339,15 +339,15 @@ export function createStore(componentId, configId) {
     },
 
     getSourceTables() {
-      return data.localState.getIn(sourceTablesPath);
+      return data.localState.getIn(SOURCE_TABLES_PATH);
     },
 
     getIncrementalCandidates() {
-      return data.localState.getIn(incrementalCandidatesPath);
+      return data.localState.getIn(INCREMENTAL_CANDIDATES_PATH);
     },
 
     getSourceTablesLoading() {
-      return !!data.localState.getIn(loadingSourceTablesPath);
+      return !!data.localState.getIn(LOADING_SOURCE_TABLES_PATH);
     },
 
     getQuickstartTables() {
@@ -359,7 +359,7 @@ export function createStore(componentId, configId) {
     },
 
     isRowConfiguration() {
-      return data.configurationType === rowConfigurationType;
+      return data.configurationType === ROW_CONFIGURATION_TYPE;
     }
   };
 }

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -43,7 +43,8 @@ export function queryFromRow(row) {
     table: rowConfig.get('table'),
     columns: rowConfig.get('columns'),
     primaryKey: rowConfig.get('primaryKey'),
-    incremental: rowConfig.get('incremental')
+    incremental: rowConfig.get('incremental'),
+    incrementalFetching: rowConfig.get('incrementalFetching')
   });
   if (rowConfig.get('query')) {
     query = query.set('query', rowConfig.get('query')).set('advancedMode', true);

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -64,10 +64,10 @@ function fetch(componentId, configId) {
     const queries = rows.map((row) => {
       return queryFromRow(row);
     }).toList();
-    const setConfig = config.setIn(['parameters', 'tables'], queries);
     return {
       config: config || Map(),
-      parameters: setConfig.get('parameters', Map()),
+      parameters: config.get('parameters', Map()),
+      queries: queries || List(),
       localState: store.getLocalState(componentId, configId) || Map(),
       configurationType: rowConfigurationType
     };
@@ -292,17 +292,23 @@ export function createStore(componentId, configId) {
     configData: data.config,
 
     getQueries() {
-      return data.parameters.get('tables', List()).map((q) => {
-        let pk = q.get('primaryKey', null);
-        if (_.isEmpty(pk) || _.isString(pk)) {
-          pk = List();
-        }
-        return q.set('primaryKey', pk);
-      });
-    },
-
-    setQueries(queries) {
-      return data.parameters.setIn('tables', queries);
+      if (data.parameters.has('tables')) {
+        return data.parameters.get('tables', List()).map((q) => {
+          let pk = q.get('primaryKey', null);
+          if (_.isEmpty(pk) || _.isString(pk)) {
+            pk = List();
+          }
+          return q.set('primaryKey', pk);
+        });
+      } else {
+        return data.queries.map((q) => {
+          let pk = q.get('primaryKey', null);
+          if (_.isEmpty(pk) || _.isString(pk)) {
+            pk = List();
+          }
+          return q.set('primaryKey', pk);
+        });
+      }
     },
 
     getQueriesFiltered() {

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -22,20 +22,6 @@ export const CONNECTION_ERROR_PATH = ['connection', 'error'];
 export const CONNECTION_VALID_PATH = ['connection', 'valid'];
 export const CONNECTION_TESTED_PATH = ['connection', 'tested'];
 
-export function rowDataFromQuery(query) {
-  const queryState = query.has('state') ? query.get('state').toJS() : {};
-  const paramsQuery = query.delete('state');
-  return {
-    'rowId': query.get('id'),
-    'name': query.get('name'),
-    'isDisabled': !query.get('enabled'),
-    'configuration': JSON.stringify({
-      'parameters': paramsQuery.toJS()
-    }),
-    'state': JSON.stringify(queryState)
-  };
-}
-
 export function queryFromRow(row) {
   const rowConfig = row.getIn(['configuration', 'parameters']);
   let query = Map({

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -23,7 +23,7 @@ export const connectionValidPath = ['connection', 'valid'];
 export const connectionTestedPath = ['connection', 'tested'];
 
 export function rowDataFromQuery(query) {
-  let queryState = JSON.stringify(query.get('state').toJS());
+  let queryState = query.has('state') ? query.get('state').toJS() : {};
   let paramsQuery = query.delete('state');
   return {
     'rowId': query.get('id'),
@@ -32,7 +32,7 @@ export function rowDataFromQuery(query) {
     'configuration': JSON.stringify({
       'parameters': paramsQuery.toJS()
     }),
-    'state': queryState
+    'state': JSON.stringify(queryState)
   };
 }
 

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -78,8 +78,11 @@ function generateId(existingIds) {
 function isValidQuery(query) {
   const nameValid = query.get('name', '').trim().length > 0;
   const queryValid = query.get('query', '').trim().length > 0;
-  const tableValid = (query.get('table')) ? query.get('table').get('tableName', '').trim().length > 0 : false;
-  return nameValid && (queryValid || tableValid);
+  const advancedMode = query.get('advancedMode', false);
+  const tableValid = (query.get('table'))
+    ? query.get('table').get('tableName', '').trim().length > 0
+    : false;
+  return nameValid && ((advancedMode && queryValid) || (!advancedMode && tableValid));
 }
 
 export const componentsStore = store;

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -62,7 +62,7 @@ function fetch(componentId, configId) {
     }).toList();
     const setConfig = config.setIn(['parameters', 'tables'], queries);
     return {
-      config: setConfig || Map(),
+      config: config || Map(),
       parameters: setConfig.get('parameters', Map()),
       localState: store.getLocalState(componentId, configId) || Map(),
       configurationType: rowConfigurationType

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -40,11 +40,12 @@ export function queryFromRow(row) {
     name: row.get('name'),
     enabled: !row.get('isDisabled'),
     outputTable: rowConfig.get('outputTable'),
-    table: rowConfig.get('table'),
+    table: rowConfig.get('table') || null,
     columns: rowConfig.get('columns'),
     primaryKey: rowConfig.get('primaryKey'),
     incremental: rowConfig.get('incremental'),
-    incrementalFetching: rowConfig.get('incrementalFetching')
+    incrementalFetchingColumn: rowConfig.get('incrementalFetchingColumn'),
+    state: rowConfig.get('state')
   });
   if (rowConfig.get('query')) {
     query = query.set('query', rowConfig.get('query')).set('advancedMode', true);
@@ -54,7 +55,7 @@ export function queryFromRow(row) {
 
 function fetch(componentId, configId) {
   const config = store.getConfigData(componentId, configId) || Map();
-  if (componentSupportsConfigRows(componentId) && (!config.hasIn(['parameters', 'tables']) || config.getIn(['parameters', 'tables']).count() === 0)) {
+  if (componentSupportsConfigRows(componentId) && !config.hasIn(['parameters', 'tables'])) {
     const rows = store.getConfigRows(componentId, configId);
     const queries = rows.map((row) => {
       return queryFromRow(row);

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -23,8 +23,8 @@ export const CONNECTION_VALID_PATH = ['connection', 'valid'];
 export const CONNECTION_TESTED_PATH = ['connection', 'tested'];
 
 export function rowDataFromQuery(query) {
-  let queryState = query.has('state') ? query.get('state').toJS() : {};
-  let paramsQuery = query.delete('state');
+  const queryState = query.has('state') ? query.get('state').toJS() : {};
+  const paramsQuery = query.delete('state');
   return {
     'rowId': query.get('id'),
     'name': query.get('name'),
@@ -159,7 +159,7 @@ export function createStore(componentId, configId) {
     },
 
     getNewCredentials() {
-      var defaultNewCredentials = data.parameters.get('db', Map());
+      let defaultNewCredentials = data.parameters.get('db', Map());
       if (!defaultNewCredentials.get('port')) {
         defaultNewCredentials = defaultNewCredentials.set('port', getDefaultPort(componentId));
       }

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -45,7 +45,7 @@ export function queryFromRow(row) {
     primaryKey: rowConfig.get('primaryKey'),
     incremental: rowConfig.get('incremental'),
     incrementalFetchingColumn: rowConfig.get('incrementalFetchingColumn'),
-    state: rowConfig.get('state')
+    state: row.get('state')
   });
   if (rowConfig.get('query')) {
     query = query.set('query', rowConfig.get('query')).set('advancedMode', true);

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -29,7 +29,8 @@ export function rowDataFromQuery(query) {
     'isDisabled': !query.get('enabled'),
     'configuration': JSON.stringify({
       'parameters': query.toJS()
-    })
+    }),
+    'state': JSON.stringify(query.get('state').toJS())
   };
 }
 

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
@@ -13,6 +13,9 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
     },
     getLocalState: () => {
       return data;
+    },
+    getConfigRows: () => {
+      return Immutable.List();
     }
   };
 });

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
@@ -20,6 +20,16 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
     },
     getLocalState: () => {
       return data;
+    },
+    getConfigRows: () => {
+      return Immutable.fromJS([
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql.test1'
+        },
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql.test2'
+        }
+      ]);
     }
   };
 });

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
@@ -17,6 +17,13 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
     },
     getLocalState: () => {
       return data;
+    },
+    getConfigRows: () => {
+      return Immutable.fromJS([
+        {
+          outputTable: 'in.c-keboola-ex-db-mysql.test1'
+        }
+      ]);
     }
   };
 });


### PR DESCRIPTION
Fixes #1533 

Proposed changes:

- use configuration rows for supported components
  - add create/update/delete configuration rows to the installedComponentStore
- allow selecting of `incrementalFetching` parameter for tables that qualify (qualifying tables are those with auto-increment id or timestamp columns)
- show last row fetched status for config rows that have incremental fetching
- have button available to migrate supported component configurations to config rows
