### PR TITLE
Remove object-assign lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "moment": "^2.18.0",
     "moment-timezone": "~0.3.1",
     "numeral": "~1.5.3",
-    "object-assign": "^1.0.0",
+    "object-assign": "^4.1.1",
     "prettycron": "~0.10.0",
     "rc-switch": "^1.3.3",
     "react": "^0.14.9",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "moment": "^2.18.0",
     "moment-timezone": "~0.3.1",
     "numeral": "~1.5.3",
-    "object-assign": "^4.1.1",
     "prettycron": "~0.10.0",
     "rc-switch": "^1.3.3",
     "react": "^0.14.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5754,10 +5754,6 @@ oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
 
-object-assign@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-1.0.0.tgz#e65dc8766d3b47b4b8307465c8311da030b070a6"
-
 object-assign@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-2.1.1.tgz#43c36e5d569ff8e4816c4efa8be02d26967c18aa"


### PR DESCRIPTION
> Upgrade 1.0.0 -> 4.1.1.
> 
> Větší update ale jde "pouze" o jeden soubor. Nová verze se liší hlavně lepší detekcí, zda je Object.assign k dispozici nebo ne. Samotný polyfill je pak již skoro stejný jako ve verzi 1.0.0.  Díky robustnější kontrole toto nebude případně + perf update.

nakoniec sme sa dohodli ze to vyhodime

> Note: Ještě koukám na dvě knihovny tam, jedna z nich je 'cross-env', která ale není nikde použita. Většinou se používá pro definování ENV proměnné ve script sekci package.json. Ale tam to nevidím. Nevím zda je použita pak někde mimo ale asi to je nepravděpodobné. Nevím teda zda se může balíček vyhodit nebo ne.

poriesene v #2031 