### PR TITLE
pads overwiev selection

### DIFF
--- a/src/scripts/modules/guide-mode/react/Guide.less
+++ b/src/scripts/modules/guide-mode/react/Guide.less
@@ -32,7 +32,7 @@
       margin-top: @statusBarHeight !important;
     }
     .kbc-overview-component-container ~ .kbc-main-content{
-      margin-top: 0;
+      margin-top: 10px;
     }
     &.guide-mode-lesson-on {
       .guide-desk-container {


### PR DESCRIPTION
Tady jsem nasel jedno chybny padovani layoutu. Overview bylo prilepeny na vyberu lekci. Nevim presne jak to vzniklo, zkounul jsem to jeste s deprecated warnings a uz to paduje dobre.