### PR TITLE
fix: use processor-move-files

### DIFF
--- a/src/scripts/modules/ex-s3/utils.js
+++ b/src/scripts/modules/ex-s3/utils.js
@@ -32,7 +32,7 @@ function createConfiguration(localState, configId) {
     after: [
       {
         definition: {
-          component: 'keboola.processor.move-files'
+          component: 'keboola.processor-move-files'
         },
         parameters: {
           direction: 'tables'

--- a/src/scripts/modules/ex-s3/utils.spec.js
+++ b/src/scripts/modules/ex-s3/utils.spec.js
@@ -32,7 +32,7 @@ const emptyConfigurationWithDefauls = {
     after: [
       {
         definition: {
-          component: 'keboola.processor.move-files'
+          component: 'keboola.processor-move-files'
         },
         parameters: {
           direction: 'tables'
@@ -79,7 +79,7 @@ const singleFileConfiguration = {
     after: [
       {
         definition: {
-          component: 'keboola.processor.move-files'
+          component: 'keboola.processor-move-files'
         },
         parameters: {
           direction: 'tables'
@@ -126,7 +126,7 @@ const wildcardConfiguration = {
     after: [
       {
         definition: {
-          component: 'keboola.processor.move-files'
+          component: 'keboola.processor-move-files'
         },
         parameters: {
           direction: 'tables'


### PR DESCRIPTION
Proposed changes:

- use `keboola.processor-move-files` instead of `keboola.processor.move-files`

Chtěl jsem změnit i `keboola.processor.merge`, ale 
a) `keboola.processor-merge` neexistuje
b) `keboola.processor.merge` je deprecated / antipattern, používají se místo toho slajsy

Až nás to bude srát, můžem zmigrovat configy.
