### PR TITLE
fix moving table input in destination OM table selector

### DIFF
--- a/src/scripts/react/common/DestinationTableSelector.jsx
+++ b/src/scripts/react/common/DestinationTableSelector.jsx
@@ -73,6 +73,7 @@ export default React.createClass({
         value={parts.bucket}
         onChange={this.selectBucket}
         options={this.prepareBucketsOptions().toJS()}
+        autosize={false}
       />
     );
 
@@ -85,6 +86,7 @@ export default React.createClass({
         value={parts.table}
         onChange={this.selectTable}
         options={this.prepareTablesOptions().toJS()}
+        autosize={false}
       />
     );
 

--- a/src/scripts/react/common/DestinationTableSelector.less
+++ b/src/scripts/react/common/DestinationTableSelector.less
@@ -1,26 +1,22 @@
 .kbc-dst-table-selector {
-    display: flex;
-    flex-wrap: wrap;
-}
+  display: flex;
 
-.kbc-dst-table-selector .kbc-select-stage {
-    flex-grow: 0;
-    flex-basis: 4.5em;
-}
-
-.kbc-dst-table-selector .kbc-dot-separator {
+  .kbc-dot-separator {
     flex-grow: 0;
     padding: 0 0.4em;
     line-height: 36px;
-}
+  }
 
-.kbc-dst-table-selector .kbc-select-bucket {
-    flex-basis: 0;
-    flex-grow: 1;
-    max-width: 300px;
-}
+  .kbc-select-stage {
+    flex-grow: 0;
+    flex-basis: 4.5em;
+  }
 
-.kbc-dst-table-selector .kbc-select-table {
-    flex-basis: 0;
+  .kbc-select-bucket {
     flex-grow: 1;
+  }
+
+  .kbc-select-table {
+    flex-grow: 1;
+  }
 }

--- a/src/scripts/react/common/DestinationTableSelector.less
+++ b/src/scripts/react/common/DestinationTableSelector.less
@@ -15,10 +15,12 @@
 }
 
 .kbc-dst-table-selector .kbc-select-bucket {
+    flex-basis: 0;
     flex-grow: 1;
     max-width: 300px;
 }
 
 .kbc-dst-table-selector .kbc-select-table {
+    flex-basis: 0;
     flex-grow: 1;
 }


### PR DESCRIPTION
Fixes #1559 

Proposed changes:
- upravene css table selectoru aby nehybalo s inputom pri pisani textu. Stale sa to vsak pri velmi dlhom stringu posunie, vid gif:

![movinginput](https://user-images.githubusercontent.com/1412120/37674353-fba78ba2-2c72-11e8-835b-d70316fbfcc3.gif)

imho taky dlhy string sa ani neobjavuje a toto riesenie pokryva vacsinu pripadov.
Na problem s nepreskakujucimi fieldami cez tabulator som nenarazil.

