### PR TITLE
fix(wr-storage): missing table link

### DIFF
--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
@@ -18,7 +18,7 @@ const TableCell = React.createClass({
   },
 
   render() {
-    if (this.props.type === columnTypes.STORAGE_LINK_DEFAULT_BUCKET) {
+    if (this.props.type === columnTypes.TABLE_LINK_DEFAULT_BUCKET) {
       const defaultBucketStage = this.props.component.getIn(['data', 'default_bucket_stage']);
       const sanitizedComponentId = this.props.component.get('id').replace(/[^a-zA-Z0-9-]/i, '-');
       const tableName = this.props.valueFn(this.props.row);

--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
@@ -40,6 +40,19 @@ const TableCell = React.createClass({
           />
         );
       }
+    } else if (this.props.type === columnTypes.TABLE_LINK) {
+      const tableId = this.props.valueFn(this.props.row);
+      if (!tableId) {
+        return (<span>
+          Unable to determine table name.
+        </span>);
+      } else {
+        return (
+          <StorageApiTableLinkEx
+            tableId={tableId}
+          />
+        );
+      }
     } else {
       return (
         <span>

--- a/src/scripts/modules/configurations/utils/columnTypeConstants.js
+++ b/src/scripts/modules/configurations/utils/columnTypeConstants.js
@@ -1,5 +1,6 @@
 const columnTypeConstants = {
   TABLE_LINK_DEFAULT_BUCKET: 'table-link-default-bucket',
+  TABLE_LINK: 'table-link',
   VALUE: 'value'
 };
 

--- a/src/scripts/modules/configurations/utils/columnTypeConstants.js
+++ b/src/scripts/modules/configurations/utils/columnTypeConstants.js
@@ -1,5 +1,5 @@
 const columnTypeConstants = {
-  STORAGE_LINK_DEFAULT_BUCKET: 'storage-link-default-bucket',
+  TABLE_LINK_DEFAULT_BUCKET: 'table-link-default-bucket',
   VALUE: 'value'
 };
 

--- a/src/scripts/modules/configurations/utils/createRoute.js
+++ b/src/scripts/modules/configurations/utils/createRoute.js
@@ -46,7 +46,7 @@ const defaults = {
       },
       {
         name: 'Storage',
-        type: columnTypeConstants.STORAGE_LINK_DEFAULT_BUCKET,
+        type: columnTypeConstants.TABLE_LINK_DEFAULT_BUCKET,
         value: function(row) {
           return row.getIn(['configuration', 'parameters', 'name'], 'untitled');
         }

--- a/src/scripts/modules/ex-aws-s3/routes.js
+++ b/src/scripts/modules/ex-aws-s3/routes.js
@@ -49,7 +49,7 @@ const routeSettings = {
       },
       {
         name: 'Storage',
-        type: columnTypes.STORAGE_LINK_DEFAULT_BUCKET,
+        type: columnTypes.TABLE_LINK_DEFAULT_BUCKET,
         value: function(row) {
           const processorMoveFiles = row.getIn(['configuration', 'processors', 'after'], Immutable.List()).find(function(processor) {
             return processor.getIn(['definition', 'component']) === 'keboola.processor-move-files';

--- a/src/scripts/modules/ex-http/routes.js
+++ b/src/scripts/modules/ex-http/routes.js
@@ -53,7 +53,7 @@ const routeSettings = {
       },
       {
         name: 'Storage',
-        type: columnTypes.STORAGE_LINK_DEFAULT_BUCKET,
+        type: columnTypes.TABLE_LINK_DEFAULT_BUCKET,
         value: function(row) {
           const processorMoveFiles = row.getIn(['configuration', 'processors', 'after'], Immutable.List()).find(
             function(processor) {

--- a/src/scripts/modules/wr-storage/routes.js
+++ b/src/scripts/modules/wr-storage/routes.js
@@ -56,7 +56,7 @@ const routeSettings = {
       },
       {
         name: 'Source Table',
-        type: columnTypes.VALUE,
+        type: columnTypes.TABLE_LINK,
         value: function(row) {
           const configuration = row.getIn(['configuration'], Map());
           return configuration.getIn(['storage', 'input', 'tables', 0, 'source'], 'Unknown');


### PR DESCRIPTION
někam v posledních pullrequestech okolo config rows zmizely table links - tipuju nějaký špatný merge po rebasech apod.

current

![image](https://user-images.githubusercontent.com/497675/40661132-39d40a4c-6353-11e8-9ff2-28a54310d3fb.png)

proposed

![image](https://user-images.githubusercontent.com/497675/40661138-4015c1f2-6353-11e8-9c75-0865dc23112a.png)
