### PR TITLE
Only reset incrementalFetching for configRow queries

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -342,6 +342,7 @@ export function createActions(componentId) {
           row: runQuery.get('id').toString()
         };
       } else {
+        runQuery = runQuery.delete('incrementalFetchingColumn').delete('incrementalFetchingLimit');
         return {
           config: configId,
           configData: store.configData.setIn(['parameters', 'tables'], List().push(runQuery))
@@ -389,6 +390,11 @@ export function createActions(componentId) {
         newQuery = newQuery.delete('query');
       }
       newQuery = newQuery.delete('advancedMode');
+      if (!store.isRowConfiguration()) {
+        // if a table was made while this bug was alive https://github.com/keboola/kbc-ui/issues/1731,
+        // need to remove the invalid parameters
+        newQuery = newQuery.delete('incrementalFetchingColumn').delete('incrementalFetchingLimit');
+      }
       newQuery = this.checkTableName(newQuery, store);
 
       var newQueries, diffMsg;

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -216,13 +216,14 @@ export default React.createClass({
     const oldTableName = this.props.query.getIn(['table', 'tableName'], '');
     const newName = (currentName && currentName !== oldTableName) ? currentName : newValue.tableName;
     const primaryKeys = (newValue === '') ? Immutable.List() : this.getPksOnSourceTableChange(newValue);
-    return this.props.onChange(
-      this.props.query
-        .set('table', (newValue === '') ? newValue : Immutable.fromJS(newValue))
-        .set('name', newName ? newName : '')
-        .set('primaryKey', primaryKeys)
-        .set('incrementalFetchingColumn', '')
-    );
+    let newQuery = this.props.query
+      .set('table', (newValue === '') ? newValue : Immutable.fromJS(newValue))
+      .set('name', newName ? newName : '')
+      .set('primaryKey', primaryKeys);
+    if (this.props.isConfigRow) {
+      newQuery = newQuery.set('incrementalFetchingColumn', '');
+    }
+    return this.props.onChange(newQuery);
   },
 
   getColumnsOptions() {


### PR DESCRIPTION
Fixes #1731 

Proposed changes:

- Only reset incrementalFetching for configRow queries on Source table change, duh
