### PR TITLE
fix save input mapping of google drive/sheets writer config

### DIFF
--- a/src/scripts/modules/wr-google-drive/actionsProvisioning.js
+++ b/src/scripts/modules/wr-google-drive/actionsProvisioning.js
@@ -66,11 +66,17 @@ export default function(COMPONENT_ID, configId) {
     return found && found.get('enabled');
   }
 
+  function tableExist(tableId, tables) {
+    return !!tables.find(t => t.get('tableId') === tableId);
+  }
+
   function saveTables(tables, mappings, savingPath, description) {
     const desc = description || 'Update tables';
-    const limitedMappings = mappings.map(t => isTableExportEnabled(t.get('source'), tables) ? t.delete('limit') : t.set('limit', 1));
+    const limitedMappings = mappings
+      .filter(mapping => tableExist(mapping.get('source'), tables))
+      .map(t => isTableExportEnabled(t.get('source'), tables) ? t.delete('limit') : t.set('limit', 1));
     const data = store.configData
-                      .setIn(['parameters', 'tables'], tables)
+      .setIn(['parameters', 'tables'], tables)
       .setIn(['storage', 'input', 'tables'], limitedMappings);
     return saveConfigData(data, savingPath, desc);
   }

--- a/src/scripts/modules/wr-google-sheets/actionsProvisioning.js
+++ b/src/scripts/modules/wr-google-sheets/actionsProvisioning.js
@@ -66,9 +66,15 @@ export default function(COMPONENT_ID, configId) {
     return found && found.get('enabled');
   }
 
+  function tableExist(tableId, tables) {
+    return !!tables.find(t => t.get('tableId') === tableId);
+  }
+
   function saveTables(tables, mappings, savingPath, description) {
     const desc = description || 'Update tables';
-    const limitedMappings = mappings.map(t => isTableExportEnabled(t.get('source'), tables) ? t.delete('limit') : t.set('limit', 1));
+    const limitedMappings = mappings
+      .filter(mapping => tableExist(mapping.get('source'), tables))
+      .map(t => isTableExportEnabled(t.get('source'), tables) ? t.delete('limit') : t.set('limit', 1));
     const data = store.configData
       .setIn(['parameters', 'tables'], tables)
       .setIn(['storage', 'input', 'tables'], limitedMappings)


### PR DESCRIPTION
Fixes https://github.com/keboola/kbc-ui/issues/1933

Proposed changes:
- uprava ukladania tabuliek do konfigu
- dejete sa to pri kazdej zmene tabulky/tabuliek
- ak tabulka neexistuje pod `parameters` ale existuje v input mappingu(v storage -> input -> tables) tak sa z input mapping zmaze tiez


