### PR TITLE
fix(orchestrations): closing the Add task modal resets the modal state

### DIFF
--- a/src/scripts/modules/guide-mode/lesson-templates/projectAutomation.js
+++ b/src/scripts/modules/guide-mode/lesson-templates/projectAutomation.js
@@ -47,9 +47,9 @@ export default {
       'title': 'Configure Task',
       'markdown': 'As tasks, you will run the Snowflake extractor, transformation and Tableau writer configured in the previous lessons. Add the tasks one by one.'
                 + `
-- Click <span class="btn btn-success btn-sm">+ New task</span>, select your Snowflake extractor, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
-- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select your Transformation from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
-- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select your Tableau writer from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
+- Click <span class="btn btn-success btn-sm">+ New task</span>, select the Snowflake extractor component, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
+- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select the Transformations component from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
+- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select the Tableau writer component from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
 
 Then click <span class="btn btn-success btn-sm">Save</span> in the upper right corner.
 

--- a/src/scripts/modules/guide-mode/lesson-templates/projectAutomation.js
+++ b/src/scripts/modules/guide-mode/lesson-templates/projectAutomation.js
@@ -48,8 +48,8 @@ export default {
       'markdown': 'As tasks, you will run the Snowflake extractor, transformation and Tableau writer configured in the previous lessons. Add the tasks one by one.'
                 + `
 - Click <span class="btn btn-success btn-sm">+ New task</span>, select your Snowflake extractor, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
-- Click <span class="btn btn-success btn-sm">+ New task</span> again. Then click <span class="btn btn-link btn-sm"> <i class="fa fa-chevron-left"></i> Back</span> on the right side to go back to component listing. Select your Transformation from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
-- Click <span class="btn btn-success btn-sm">+ New task</span> again. Then click <span class="btn btn-link btn-sm"> <i class="fa fa-chevron-left"></i> Back</span> on the right side to go back to component listing. Select your Tableau writer from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
+- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select your Transformation from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
+- Click <span class="btn btn-success btn-sm">+ New task</span> again. Select your Tableau writer from the list, then select your configuration by clicking on <i class="fa fa-plus-circle"></i>. <br><br>
 
 Then click <span class="btn btn-success btn-sm">Save</span> in the upper right corner.
 

--- a/src/scripts/modules/orchestrations/react/modals/add-task/AddTaskModal.coffee
+++ b/src/scripts/modules/orchestrations/react/modals/add-task/AddTaskModal.coffee
@@ -65,9 +65,13 @@ AddTaskModal = React.createClass
     @state.orchestrations.filter ->
       fuzzy.match(filter, 'orchestrator')
 
+  _handleOnHide: ->
+    @_handleComponentReset()
+    @props.onHide()
+
   render: ->
     Modal
-      onHide: @props.onHide
+      onHide: @_handleOnHide
       show: @props.show,
 
       ModalHeader closeButton: true,
@@ -106,7 +110,7 @@ AddTaskModal = React.createClass
         ButtonToolbar null,
           Button
             bsStyle: 'link'
-            onClick: @props.onHide
+            onClick: @_handleOnHide
           ,
             'Cancel'
 
@@ -130,7 +134,7 @@ AddTaskModal = React.createClass
   ###
   _handleConfigurationSelect: (configuration) ->
     @props.onConfigurationSelect(@state.selectedComponent, configuration, @props.phaseId)
-    @props.onHide()
+    @_handleOnHide()
 
 
 


### PR DESCRIPTION
ref #1846

- no more `< Back` button clicking after reopening add task modal
- updated guide mode texts to reflect the change
- modified guide mode texts, eg `your Snowflake extractor` => `the Snowflake extractor component` 