### PR TITLE
fix build: use generated source maps

### DIFF
--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -70,7 +70,7 @@ module.exports = function (options) {
     }
 
     return {
-        devtool: isDevelopment ? 'eval-source-map' : 'source-map',
+        devtool: isDevelopment ? 'eval' : 'source-map',
         entry: entry,
         output: {
             path: isDevelopment ? './dist' : './dist/' + process.env.KBC_REVISION,

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -70,7 +70,7 @@ module.exports = function (options) {
     }
 
     return {
-        devtool: isDevelopment ? 'cheap-module-eval-source-map' : 'source-map',
+        devtool: isDevelopment ? 'eval-source-map' : 'source-map',
         entry: entry,
         output: {
             path: isDevelopment ? './dist' : './dist/' + process.env.KBC_REVISION,


### PR DESCRIPTION
- reverts this PR https://github.com/keboola/kbc-ui/pull/1811
- dikisua https://keboola.slack.com/archives/C02J3DKH3/p1530609350000070
- fixuje zle generovanie source map pri logu chyby v ui 