### PR TITLE
Update undescore/underscore.string libs

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,8 +61,8 @@
     "remove-markdown": "^0.1.0",
     "sortablejs": "^1.7.0",
     "superagent": "~3.8.3",
-    "underscore": "~1.7.0",
-    "underscore.string": "~3.0.3"
+    "underscore": "^1.9.0",
+    "underscore.string": "^3.3.4"
   },
   "scripts": {
     "start": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7631,6 +7631,10 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
+sprintf-js@^1.0.3:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.1.tgz#36be78320afe5801f6cea3ee78b6e5aab940ea0c"
+
 sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
@@ -8113,13 +8117,20 @@ uncontrollable@^4.1.0:
   dependencies:
     invariant "^2.1.0"
 
+underscore.string@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.3.4.tgz#2c2a3f9f83e64762fdc45e6ceac65142864213db"
+  dependencies:
+    sprintf-js "^1.0.3"
+    util-deprecate "^1.0.2"
+
 underscore.string@~2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-2.4.0.tgz#8cdd8fbac4e2d2ea1e7e2e8097c42f442280f85b"
 
-underscore.string@~3.0.3:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/underscore.string/-/underscore.string-3.0.3.tgz#4617b8c1a250cf6e5064fbbb363d0fa96cf14552"
+underscore@^1.9.0:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
 
 underscore@~1.4.4:
   version "1.4.4"
@@ -8250,7 +8261,7 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
 
-util-deprecate@~1.0.1:
+util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 


### PR DESCRIPTION
Neměl by tam být žádný BC break. 

Z changlogu underscore:
*1.9.0 - Three years of performance improvements.*

Z changlogu underscore.string:
*3.1.0 - Performance improvement in levenshtein*
*3.2.0 - Small performance improvements*

Ještě kouknu na pár knihoven jestli to je v pohodě.
React knihovny mohou vyžadovat novější React ale jsou tam i jiné, kde nejsou žádné BC breaky, a kde update může přinést nějaké vylepšení co to výkonu, nebo řešení edge casů atd.