### PR TITLE
fix string webalize: allow one underscore in the middle and case sensitivity

### DIFF
--- a/src/scripts/react/common/DestinationTableSelector.jsx
+++ b/src/scripts/react/common/DestinationTableSelector.jsx
@@ -138,7 +138,7 @@ export default React.createClass({
   },
 
   selectBucketOptionCreator({ label }) {
-    const option = (label.startsWith('c-') ? '' : 'c-') + webalize(label);
+    const option = (label.startsWith('c-') ? '' : 'c-') + webalize(label, {caseSensitive: true});
     return {
       label: 'Create new bucket ' + option,
       value: option
@@ -146,7 +146,7 @@ export default React.createClass({
   },
 
   selectTableOptionCreator({ label }) {
-    const option = webalize(label);
+    const option = webalize(label, {caseSensitive: true});
     return {
       label: 'Create new table ' + option,
       value: option

--- a/src/scripts/utils/string.js
+++ b/src/scripts/utils/string.js
@@ -136,10 +136,11 @@ export default {
     return str.replace(/[^a-zA-Z0-9-]/g, '-');
   },
 
-  webalize(string, separator = '-') {
-    return removeDiacritics(string)
-      .toLowerCase()
-      .replace(/[^a-z0-9\-_]/g, '-')
+  webalize(string, options = {}) {
+    const {separator = '-', caseSensitive = false} = options;
+    const caseHandledString = caseSensitive ? removeDiacritics(string) : removeDiacritics(string).toLowerCase();
+    return caseHandledString
+      .replace(caseSensitive ? /[^A-Za-z0-9\-_]/g : /[^a-z0-9\-_]/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-(.*)$/g, '$1')
       .replace(/^(.*)-$/g, '$1')

--- a/src/scripts/utils/string.js
+++ b/src/scripts/utils/string.js
@@ -138,12 +138,15 @@ export default {
 
   webalize(string, separator = '-') {
     return removeDiacritics(string)
-    .toLowerCase()
-    .replace(/[^a-z0-9\-]/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-(.*)$/g, '$1')
-    .replace(/^(.*)-$/g, '$1')
-    .replace(/-/g, separator);
+      .toLowerCase()
+      .replace(/[^a-z0-9\-_]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-(.*)$/g, '$1')
+      .replace(/^(.*)-$/g, '$1')
+      .replace(/_+/g, '_')
+      .replace(/^_+/, '')
+      .replace(/_+$/, '')
+      .replace(/-/g, separator);
   },
 
   capitalize(string) {

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -10,6 +10,9 @@ describe('string utils tests', function() {
     it('jeden dva  Tri -> jeden-dva-tri', function() {
       assert.equal(webalize('jeden dva  Tri'), 'jeden-dva-tri');
     });
+    it('jeden DVA  Tri -> jeden-DVA-Tri', function() {
+      assert.equal(webalize('jeden DVA  Tri', {caseSensitive: true}), 'jeden-DVA-Tri');
+    });
     it('Háčky a čárky NEdělají problémyô->hacky-a-carky-nedelaji-problemyo', function() {
       assert.equal(webalize('Háčky a čárky NEdělají problémyô'), 'hacky-a-carky-nedelaji-problemyo');
     });

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -16,14 +16,14 @@ describe('string utils tests', function() {
     it('LaLaLa123->lalala123', function() {
       assert.equal(webalize('LaLaLa123'), 'lalala123');
     });
-    it('a_b->a-b', function() {
-      assert.equal(webalize('a_b'), 'a-b');
+    it('a_b->a_b', function() {
+      assert.equal(webalize('a_b'), 'a_b');
     });
-    it('a__b___c->a-b-c', function() {
-      assert.equal(webalize('a__b___c'), 'a-b-c');
+    it('__a__b___c->a_b_c', function() {
+      assert.equal(webalize('__a__b___c'), 'a_b_c');
     });
-    it('_a_b_->a-b', function() {
-      assert.equal(webalize('_a_b_'), 'a-b');
+    it('_a_b_->a_b', function() {
+      assert.equal(webalize('_a_b_'), 'a_b');
     });
   });
 });


### PR DESCRIPTION
Fixes #1682 

Proposed changes:
- string webalize allow one underscore in the middle of the given string e.g: `abc_dfsdf`
- string webalize supports case sensitivity via options i.e `webalize('My String', {caseSensitive: true}) => My-String`, default is `caseSensitive: false`
- allow OM to enter destination bucket and table names with such loose restrictrions ^^