### PR TITLE
fix(ex-db-generic): dont reset input of quickstart select on jobs reload

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -20,6 +20,11 @@ export default React.createClass({
     refreshMethod: React.PropTypes.func.isRequired
   },
 
+  shouldComponentUpdate(nextProps) {
+    const updateOnProps = ['isLoadingSourceTables', 'isTestingConnection', 'validConnection', 'sourceTables', 'sourceTablesError', 'quickstart'];
+    return updateOnProps.reduce((acc, prop) => acc || nextProps[prop] !== this.props[prop], false);
+  },
+
   quickstart() {
     this.props.onSubmit(this.props.configId, this.props.quickstart.get('tables'));
   },


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1412120/41774182-e7a28102-761e-11e8-8b93-037ca20f79b3.png)

### Problem

Na stranke quickstart u ex db generic sa input selectu zresetuje zakazdym reloadom last jobs. Po reloade sa zmeni referencia na value property selectu a ten na zaklade toho pozna ze ma zmazat svoj interny state v ktoromu ma ulozenu hodnotu inputu.
https://github.com/JedWatson/react-select/blob/master/src/Select.js#L145
Je to sposobene aj tym ze my pouzivame immutable takze sa value property zakazdym prevedie na novu referenciu(volanim toJS()) ajked sa hodnota nezmenila.

### Riesenie
V komponente kde sa rendruje select kontrolovat zmenu props rucne tj dopisat `shouldComponentUpdate(nextProps)` 


