### PR TITLE
Upgrade csv-parse lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "classnames": "~2.1.0",
     "codemirror": "~5.8",
     "crypto-js": "^3.1.5",
-    "csv-parse": "0.0.9",
+    "csv-parse": "3.0.0",
     "d3": "~3.5.6",
     "dagre-d3": "git+https://git@github.com/keboola/dagre-d3.git#6b444d10ddb5276789b4b2bc1eafcd22a767968a",
     "deep-diff": "^0.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1828,9 +1828,9 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-csv-parse@0.0.9:
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-0.0.9.tgz#d0e2519c5ea4ed9c74efb6872747c6abe95ac090"
+csv-parse@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-3.0.0.tgz#2d592cf4bf7f3b1606900812df298a5bcc9f66e5"
 
 d3@~3.5.6:
   version "3.5.17"


### PR DESCRIPTION
Tady to je velký skok, na rozdíl od ostatních updatů bude potřeba asi nějaké testy.
Našel jsem použítí parse ve Storage, který nemám na localhostu a pak ještě na jednom místě, ale také se mi nepodařilo se k tomu nějak proklikat.

Upgrade 0.0.9 -> 3.0.0

Koukal jsem že *parse* se v aplikace používá bez nějakého dalšího nastavení. Takže asi základní funkcionalita, která snad bude furt stejná. Verze 0.0.9 zní jako hodně ranná, ani není v history na githubu. Takže nevím co vše se změnilo. 

Myslím, že by stálo za to prověřit zda vše funguje jak doposud. Nová verze bude asi o dost dál v parsování CSV v nějakých edge-case a bezpečnosti.