### PR TITLE
webpack: better source maps in development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ npm-debug.log
 /start-chrome-debug.sh
 /.dir-locals.el
 /yarn-error.log
+.vscode/launch.json

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -70,7 +70,7 @@ module.exports = function (options) {
     }
 
     return {
-        devtool: isDevelopment ? 'eval-source-map' : 'source-map',
+        devtool: isDevelopment ? 'cheap-module-eval-source-map' : 'source-map',
         entry: entry,
         output: {
             path: isDevelopment ? './dist' : './dist/' + process.env.KBC_REVISION,

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -70,7 +70,7 @@ module.exports = function (options) {
     }
 
     return {
-        devtool: isDevelopment ? 'eval' : 'source-map',
+        devtool: isDevelopment ? 'eval-source-map' : 'source-map',
         entry: entry,
         output: {
             path: isDevelopment ? './dist' : './dist/' + process.env.KBC_REVISION,


### PR DESCRIPTION
- nastavuje devtool podla https://webpack.js.org/configuration/devtool/
- plati len pre development mode build
- generuje source mapy 1:1 k zdrojakom takze v chrome console source alebo inom externom debuggery to lepsie ukazuje zdrojaky
![image](https://user-images.githubusercontent.com/1412120/41813301-95539e20-7733-11e8-9d03-319ec14d3e3f.png)

