### PR TITLE
fail safe job detail render with null object job

### DIFF
--- a/src/scripts/modules/jobs/react/components/JobDetailButtons.coffee
+++ b/src/scripts/modules/jobs/react/components/JobDetailButtons.coffee
@@ -18,7 +18,9 @@ module.exports = React.createClass
     job: JobsStore.get jobId
 
   render: ->
-    span null,
-      JobTerminateButton
-        job: @state.job
-
+    if @state.job
+      span null,
+        JobTerminateButton
+          job: @state.job
+    else
+      null

--- a/src/scripts/modules/jobs/react/components/JobDetailReloaderButton.coffee
+++ b/src/scripts/modules/jobs/react/components/JobDetailReloaderButton.coffee
@@ -17,11 +17,14 @@ JobDetailReloaderButton = React.createClass
     jobLoading: JobsStore.getIsJobLoading(@_getJobId())
 
   render: ->
-    React.DOM.span null,
-      if @state.jobLoading
-        React.DOM.span null,
-          ' '
-          Loader()
+    if @state.job
+      React.DOM.span null,
+        if @state.jobLoading
+          React.DOM.span null,
+            ' '
+            Loader()
+    else
+      null
 
 
 module.exports = JobDetailReloaderButton

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -54,10 +54,10 @@ module.exports = React.createClass
   displayName: "JobDetail"
 
   getStateFromStores: ->
-    job = JobsStore.get RoutesStore.getCurrentRouteIntParam('jobId')
+    job = JobsStore.get(RoutesStore.getCurrentRouteIntParam('jobId'))
 
     configuration = new Map()
-    if job.hasIn ['params', 'config']
+    if job and job.hasIn ['params', 'config']
       config = job.getIn ['params', 'config']
       configuration = InstalledComponentsStore.getConfig(getComponentId(job), config?.toString())
 
@@ -74,6 +74,8 @@ module.exports = React.createClass
     activeAccordion: activeAccordion
 
   componentDidUpdate: (prevProps, prevState) ->
+    if not @state.job
+      return
     currentStatus = @state.job.get 'status'
     prevStatus = prevState.job.get 'status'
     return if currentStatus == prevStatus
@@ -92,13 +94,17 @@ module.exports = React.createClass
 
   render: ->
     job = @state.job
-    div {className: 'container-fluid'},
-      div {className: 'kbc-main-content'},
-        @_renderGeneralInfoRow(job)
-        @_renderRunInfoRow(job)
-        @_renderErrorResultRow(job) if job.get('status') == 'error'
-        @_renderAccordion(job)
-        @_renderLogRow(job)
+    if @state.job
+      div {className: 'container-fluid'},
+        div {className: 'kbc-main-content'},
+          @_renderGeneralInfoRow(job)
+          @_renderRunInfoRow(job)
+          @_renderErrorResultRow(job) if job.get('status') == 'error'
+          @_renderAccordion(job)
+          @_renderLogRow(job)
+    else
+      null
+
 
   _renderErrorDetails: (job) ->
     exceptionId = job.getIn ['result', 'exceptionId']

--- a/src/scripts/react/common/JobTerminateButton.jsx
+++ b/src/scripts/react/common/JobTerminateButton.jsx
@@ -29,7 +29,7 @@ export default React.createClass({
   },
 
   canBeTerminated() {
-    return this.props.job.get('status') === 'waiting' || this.props.job.get('status') === 'processing';
+    return this.props.job && (this.props.job.get('status') === 'waiting' || this.props.job.get('status') === 'processing');
   }
 
 });


### PR DESCRIPTION
Fixes #1585 

Tyka sa to stranky detailu jobu aby nespadla pri rendrovani null jobu ktory sa tam dostane pri prechode na Jobs stranku kde po naloadovani noveho zoznamu jobov s inym parametrom(napr page alebo query) uz dany job neexistuje.
