### PR TITLE
[R4R] removes obsolete classname

### DIFF
--- a/src/scripts/modules/sapi-events/react/EventDetail.jsx
+++ b/src/scripts/modules/sapi-events/react/EventDetail.jsx
@@ -87,7 +87,7 @@ export default React.createClass({
       return this.props.backButton;
     }
     return (
-      <Link className="btn-back" {...this.props.link}>
+      <Link {...this.props.link}>
         <span className="fa fa-chevron-left"/> Back
       </Link>
     );


### PR DESCRIPTION
Kvuli teto uprave uz classa a styl neni potreba.
https://github.com/keboola/indigo-ui/blob/88c634b46b6416502f124797143180c05c6ab9ec/src/indigo/less/shame.less#L754

Pred cistkou
![image](https://user-images.githubusercontent.com/15363559/45416110-77b12500-b67f-11e8-9b79-a3454936db94.png)

Po cistce
![image](https://user-images.githubusercontent.com/15363559/45416123-7bdd4280-b67f-11e8-8af0-125051d412d3.png)

Souvisi s https://github.com/keboola/indigo-ui/pull/259

Na poradi nasazeni nezalezi.
