### PR TITLE
tokens update

### DIFF
--- a/src/scripts/modules/tokens/StorageTokensStore.js
+++ b/src/scripts/modules/tokens/StorageTokensStore.js
@@ -82,7 +82,7 @@ Dispatcher.register( (payload) => {
       break;
     case ActionTypes.STORAGE_TOKEN_REFRESH_SUCCESS:
       _store = _store.setIn(['refreshingTokens', action.tokenId], false);
-      newTokens = _store.get('tokens').filter(function(t) {
+      newTokens = _store.get('tokens').map(function(t) {
         return t.get('id') === action.tokenId ? action.newToken : t;
       });
       _store = _store.set('tokens', newTokens);

--- a/src/scripts/modules/tokens/react/Index/TokenAge.jsx
+++ b/src/scripts/modules/tokens/react/Index/TokenAge.jsx
@@ -3,11 +3,14 @@ import moment from 'moment';
 
 const TokenAge = ({token}) => {
   const dateString = token.get('refreshed');
+  if (!dateString) {
+    return <span />;
+  }
   const refreshed = moment(dateString);
-  const formattedDate =  refreshed.format('YYYY-MM-DD HH:mm');
+  const formattedDate = refreshed.format('YYYY-MM-DD HH:mm');
   return (
-    <span title={dateString ? formattedDate : ''}>
-      {dateString ? refreshed.fromNow(false) : 'unknown'}
+    <span title={formattedDate}>
+      {refreshed.fromNow(false)}
     </span>
   );
 };

--- a/src/scripts/modules/tokens/react/Index/TokenAge.jsx
+++ b/src/scripts/modules/tokens/react/Index/TokenAge.jsx
@@ -1,0 +1,19 @@
+import React, {PropTypes} from 'react';
+import moment from 'moment';
+
+const TokenAge = ({token}) => {
+  const dateString = token.get('refreshed');
+  const refreshed = moment(dateString);
+  const formattedDate =  refreshed.format('YYYY-MM-DD HH:mm');
+  return (
+    <span title={dateString ? formattedDate : ''}>
+      {dateString ? refreshed.fromNow(false) : 'unknown'}
+    </span>
+  );
+};
+
+TokenAge.propTypes = {
+  token: PropTypes.object.isRequired
+};
+
+export default TokenAge;

--- a/src/scripts/modules/tokens/react/Index/TokensTable.jsx
+++ b/src/scripts/modules/tokens/react/Index/TokensTable.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 // import {Table} from 'react-bootstrap';
 import {List, Map} from 'immutable';
+import TokenAge from './TokenAge';
 
 import Tooltip from '../../../../react/common/Tooltip';
 import Confirm from '../../../../react/common/Confirm';
@@ -48,6 +49,9 @@ export default React.createClass({
               </div>
               <div className="th">
                 Created
+              </div>
+              <div className="th">
+                Refreshed
               </div>
               <div className="th">
                 Expires
@@ -239,6 +243,9 @@ export default React.createClass({
         </div>
         <div className="td">
           <CreatedDate token={token} />
+        </div>
+        <div className="td">
+          <TokenAge token={token} />
         </div>
         <div className="td">
           <ExpiresInfo token={token} />

--- a/src/scripts/modules/tokens/react/TokenDetail.jsx
+++ b/src/scripts/modules/tokens/react/TokenDetail.jsx
@@ -13,6 +13,7 @@ import SaveButtons from '../../../react/common/SaveButtons';
 import ConfirmButtons from '../../../react/common/ConfirmButtons';
 import TokenString from './Index/TokenString';
 import SendTokenModal from '../react/Index/SendTokenModal';
+import {Link} from 'react-router';
 // import Tooltip from '../../../react/common/Tooltip';
 import ApplicationActionCreators from '../../../actions/ApplicationActionCreators';
 
@@ -121,12 +122,18 @@ export default React.createClass({
   },
 
   renderTokenCreated() {
+    const creatorLink = (
+      <Link to="tokens-detail" params={{tokenId: this.state.createdToken.get('id')}}>
+        {this.state.createdToken.get('description')}
+      </Link>
+    );
     return (
-      <div>
+      <div className="text-center">
         {this.renderTokenSendModal()}
-        <p className="alert alert-success">Token {this.state.createdToken.get('description')} has been created. </p>
+        <p className="alert alert-success">Token {creatorLink} has been created. </p>
         <TokenString token={this.state.createdToken}
           sendTokenComponent={this.renderTokenSendButton(this.state.createdToken)}/>
+
       </div>
     );
   },
@@ -200,7 +207,7 @@ export default React.createClass({
              </div>
            )
           }
-          {this.renderTokenEditor(false)}
+          {!this.state.createdToken && this.renderTokenEditor(false)}
         </div>
       </div>
     );

--- a/src/scripts/modules/tokens/react/TokenDetail.jsx
+++ b/src/scripts/modules/tokens/react/TokenDetail.jsx
@@ -112,7 +112,7 @@ export default React.createClass({
   renderTokenEditor(isEditing) {
     return (
       <TokenEditor
-        disabled={!!this.state.isSaving || !!this.state.createdToken}
+        disabled={!!this.state.isSaving}
         isEditing={isEditing}
         token={this.state.dirtyToken}
         allBuckets={this.state.allBuckets}

--- a/src/scripts/modules/tokens/react/tokenEditor/TokenEditor.jsx
+++ b/src/scripts/modules/tokens/react/tokenEditor/TokenEditor.jsx
@@ -130,6 +130,7 @@ export default React.createClass({
   renderDescriptionInput() {
     return (
       <input
+        autoFocus={!this.props.isEditing}
         placeholder="Describe token..."
         disabled={this.props.disabled}
         className="form-control"


### PR DESCRIPTION
Fixes #1448 
Fixes #1493 
Fixes #1492 

Proposed changes:
- set autofocus to description input when creating new token (#1493)
- hide token form after its creation (#1492)
- display `refreshed` token propety in the tokens table (#1448)

#### After token created page with link to the created token
![image](https://user-images.githubusercontent.com/1412120/37476512-a91aea38-2875-11e8-9f59-aba1349cc9a8.png)

#### Tokens table with refreshed property
Some of the tokens do not have refreshed property filled yet so it is not possible for now to display only token age based on the token refreshed property.

![image](https://user-images.githubusercontent.com/1412120/37476580-cbeb1b5a-2875-11e8-9bda-d1f606ba0c21.png)



