### PR TITLE
Fix input mapping warning in transformations

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.coffee
@@ -120,7 +120,7 @@ module.exports = React.createClass
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
             SapiTableSelector
-              value: @props.value.get("source")
+              value: @props.value.get("source", '')
               disabled: @props.disabled
               placeholder: "Source table"
               onSelectTableFn: @_handleChangeSource

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowMySqlEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowMySqlEditor.coffee
@@ -159,7 +159,7 @@ module.exports = React.createClass
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
             SapiTableSelector
-              value: @props.value.get("source")
+              value: @props.value.get("source", '')
               disabled: @props.disabled
               placeholder: "Source table"
               onSelectTableFn: @_handleChangeSource

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.coffee
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.coffee
@@ -177,7 +177,7 @@ module.exports = React.createClass
           React.DOM.label className: 'col-xs-2 control-label', 'Source'
           React.DOM.div className: 'col-xs-10',
             SapiTableSelector
-              value: @props.value.get("source")
+              value: @props.value.get("source", '')
               disabled: @props.disabled
               placeholder: "Source table"
               onSelectTableFn: @_handleChangeSource

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -133,7 +133,7 @@ export default React.createClass({
             <label className="col-xs-2 control-label">Source</label>
             <div className="col-xs-10">
               <SapiTableSelector
-                value={this.props.value.get('source')}
+                value={this.props.value.get('source', '')}
                 disabled={this.props.disabled}
                 placeholder="Source Table"
                 onSelectTableFn={this._handleChangeSource}


### PR DESCRIPTION
Fixes #1705 

Proposed changes:

- pass empty string to `value` prop of `SapiTableSelector` if it's not defined
