### PR TITLE
Fix sync action response handling on error

### DIFF
--- a/src/scripts/modules/components/DockerActionsApi.js
+++ b/src/scripts/modules/components/DockerActionsApi.js
@@ -20,6 +20,12 @@ export default function(componentId, action, body) {
     .promise()
     .then(
       (response) => response.body,
-      (err) => err.response.body
+      (err) => {
+        if (err.response) {
+          return err.response.body;
+        } else {
+          return err;
+        }
+      }
     );
 }


### PR DESCRIPTION
Fixes #1582 

Proposed changes:

- Check `err.response` befere accessing its `body` prop. Otherwise return whole err.
