### PR TITLE
tde/auth-v2: fix default imports from coffee files

### DIFF
--- a/src/scripts/modules/tde-exporter/react/pages/Destination/Destination.coffee
+++ b/src/scripts/modules/tde-exporter/react/pages/Destination/Destination.coffee
@@ -14,7 +14,7 @@ SelectWriterModal = require('./WritersModal').default
 ActivateDeactivateButton = React.createFactory(require('../../../../../react/common/ActivateDeactivateButton').default)
 
 InstalledComponentsStore = require '../../../../components/stores/InstalledComponentsStore'
-OAuthStore = require '../../../../oauth-v2/Store'
+OAuthStore = require('../../../../oauth-v2/Store').default
 
 InstalledComponentsActions = require '../../../../components/InstalledComponentsActionCreators'
 ApplicationActionCreators = require '../../../../../actions/ApplicationActionCreators'

--- a/src/scripts/modules/tde-exporter/tdeRoutes.coffee
+++ b/src/scripts/modules/tde-exporter/tdeRoutes.coffee
@@ -11,8 +11,8 @@ LatestJobsStore = require '../jobs/stores/LatestJobsStore'
 installedComponentsActions = require '../components/InstalledComponentsActionCreators'
 oauthStore = require '../components/stores/OAuthStore'
 oauthActions = require '../components/OAuthActionCreators'
-oauth2Actions = require '../oauth-v2/ActionCreators'
-oauth2Store = require '../oauth-v2/Store'
+oauth2Actions = require('../oauth-v2/ActionCreators').default
+oauth2Store = require('../oauth-v2/Store').default
 {OAUTH_V2_WRITERS} = require './tdeCommon'
 
 InstalledComponentsStore = require '../components/stores/InstalledComponentsStore'


### PR DESCRIPTION
pri preklikavani TDE(Tableau) ui som zistil ze to pada na zlych importoch pri google drive autorizacii. Zrejme sa to dostalo z predchadzajuceho PR oauth-v2 coffee=>js https://github.com/keboola/kbc-ui/pull/1988 tak som pripravil fix

