### PR TITLE
fix wr-db*: keep table columns order same as in storage

### DIFF
--- a/src/scripts/modules/wr-db/react/pages/table/Table.coffee
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.coffee
@@ -84,11 +84,9 @@ templateFn = (componentId) ->
     dataPreview: null
 
   _prepareColumns: (configColumns, storageColumns) ->
-    allColumns = configColumns
-      .map((c) -> c.get('name'))
-      .toSet()
-      .union(storageColumns.toSet())
-      .toList()
+    configColumnsNamesSet = configColumns.map((c) -> c.get('name')).toSet()
+    deletedColumns = configColumnsNamesSet.subtract(storageColumns)
+    allColumns = storageColumns.concat(deletedColumns)
     allColumns.map (storageColumn) ->
       configColumnFound = configColumns.find( (cc) -> cc.get('name') == storageColumn)
       if configColumnFound


### PR DESCRIPTION
Fixes #1645

Proposed changes:
- zachovava poradia stlpcov podla toho ako ich zoznam vracia storage api
