### PR TITLE
Select options overflow

### DIFF
--- a/src/scripts/modules/transformations/react/components/ConfigureSandbox.coffee
+++ b/src/scripts/modules/transformations/react/components/ConfigureSandbox.coffee
@@ -24,12 +24,12 @@ ConfigureSandbox = React.createClass
   render: ->
     form className: 'form-horizontal',
       div className: 'form-group',
-        label className: 'col-sm-4 control-label', 'Backend'
-        div className: 'col-sm-6',
+        label className: 'col-sm-3 control-label', 'Backend'
+        div className: 'col-sm-9',
           p className: 'form-control-static', @state.backend
       div className: 'form-group',
-        label className: 'col-sm-4 control-label', 'Data'
-        div className: 'col-sm-6',
+        label className: 'col-sm-3 control-label', 'Data'
+        div className: 'col-sm-9',
           React.createElement Select,
             name: 'include'
             value: @state.include
@@ -39,8 +39,8 @@ ConfigureSandbox = React.createClass
             onChange: @_setInclude
             placeholder: 'Select buckets and tables...'
       div className: 'form-group',
-        label className: 'col-sm-4 control-label', 'Sample rows'
-        div className: 'col-sm-6',
+        label className: 'col-sm-3 control-label', 'Sample rows'
+        div className: 'col-sm-9',
           input
             type: 'number'
             placeholder: 'Number of rows'
@@ -49,8 +49,8 @@ ConfigureSandbox = React.createClass
             onChange: @_setRows
             ref: 'exclude'
       div className: 'form-group',
-        label className: 'col-sm-4 control-label'
-        div className: 'col-sm-6',
+        label className: 'col-sm-3 control-label'
+        div className: 'col-sm-9',
           label className: 'control-label',
             input
               type: 'checkbox'

--- a/src/styles/theme-kbc-react-select.less
+++ b/src/styles/theme-kbc-react-select.less
@@ -8,3 +8,7 @@
 .Select-input {
   width: 100%;
 }
+
+.Select-option {
+    word-wrap: break-word;
+}


### PR DESCRIPTION
Fixes #1925

Opravil jsem to roztazenim gridu na plnou sirku modalu (byla tam rezerva)
Pokud to nekdo prezene s nazvem, pridavam fallback (word-wrap: break-word) tim se zalamuji dlouhy stringy, ktery nemaji v nazvu mezerniky.

![image](https://user-images.githubusercontent.com/15363559/44151124-e446936a-a0a1-11e8-88a2-3ca83d6d2876.png)
