### PR TITLE
fix(ex-http/ex-aws-s3): columns + columns_from

### DIFF
--- a/src/scripts/modules/ex-aws-s3/adapters/conform.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/conform.js
@@ -1,0 +1,20 @@
+import Immutable from 'immutable';
+
+export default function(configuration) {
+  let conformedConfiguration = configuration;
+
+  // remove columns array from processor-create-manifest when columns_from is set
+  let processorCreateManifestKey = null;
+  let processorCreateManifest = configuration.getIn(['processors', 'after'], Immutable.List()).find(function(processor, key) {
+    processorCreateManifestKey = key;
+    return processor.getIn(['definition', 'component']) === 'keboola.processor-create-manifest';
+  });
+  if (processorCreateManifest) {
+    if (processorCreateManifest.hasIn(['parameters', 'columns_from']) && processorCreateManifest.hasIn(['parameters', 'columns'])) {
+      processorCreateManifest = processorCreateManifest.removeIn(['parameters', 'columns']);
+      conformedConfiguration = conformedConfiguration.setIn(['processors', 'after', processorCreateManifestKey], processorCreateManifest);
+    }
+  }
+
+  return conformedConfiguration;
+}

--- a/src/scripts/modules/ex-aws-s3/adapters/conform.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/conform.spec.js
@@ -1,0 +1,246 @@
+import assert from 'assert';
+import Immutable from 'immutable';
+import conform  from './conform';
+
+describe('conform', function() {
+  it('should remove columns property from processor-create-manifest if columns_from is set to header', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: [],
+              columns_from: 'header'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns_from: 'header'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+  it('should remove columns property from processor-create-manifest if columns_from is set to auto', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: [],
+              columns_from: 'auto'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns_from: 'auto'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+
+  it('should not remove columns property from processor-create-manifest if columns_from is not set', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: []
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: []
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+});

--- a/src/scripts/modules/ex-aws-s3/adapters/row.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.js
@@ -12,8 +12,7 @@ export function createConfiguration(localState) {
       delimiter: localState.get('delimiter', ','),
       enclosure: localState.get('enclosure', '"'),
       incremental: localState.get('incremental', false),
-      primary_key: localState.get('primaryKey', Immutable.List()),
-      columns: Immutable.List()
+      primary_key: localState.get('primaryKey', Immutable.List())
     }
   });
 
@@ -141,7 +140,7 @@ export function parseConfiguration(configuration) {
   }, null, Immutable.Map());
 
   let columnsFrom = processorCreateManifest.getIn(['parameters', 'columns_from'], 'header');
-  if (processorCreateManifest.getIn(['parameters', 'columns'], Immutable.List()).count() > 0) {
+  if (processorCreateManifest.hasIn(['parameters', 'columns'])) {
     columnsFrom = 'manual';
   }
 

--- a/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.spec.def.js
@@ -45,7 +45,6 @@ export const cases = {
               enclosure: '"',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },
@@ -637,7 +636,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'auto'
             }
           }
@@ -691,7 +689,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },
@@ -766,7 +763,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },
@@ -828,7 +824,6 @@ export const cases = {
               enclosure: '"',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },
@@ -899,7 +894,6 @@ export const cases = {
               enclosure: '"',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },

--- a/src/scripts/modules/ex-aws-s3/routes.js
+++ b/src/scripts/modules/ex-aws-s3/routes.js
@@ -15,6 +15,7 @@ import CredentialsForm from './react/components/Credentials';
 import React from 'react';
 import {CollapsibleSection} from '../configurations/utils/renderHelpers';
 import Immutable from 'immutable';
+import conform from './adapters/conform';
 
 const routeSettings = {
   componentId: 'keboola.ex-aws-s3',
@@ -32,6 +33,7 @@ const routeSettings = {
     }]
   },
   row: {
+    onConform: conform,
     hasState: true,
     sections: [{
       render: ConfigurationForm,

--- a/src/scripts/modules/ex-http/adapters/conform.js
+++ b/src/scripts/modules/ex-http/adapters/conform.js
@@ -1,0 +1,20 @@
+import Immutable from 'immutable';
+
+export default function(configuration) {
+  let conformedConfiguration = configuration;
+
+  // remove columns array from processor-create-manifest when columns_from is set
+  let processorCreateManifestKey = null;
+  let processorCreateManifest = configuration.getIn(['processors', 'after'], Immutable.List()).find(function(processor, key) {
+    processorCreateManifestKey = key;
+    return processor.getIn(['definition', 'component']) === 'keboola.processor-create-manifest';
+  });
+  if (processorCreateManifest) {
+    if (processorCreateManifest.hasIn(['parameters', 'columns_from']) && processorCreateManifest.hasIn(['parameters', 'columns'])) {
+      processorCreateManifest = processorCreateManifest.removeIn(['parameters', 'columns']);
+      conformedConfiguration = conformedConfiguration.setIn(['processors', 'after', processorCreateManifestKey], processorCreateManifest);
+    }
+  }
+
+  return conformedConfiguration;
+}

--- a/src/scripts/modules/ex-http/adapters/conform.spec.js
+++ b/src/scripts/modules/ex-http/adapters/conform.spec.js
@@ -1,0 +1,246 @@
+import assert from 'assert';
+import Immutable from 'immutable';
+import conform  from './conform';
+
+describe('conform', function() {
+  it('should remove columns property from processor-create-manifest if columns_from is set to header', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: [],
+              columns_from: 'header'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns_from: 'header'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+  it('should remove columns property from processor-create-manifest if columns_from is set to auto', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: [],
+              columns_from: 'auto'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns_from: 'auto'
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+
+  it('should not remove columns property from processor-create-manifest if columns_from is not set', function() {
+    const configuration = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: []
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    const expected = {
+      parameters: {
+        path: ''
+      },
+      processors: {
+        after: [
+          {
+            definition: {
+              component: 'keboola.processor-move-files'
+            },
+            parameters: {
+              direction: 'tables',
+              folder: ''
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-create-manifest'
+            },
+            parameters: {
+              delimiter: ',',
+              enclosure: '"',
+              incremental: false,
+              primary_key: [],
+              columns: []
+            }
+          },
+          {
+            definition: {
+              component: 'keboola.processor-skip-lines'
+            },
+            parameters: {
+              lines: 1
+            }
+          }
+        ]
+      }
+    };
+    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+  });
+});

--- a/src/scripts/modules/ex-http/adapters/row.js
+++ b/src/scripts/modules/ex-http/adapters/row.js
@@ -12,8 +12,7 @@ export function createConfiguration(localState) {
       delimiter: localState.get('delimiter', ','),
       enclosure: localState.get('enclosure', '"'),
       incremental: localState.get('incremental', false),
-      primary_key: localState.get('primaryKey', Immutable.List()),
-      columns: Immutable.List()
+      primary_key: localState.get('primaryKey', Immutable.List())
     }
   });
 
@@ -100,7 +99,7 @@ export function parseConfiguration(configuration) {
   }, null, Immutable.Map());
 
   let columnsFrom = processorCreateManifest.getIn(['parameters', 'columns_from'], 'header');
-  if (processorCreateManifest.getIn(['parameters', 'columns'], Immutable.List()).count() > 0) {
+  if (processorCreateManifest.hasIn(['parameters', 'columns'])) {
     columnsFrom = 'manual';
   }
 

--- a/src/scripts/modules/ex-http/adapters/row.spec.def.js
+++ b/src/scripts/modules/ex-http/adapters/row.spec.def.js
@@ -35,8 +35,7 @@ export const cases = {
               enclosure: '"',
               incremental: false,
               primary_key: [],
-              columns_from: 'header',
-              columns: []
+              columns_from: 'header'
             }
           },
           {
@@ -388,7 +387,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'auto'
             }
           }
@@ -432,7 +430,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },
@@ -497,7 +494,6 @@ export const cases = {
               enclosure: '\'',
               incremental: false,
               primary_key: [],
-              columns: [],
               columns_from: 'header'
             }
           },

--- a/src/scripts/modules/ex-http/routes.js
+++ b/src/scripts/modules/ex-http/routes.js
@@ -15,7 +15,7 @@ import CredentialsForm from './react/components/Credentials';
 import React from 'react';
 import Immutable from 'immutable';
 import {CollapsibleSection} from '../configurations/utils/renderHelpers';
-
+import conform from './adapters/conform';
 
 const routeSettings = {
   componentId: 'keboola.ex-http',
@@ -35,6 +35,7 @@ const routeSettings = {
     ]
   },
   row: {
+    onConform: conform,
     sections: [
       {
         render: ConfigurationForm,


### PR DESCRIPTION
Fixes #1770 

Proposed changes:

- do not save empty `columns` array in `create-processor-manifest` when `columns_from` is set to `header` or `auto`
- when `columns` array is present in the configuration of `create-processor-manifest`, assume the columns from is set to `manual`
- use conform function for backward compatibility