### PR TITLE
fix(csv-import): allow csv import with empty enclosure

### DIFF
--- a/src/scripts/modules/csv-import/actionsProvisioning.js
+++ b/src/scripts/modules/csv-import/actionsProvisioning.js
@@ -203,9 +203,7 @@ export default function(configId) {
               if (store.settings.get('delimiter')) {
                 createTableParams.delimiter = store.settings.get('delimiter');
               }
-              if (store.settings.get('enclosure')) {
-                createTableParams.enclosure = store.settings.get('enclosure');
-              }
+              createTableParams.enclosure = store.settings.get('enclosure');
 
               storageApiActions.createTable(bucketId, createTableParams)
               .then(function() {
@@ -244,7 +242,7 @@ export default function(configId) {
 
               store.settings.get('incremental') && (loadTableParams.incremental = store.settings.get('incremental'));
               store.settings.get('delimiter') && (loadTableParams.delimiter = store.settings.get('delimiter'));
-              store.settings.get('enclosure') && (loadTableParams.enclosure = store.settings.get('enclosure'));
+              loadTableParams.enclosure = store.settings.get('enclosure');
 
               updateLocalState(['uploadingMessage'], 'Loading into table ' + tableId);
               updateLocalState(['uploadingProgress'], 90);

--- a/src/scripts/modules/csv-import/react/components/Settings.jsx
+++ b/src/scripts/modules/csv-import/react/components/Settings.jsx
@@ -177,7 +177,7 @@ export default React.createClass({
           wrapperClassName="col-xs-8"
           value={this.props.settings.get('enclosure')}
           onChange={this.onChangeEnclosure}
-          help={(<span>Field enclosure used in CSV file. Default value is <code>"</code>.</span>)}
+          help="Field enclosure used in CSV file."
           disabled={this.props.disabled}
           />
       </div>

--- a/src/scripts/modules/csv-import/utils.js
+++ b/src/scripts/modules/csv-import/utils.js
@@ -28,7 +28,7 @@ const createConfiguration = function(settings, configId) {
     config = config.set('delimiter', ',');
   }
 
-  if (settings.get('enclosure') && settings.get('enclosure') !== '') {
+  if (settings.has('enclosure')) {
     config = config.set('enclosure', settings.get('enclosure'));
   } else {
     config = config.set('enclosure', '"');


### PR DESCRIPTION
Fixes #1814 

Proposed changes:
- umoznuje ulozit a importovat csv s prazdnym enclosure
- prvotna hodnota enclosure po vytvoreni configu ostava `"`
