### PR TITLE
Simplify check for primary key

### DIFF
--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -295,8 +295,8 @@ export function createStore(componentId, configId) {
 
     prepareQueries(tables) {
       return tables.map((q) => {
-        let pk = q.get('primaryKey', null);
-        if (_.isEmpty(pk) || _.isString(pk)) {
+        let pk = q.get('primaryKey', List());
+        if (!List.isList(pk)) {
           pk = List();
         }
         return q.set('primaryKey', pk);


### PR DESCRIPTION
Fixes #2045

Proposed changes:

- do not call `_.isEmpty` on immutable

Actually we do not care if it's string or not - we care if it's proper immutable List. So imho one check is enough. If for some reason it is not immutable List we  just set it to empty List.

Also, I set default value to empt List.