### PR TITLE
Documentation badge

### DIFF
--- a/src/scripts/modules/components/react/pages/ComponentRow.jsx
+++ b/src/scripts/modules/components/react/pages/ComponentRow.jsx
@@ -6,7 +6,7 @@ import ComponentIcon from '../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../react/common/ComponentName';
 import ComponentDetailLink from '../../../../react/common/ComponentDetailLink';
 import ComponentBadgeRow from '../../../../react/common/ComponentBadgeRow';
-import { getComponentBadges } from '../../../../react/common/componentHelpers';
+import { getComponentBadgesExcluding } from '../../../../react/common/componentHelpers';
 
 export default React.createClass({
   mixins: [PureRenderMixin],
@@ -28,7 +28,7 @@ export default React.createClass({
             </h2>
           </div>
           <ComponentBadgeRow
-            badges={getComponentBadges(this.props.component)}
+            badges={getComponentBadgesExcluding(this.props.component, ['documentation'])}
           />
         </div>
         <div className="table table-hover">

--- a/src/scripts/react/common/ComponentBadgeCell.jsx
+++ b/src/scripts/react/common/ComponentBadgeCell.jsx
@@ -2,24 +2,13 @@ import React, {PropTypes} from 'react';
 
 export default React.createClass({
   propTypes: {
-    badges: PropTypes.array.isRequired,
-    badgesFilter: PropTypes.array
-  },
-
-  getDefaultProps() {
-    return {
-      badgesFilter: []
-    };
+    badges: PropTypes.array.isRequired
   },
 
   render() {
-    const badges = this.props.badgesFilter.length > 0
-      ? this.props.badges.filter((badge) => this.props.badgesFilter.includes(badge.key))
-      : this.props.badges;
-
     return (
       <div className="badge-component-container badge-component-container-selection">
-        {badges.map((badge, idx) =>
+        {this.props.badges.map((badge, idx) =>
           <div className={'badge badge-component-item badge-component-item-title badge-component-item-' + badge.key}
             title={badge.description}
             key={idx}

--- a/src/scripts/react/common/ComponentBox.jsx
+++ b/src/scripts/react/common/ComponentBox.jsx
@@ -4,7 +4,7 @@ import ComponentDetailLink from './ComponentDetailLink';
 import ComponentBadgeCell from './ComponentBadgeCell';
 import ComponentIcon from './ComponentIcon';
 import ComponentName from './ComponentName';
-import { getComponentBadges } from './componentHelpers';
+import { getComponentBadgesIncluding } from './componentHelpers';
 
 export default React.createClass({
   propTypes: {
@@ -19,8 +19,7 @@ export default React.createClass({
         type={component.get('type')}
       >
         <ComponentBadgeCell
-          badges={getComponentBadges(component)}
-          badgesFilter={['3rdParty', 'appInfo.beta', 'complexity']}
+          badges={getComponentBadgesIncluding(component, ['3rdParty', 'appInfo.beta', 'complexity'])}
         />
         <ComponentIcon component={component} size="64" />
         <h2>

--- a/src/scripts/react/common/componentHelpers.js
+++ b/src/scripts/react/common/componentHelpers.js
@@ -144,6 +144,20 @@ const getComponentBadges = (component) => {
       key: 'complexity'
     });
   }
+  if (component.get('documentationUrl')) {
+    badges.push({
+      title: (
+        <span>
+          <i className="fa fa-book "/> Documentation
+        </span>
+      ),
+      description: (
+        <span>Documentation for this {componentType} is <ExternalLink href={component.get('documentationUrl')}>available.</ExternalLink></span>
+      ),
+      descriptionPlain: `Documentation for this ${componentType} is available.`,
+      key: 'documentation'
+    });
+  }
   return badges;
 };
 

--- a/src/scripts/react/common/componentHelpers.js
+++ b/src/scripts/react/common/componentHelpers.js
@@ -161,6 +161,20 @@ const getComponentBadges = (component) => {
   return badges;
 };
 
+const getComponentBadgesIncluding = (component, filter = []) => {
+  return getComponentBadges(component).filter((badge) => {
+    return filter.includes(badge.key);
+  });
+};
+
+const getComponentBadgesExcluding = (component, filter = []) => {
+  return getComponentBadges(component).filter((badge) => {
+    return !filter.includes(badge.key);
+  });
+};
+
 export {
-  getComponentBadges
+  getComponentBadges,
+  getComponentBadgesIncluding,
+  getComponentBadgesExcluding
 };

--- a/src/scripts/react/common/componentHelpers.js
+++ b/src/scripts/react/common/componentHelpers.js
@@ -148,7 +148,7 @@ const getComponentBadges = (component) => {
     badges.push({
       title: (
         <span>
-          <i className="fa fa-book "/> Documentation
+          <i className="fa fa-question-circle "/> Documentation
         </span>
       ),
       description: (

--- a/src/scripts/react/common/componentHelpers.js
+++ b/src/scripts/react/common/componentHelpers.js
@@ -152,9 +152,9 @@ const getComponentBadges = (component) => {
         </span>
       ),
       description: (
-        <span>Documentation for this {componentType} is <ExternalLink href={component.get('documentationUrl')}>available.</ExternalLink></span>
+        <span>Additional documentation for this {componentType} is <ExternalLink href={component.get('documentationUrl')}>available.</ExternalLink></span>
       ),
-      descriptionPlain: `Documentation for this ${componentType} is available.`,
+      descriptionPlain: `Additional documentation for this ${componentType} is available.`,
       key: 'documentation'
     });
   }


### PR DESCRIPTION
Fixes #1782 

Proposed changes:

- Show link to documentation on component detail page (if available)
- Add new functions to filter (include, exclude) badges
- Remove filtering from ComponentBadgeCell - all components now only "consuming" badges

![screenshot_2018-08-08_15-15-30](https://user-images.githubusercontent.com/419849/43839253-ee011efe-9b1d-11e8-9009-7bb860f1b92a.png)

