### PR TITLE
fix google drive ex - dont reset multi select input value after jobs reload

### DIFF
--- a/src/scripts/modules/ex-google-drive/react/components/HeaderColumnsMultiSelect.jsx
+++ b/src/scripts/modules/ex-google-drive/react/components/HeaderColumnsMultiSelect.jsx
@@ -1,11 +1,16 @@
 import React, {PropTypes} from 'react';
 import Select from 'react-select';
+import _ from 'underscore';
 
 export default React.createClass({
 
   propTypes: {
     value: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired
+  },
+
+  shouldComponentUpdate(nextProps) {
+    return !_.isEqual(nextProps.value, this.props.value);
   },
 
   render() {


### PR DESCRIPTION
related to https://github.com/keboola/kbc-ui/issues/1807

Uprava sa tyka editacie sheetu - pridavanie columns do headeru.
Uz to tam predtym bolo fixnute ze `shouldComponentUpdate` furt vratil `false` ale pri migracii na novy select(creatable) to prestalo fungovat tak som to zmazal(vid historia toho modulu). Teraz sme nato cez zendesk ticket narazili znova a uz je to snad finxute poriadne.

Problem je v tom ze `this.props.value` a `nextProps.value` su vzdy rozne referencie na polia stringov a nezafunguje `!==` takze treba porovnat tie polia hodnotovo. Jediny kompromis mi vysiel cez underscore isEqual. Porovnavat to cez immutable mi pride zbytocne..




