### PR TITLE
fixes react-select style to use full width of input

### DIFF
--- a/src/styles/theme-kbc-react-select.less
+++ b/src/styles/theme-kbc-react-select.less
@@ -4,3 +4,7 @@
 .Select-menu-outer {
   z-index: 5;
 }
+
+.Select-input {
+  width: 100%;
+}


### PR DESCRIPTION
Resi bod c.10 https://github.com/keboola/kbc-ui/issues/1685#issuecomment-389781934

Stavajici stav:
![select1](https://user-images.githubusercontent.com/15363559/42932966-f3f7a556-8b43-11e8-8005-9f8385927e94.gif)



Zmena:
![select2](https://user-images.githubusercontent.com/15363559/42933018-100524c6-8b44-11e8-8035-10efbbb8d44f.gif)

