### PR TITLE
prefill OM bucket with transformation bucket name

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.coffee
@@ -13,6 +13,7 @@ module.exports = React.createClass
   mixins: [ImmutableRenderMixin]
 
   propTypes:
+    transformationBucket: React.PropTypes.object.isRequired
     value: React.PropTypes.object.isRequired
     tables: React.PropTypes.object.isRequired
     buckets: React.PropTypes.object.isRequired
@@ -39,8 +40,13 @@ module.exports = React.createClass
     )
 
   _parseDestination: ->
+    bucketName = @props.transformationBucket.get('name')
+      .replace(/[^a-zA-Z0-9-]/i, '-')
+      .toLowerCase()
+    if !bucketName.startsWith('c-')
+      bucketName = 'c-' + bucketName
     destination = @props.value.get('destination')
-    tableIdParser.parse(destination, {defaultStage: 'out'})
+    tableIdParser.parse(destination, {defaultStage: 'out', defaultBucket: bucketName})
 
   _handleBlurSource: (e) ->
     isFileMapping = !@props.definition.has('source')
@@ -50,7 +56,8 @@ module.exports = React.createClass
       sourceValue = sourceValue.substring(0, lastDotIdx)
     dstParser = @_parseDestination()
     if !dstParser.parts.table
-      newDestination = dstParser.setPart('table', sourceValue)
+      newDestination = dstParser
+        .setPart('table', sourceValue)
       @_handleChangeDestination(newDestination.tableId)
 
   _handleChangeSource: (e) ->

--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.coffee
@@ -7,6 +7,7 @@ AutosuggestWrapper = require('./AutoSuggestWrapper').default
 Select = React.createFactory require('../../../../../react/common/Select').default
 DestinationTableSelector = require('../../../../../react/common/DestinationTableSelector').default
 tableIdParser = require('../../../../../utils/tableIdParser').default
+stringUtils = require('../../../../../utils/string').default
 
 module.exports = React.createClass
   displayName: 'OutputMappingRowEditor'
@@ -40,10 +41,8 @@ module.exports = React.createClass
     )
 
   _parseDestination: ->
-    bucketName = @props.transformationBucket.get('name')
-      .replace(/[^a-zA-Z0-9-]/i, '-')
-      .toLowerCase()
-    if !bucketName.startsWith('c-')
+    bucketName = stringUtils.webalize(@props.transformationBucket.get('name'))
+    if not bucketName.startsWith('c-')
       bucketName = 'c-' + bucketName
     destination = @props.value.get('destination')
     tableIdParser.parse(destination, {defaultStage: 'out', defaultBucket: bucketName})
@@ -56,8 +55,7 @@ module.exports = React.createClass
       sourceValue = sourceValue.substring(0, lastDotIdx)
     dstParser = @_parseDestination()
     if !dstParser.parts.table
-      newDestination = dstParser
-        .setPart('table', sourceValue)
+      newDestination = dstParser.setPart('table', sourceValue)
       @_handleChangeDestination(newDestination.tableId)
 
   _handleChangeSource: (e) ->

--- a/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
@@ -11,6 +11,7 @@ const MODE_CREATE = 'create', MODE_EDIT = 'edit';
 
 export default React.createClass({
   propTypes: {
+    transformationBucket: PropTypes.object.isRequired,
     mode: PropTypes.oneOf([MODE_CREATE, MODE_EDIT]).isRequired,
     mapping: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
@@ -77,12 +78,13 @@ export default React.createClass({
           onHide={this.close}
           show={this.state.showModal}
           bsSize="large"
-          >
+        >
           <Modal.Header closeButton={true}>
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
             <OutputMappingRowEditor
+              transformationBucket={this.props.transformationBucket}
               fill={true}
               value={this.props.mapping}
               tables={this.props.tables}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/AddOutputMapping.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/AddOutputMapping.jsx
@@ -13,6 +13,7 @@ export default React.createClass({
 
   render() {
     return React.createElement(OutputMappingModal, {
+      transformationBucket: this.props.bucket,
       mode: 'create',
       mapping: this.props.mapping,
       tables: this.props.tables,

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.coffee
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.coffee
@@ -89,6 +89,7 @@ OutputMappingRow = React.createClass(
                   onConfirm: @_handleDelete
 
             React.createElement OutputMappingModal,
+              transformationBucket: this.props.bucket
               mode: 'edit'
               tables: @props.tables
               buckets: @props.buckets

--- a/src/scripts/utils/string.js
+++ b/src/scripts/utils/string.js
@@ -114,7 +114,7 @@ const REMOVE_DIACRITICS_MAP = [
   { base: 'y', letters: RegExp('[\u0079\u24E8\uFF59\u1EF3\u00FD\u0177\u1EF9\u0233\u1E8F\u00FF\u1EF7\u1E99\u1EF5\u01B4' +
     '\u024F\u1EFF]', 'g')},
   { base: 'z', letters: /[\u007A\u24E9\uFF5A\u017A\u1E91\u017C\u017E\u1E93\u1E95\u01B6\u0225\u0240\u2C6C\uA763]/g },
-  { base: '-', letters: /\s/g }
+  { base: '-', letters: /\s+/g }
 ];
 
 let removeDiacriticsCache = {};

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -16,5 +16,8 @@ describe('string utils tests', function() {
     it('LaLaLa123->lalala123', function() {
       assert.equal(webalize('LaLaLa123'), 'lalala123');
     });
+    it('a_b->ab', function() {
+      assert.equal(webalize('a_b'), 'ab');
+    });
   });
 });

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -1,0 +1,20 @@
+import assert from 'assert';
+import stringUtils from './string';
+const {webalize} = stringUtils;
+
+describe('string utils tests', function() {
+  describe('webalize', function() {
+    it('jeden dva tri styri pat -> jeden-dva-tri-styri-pat', function() {
+      assert.equal(webalize('jeden dva tri styri pat'), 'jeden-dva-tri-styri-pat');
+    });
+    it('jeden dva  Tri -> jeden-dva-tri', function() {
+      assert.equal(webalize('jeden dva  Tri'), 'jeden-dva--tri');
+    });
+    it('Háčky a čárky NEdělají problémyô->hacky-a-carky-nedelaji-problemyo', function() {
+      assert.equal(webalize('Háčky a čárky NEdělají problémyô'), 'hacky-a-carky-nedelaji-problemyo');
+    });
+    it('LaLaLa123->lalala123', function() {
+      assert.equal(webalize('LaLaLa123'), 'lalala123');
+    });
+  });
+});

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -8,7 +8,7 @@ describe('string utils tests', function() {
       assert.equal(webalize('jeden dva tri styri pat'), 'jeden-dva-tri-styri-pat');
     });
     it('jeden dva  Tri -> jeden-dva-tri', function() {
-      assert.equal(webalize('jeden dva  Tri'), 'jeden-dva--tri');
+      assert.equal(webalize('jeden dva  Tri'), 'jeden-dva-tri');
     });
     it('Háčky a čárky NEdělají problémyô->hacky-a-carky-nedelaji-problemyo', function() {
       assert.equal(webalize('Háčky a čárky NEdělají problémyô'), 'hacky-a-carky-nedelaji-problemyo');

--- a/src/scripts/utils/tableIdParser.js
+++ b/src/scripts/utils/tableIdParser.js
@@ -1,14 +1,14 @@
-function parseTableId(tableId, defaultStage) {
+function parseTableId(tableId, defaultStage, defaultBucket) {
   const parts = tableId.match(/^(in|out)?\.(.+)?\.(.+)?$/);
   return {
     stage: parts ? (parts[1] || defaultStage)  : defaultStage,
-    bucket: parts ? (parts[2] || '') : '',
+    bucket: parts ? (parts[2] || defaultBucket) : defaultBucket,
     table: parts ? (parts[3]  || '') : ''
   };
 }
 
 export function parse(tableId, options = {}) {
-  const parts = parseTableId(tableId || '', options.defaultStage || '');
+  const parts = parseTableId(tableId || '', options.defaultStage || '', options.defaultBucket || '');
   const {stage, bucket, table} = parts;
   return {
     tableId: `${stage}.${bucket}.${table}`,

--- a/src/scripts/utils/tableIdParser.spec.js
+++ b/src/scripts/utils/tableIdParser.spec.js
@@ -45,4 +45,30 @@ describe('tableIdParser', () => {
     assert.equal('bucket', bucket);
     assert.equal('table', table);
   });
+
+  it('should parse null input with default stage and bucket', function() {
+    const parsed = parse(null, {defaultStage: 'out', defaultBucket: 'bucket'});
+    assert.equal('out.bucket.', parsed.tableId);
+    const {stage, bucket, table} = parsed.parts;
+    assert.equal('out', stage);
+    assert.equal('bucket', bucket);
+    assert.equal('', table);
+  });
+
+  it('should parse input with default stage and bucket', function() {
+    const parsed = parse('in.other.table', {defaultStage: 'out', defaultBucket: 'bucket'});
+    assert.equal('in.other.table', parsed.tableId);
+    const {stage, bucket, table} = parsed.parts;
+    assert.equal('in', stage);
+    assert.equal('other', bucket);
+    assert.equal('table', table);
+  });
+  it('should parse input filling defaultbucket', function() {
+    const parsed = parse('in..table', {defaultStage: 'out', defaultBucket: 'bucket'});
+    assert.equal('in.bucket.table', parsed.tableId);
+    const {stage, bucket, table} = parsed.parts;
+    assert.equal('in', stage);
+    assert.equal('bucket', bucket);
+    assert.equal('table', table);
+  });
 });


### PR DESCRIPTION
Proposed changes:
- default output mapping bucket name to sanitized transformation bucket name

story by @janmichek 
https://keboola.slack.com/files/U4K6RFCP3/F9Q7BNUAG/image.png
`
Premejslim schvalne jako BFU. Nejdriv pojmenovavam bucket 'Guide bucket' a pak musim znovu pojmenovavat bucket v OM. Chapu ze je to asi jinej bucket, ale z uzivatelskyho hlediska bych cekal ce mi to v OM nabidne 'Guide bucket' jako nazev.  Mozna by to chtelo nejak vysvetli nebo presneji wordovat
`
![image](https://user-images.githubusercontent.com/1412120/37480206-eeb5052a-287e-11e8-8b68-88dac6316242.png)


