### PR TITLE
table preview: show formated rows count 

### DIFF
--- a/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
@@ -19,6 +19,7 @@ import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import {factory as eventsFactory} from '../../../sapi-events/EventsService';
 import RoutesStore from '../../../../stores/RoutesStore';
 import hiddenComponents from '../../utils/hiddenComponents';
+import formatCardinalNumber from '../../../../utils/formatCardinalNumber';
 
 const  IMPORT_EXPORT_EVENTS = ['tableImportStarted', 'tableImportDone', 'tableImportError', 'tableExported'];
 
@@ -199,7 +200,7 @@ export default React.createClass({
           {filesize(table.get('dataSizeBytes', 'N/A'))}
         </div>
         <div>
-          {table.get('rowsCount', 'N/A')} rows
+          {formatCardinalNumber(table.get('rowsCount'))} rows
         </div>
       </span>
     );

--- a/src/scripts/modules/components/react/components/StorageApiTableLinkExComponents/GeneralInfoTab.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLinkExComponents/GeneralInfoTab.jsx
@@ -8,6 +8,7 @@ import immutableMixin from '../../../../../react/mixins/ImmutableRendererMixin';
 import EmptyState from '../../../../components/react/components/ComponentEmptyState';
 import filesize from 'filesize';
 import TableUpdatedByComponentInfo from '../../../../../react/common/TableUpdatedByComponentInfo';
+import formatCardinalNumber from '../../../../../utils/formatCardinalNumber';
 
 export default React.createClass({
 
@@ -64,10 +65,7 @@ export default React.createClass({
   },
 
   renderRowsCount(value) {
-    if (value === null) {
-      return 'N/A';
-    }
-    return value + ' rows';
+    return formatCardinalNumber(value) + ' rows';
   },
 
   renderDataSize(value) {

--- a/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/GeneralInfoTab.jsx
@@ -8,6 +8,7 @@ import immutableMixin from '../../../../react/mixins/ImmutableRendererMixin';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import filesize from 'filesize';
 import TableUpdatedByComponentInfo from '../../../../react/common/TableUpdatedByComponentInfo';
+import formatCardinalNumber from '../../../../utils/formatCardinalNumber';
 
 export default React.createClass({
 
@@ -64,10 +65,7 @@ export default React.createClass({
   },
 
   renderRowsCount(value) {
-    if (value === null) {
-      return 'N/A';
-    }
-    return value + ' rows';
+    return formatCardinalNumber(value) + ' rows';
   },
 
   renderDataSize(value) {

--- a/src/scripts/utils/formatCardinalNumber.js
+++ b/src/scripts/utils/formatCardinalNumber.js
@@ -1,0 +1,11 @@
+// given cardinal number as string or int function returns formated number with comma thousands separator
+export default function(numberStr) {
+  if (!numberStr && numberStr !== 0) {
+    return 'N/A';
+  }
+  const number = parseInt(numberStr, 10);
+  if (!number && number !== 0) {
+    return 'N/A';
+  }
+  return number.toLocaleString('en-US');
+}

--- a/src/scripts/utils/formatCardinalNumber.spec.js
+++ b/src/scripts/utils/formatCardinalNumber.spec.js
@@ -1,0 +1,26 @@
+import assert from 'assert';
+import formatCardinalNumber from './formatCardinalNumber';
+
+describe('formatCardinalNumber', () =>{
+  describe('invalid input', () => {
+    it('null should return N/A', () => assert.equal(formatCardinalNumber(null), 'N/A'));
+    it('empty string should return N/A', () => assert.equal(formatCardinalNumber(''), 'N/A'));
+    it('invalid number should return N/A', () => assert.equal(formatCardinalNumber('asdafa'), 'N/A'));
+  });
+
+  describe('valid string input', () => {
+    it('0 should return 0', () => assert.equal(formatCardinalNumber('0'), '0'));
+    it('1 should return 1', () => assert.equal(formatCardinalNumber('1'), '1'));
+    it('100 should return 100', () => assert.equal(formatCardinalNumber('100'), '100'));
+    it('1234 should return 1,234', () => assert.equal(formatCardinalNumber('1234'), '1,234'));
+    it('1234567 should return 1,234,567', () => assert.equal(formatCardinalNumber('1234567'), '1,234,567'));
+  });
+
+  describe('valid integer input', () => {
+    it('0 should return 0', () => assert.equal(formatCardinalNumber(0), '0'));
+    it('1 should return 1', () => assert.equal(formatCardinalNumber(1), '1'));
+    it('100 should return 100', () => assert.equal(formatCardinalNumber(100), '100'));
+    it('1234 should return 1,234', () => assert.equal(formatCardinalNumber(1234), '1,234'));
+    it('1234567 should return 1,234,567', () => assert.equal(formatCardinalNumber(1234567), '1,234,567'));
+  });
+});


### PR DESCRIPTION
Fixes #1630

In table preview tooltip and general info tab show formated rows count with thousand comma separator, e.g. `1234` would show as `1,234`