### PR TITLE
Fix configuration list for components with type "other"

### DIFF
--- a/src/scripts/modules/components/react/components/ComponentConfigurationLink.coffee
+++ b/src/scripts/modules/components/react/components/ComponentConfigurationLink.coffee
@@ -61,7 +61,7 @@ module.exports = React.createClass
       ,
         @props.children
     else
-      span null,
+      span className: @props.className,
         @props.children
 
   getComponentType: ->


### PR DESCRIPTION
Fixes #1738 

Proposed changes:

- add missing `class` to `span` to fix configurations list for components with type `other`
