### PR TITLE
fix disable table

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -283,8 +283,9 @@ export function createActions(componentId) {
       const prefixMsg = !!newValue ? 'Enable' : 'Disable';
       const diffMsg = prefixMsg + ' query ' + store.getQueryName(qid);
       if (store.isRowConfiguration()) {
-        let query = newQueries.find((q) => q.get('id') === qid);
-        return updateConfigRow(configId, qid, query, ['pending', qid, 'enabled'], diffMsg);
+        const query = newQueries.find((q) => q.get('id') === qid);
+        const rowData = rowDataFromQuery(query);
+        return updateConfigRow(configId, qid, rowData, ['pending', qid, 'enabled'], diffMsg);
       }
       const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
       return saveConfigData(configId, newData, ['pending', qid, 'enabled'], diffMsg);

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -494,7 +494,7 @@ export function createActions(componentId) {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, null);
           }
           updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, fromJS(data.tables));
-          if (store.isRowConfiguration()) {
+          if (store.isRowConfiguration() && data.tables) {
             const candidates = getIncrementalCandidates(fromJS(data.tables));
             updateLocalState(configId, storeProvisioning.INCREMENTAL_CANDIDATES_PATH, candidates);
           }


### PR DESCRIPTION
Fixes #1702 

Proposed changes:

- fix the disable and enable for config rows (it wasn't properly preparing the data)
- check for the existence of tables before looking for incremental fetching candidates.  (fixes error that appears in console when no tables are present)
