### PR TITLE
fix: row version redirect

### DIFF
--- a/src/scripts/modules/components/react/pages/Versions.jsx
+++ b/src/scripts/modules/components/react/pages/Versions.jsx
@@ -18,7 +18,7 @@ const ITEMS_PER_PAGE = 20;
 
 export default function(componentIdValue, configIdParam = 'config') {
   return React.createClass({
-    mixins: [createStoreMixin(VersionsStore, RoutesStore), immutableMixin],
+    mixins: [createStoreMixin(VersionsStore), immutableMixin],
 
     getStateFromStores() {
       var versions, filteredVersions, query;

--- a/src/scripts/modules/configurations/react/pages/Versions.jsx
+++ b/src/scripts/modules/configurations/react/pages/Versions.jsx
@@ -19,7 +19,7 @@ import '../../styles.less';
 const ITEMS_PER_PAGE = 20;
 
 export default React.createClass({
-  mixins: [createStoreMixin(VersionsStore, RoutesStore), immutableMixin],
+  mixins: [createStoreMixin(VersionsStore), immutableMixin],
 
   getStateFromStores() {
     var versions, filteredVersions, query;


### PR DESCRIPTION
Proposed changes:

- `configurations/react/pages/Versions.jsx` není napojený na `RoutesStore`. tahá si v `getStateFromStores` parametry ze `settings`, ale když přijde redirect z `/extractors/keboola.ex-aws-s3/#/rows/#/versions` na `/extractors/keboola.ex-aws-s3`, tak si není settings z čeho načíst (settings se inicializují až v konfiguraci)

- `components/react/pages/Versions.jsx` taky odpojuju z `RoutesStore`, nevím, k čemu to tam bylo, zkoušel jsem to proklikat a šlape to bez toho v klidu.