### PR TITLE
Fix saving in InlineEditTextInput; Use onSubmit

### DIFF
--- a/src/scripts/react/common/InlineEditTextInput.coffee
+++ b/src/scripts/react/common/InlineEditTextInput.coffee
@@ -48,9 +48,16 @@ EditInput = React.createFactory React.createClass
   _onChange: (e) ->
     @props.onChange e.target.value
 
+  _onSubmit: (e) ->
+    e.preventDefault()
+    @props.onSave()
+
   render: ->
     div className: 'form-inline kbc-inline-edit',
-      form style: {display: 'inline'},
+      form
+        style: {display: 'inline'}
+        onSubmit: @_onSubmit
+      ,
         Input
           ref: 'valueInput'
           type: 'text'
@@ -72,7 +79,6 @@ EditInput = React.createFactory React.createClass
             className: 'kbc-inline-edit-submit'
             bsStyle: 'info'
             disabled: @props.isSaving || !@props.isValid
-            onClick: @props.onSave
             type: 'submit'
           ,
             'Save'


### PR DESCRIPTION
Fixes #1911 

Proposed changes:

- move saving to "onSubmit"
- since button has type "submit" there's no need to save "onClick"

This was broken for ages - I remember at least 1 or 2 zendesk shifts ago there was also ticket for it.