### PR TITLE
Remove ssh tunnel option for ex-teradata 

### DIFF
--- a/src/scripts/modules/ex-db-generic/templates/hasSshTunnel.js
+++ b/src/scripts/modules/ex-db-generic/templates/hasSshTunnel.js
@@ -2,7 +2,8 @@
 // put it here:
 const componentsNotWithSsh = [
   'keboola.ex-db-snowflake',
-  'keboola.ex-db-firebird'
+  'keboola.ex-db-firebird',
+  'keboola.ex-teradata'
 ];
 
 export default function(componentId) {


### PR DESCRIPTION
Related to: https://github.com/keboola/ex-teradata/issues/21

Proposed changes:

- add ex-terradata to list of ex-db-generic components that do not support ssh tunnels
