### PR TITLE
Update classname lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "bluebird": "~2.3.11",
     "byte-converter": "^0.1.4",
     "canvg": "git+https://git@github.com/keboola/canvg.git#f3e9fa2992d9a25fe4a46db3a59a208b5a8b86cb",
-    "classnames": "~2.1.0",
+    "classnames": "^2.2.6",
     "codemirror": "~5.8",
     "crypto-js": "^3.1.5",
     "csv-parse": "0.0.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1806,17 +1806,13 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.1.0:
+classnames@^2.1.0, classnames@^2.2.6:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
 
 classnames@^2.2.1, classnames@^2.2.4, classnames@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
-
-classnames@~2.1.0:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.1.5.tgz#9c9a9cea3e2ff3ffd9b575442e3bd86d88dddf3e"
 
 cli-cursor@^2.1.0:
   version "2.1.0"


### PR DESCRIPTION
Menší update classname 2.1.0 -> 2.2.6.

*2.1.1 - minor performance improvement*
*2.2.2 - Switched from string concatenation to [].join(' ') for a slight performance gain in the main function.*
*2.2.4 - Improved performance of dedupe variant by about 2x*
*2.2.5 - Improved performance of dedupe variant even further*

Podle [Githubu ](https://github.com/JedWatson/classnames#project-philosophy)dodržují SemVer.
Malý bonus do výkonu ale zase je classname použitý napříč celou aplikací.