### PR TITLE
Tabs - remove unnecessary generateChildId props

### DIFF
--- a/src/scripts/modules/wr-google-drive/react/components/FileModal.jsx
+++ b/src/scripts/modules/wr-google-drive/react/components/FileModal.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <Tabs className="tabs-inside-modal" activeKey={step} animation={false} onSelect={() => {return true;}} generateChildId={true}>
+          <Tabs id="google-drive-file-modal-tabs" className="tabs-inside-modal" activeKey={step} animation={false} onSelect={() => {return true;}}>
             <Tab title="Source" eventKey={1} disabled={step !== 1}>
               <InputTab
                 mapping={this.localState(['mapping'], Map())}


### PR DESCRIPTION
GenerateChildId již není props u Tabs (nevím zda dříve bylo, ale asi jo).
Je teda potřeba id přidat ručně. Jinde v aplikaci již generateChildId není u Tabs a je tam také id.

https://react-bootstrap.github.io/components/tabs/#tabs-props-area

*Hlásilo to chyby v konzoli při testování toho react-radio-group, tak to rovnou opravuji.*