### PR TITLE
table-selector markup

### DIFF
--- a/src/scripts/react/common/TableSelector.jsx
+++ b/src/scripts/react/common/TableSelector.jsx
@@ -6,7 +6,7 @@ import Immutable from 'immutable';
 import TableLink from '../../modules/components/react/components/StorageApiTableLinkEx';
 import TableSelectorInput from './TableSelectorInput';
 import StorageTablesStore from '../../modules/components/stores/StorageTablesStore';
-import Tooltip from './Tooltip';
+import {Button} from 'react-bootstrap';
 
 export default React.createClass({
 
@@ -47,18 +47,16 @@ export default React.createClass({
       return null;
     }
     return (
-      <Tooltip tooltip="Edit" placement="top">
-        <span className="kbc-icon-pencil"
-          onClick={this.props.onEdit}
-        />
-      </Tooltip>
+      <Button bsStyle="link" onClick={this.props.onEdit} title="Rename table">
+        <span className="kbc-icon-pencil"/>
+      </Button>
     );
   },
 
   render() {
     if (this.props.editing) {
       return (
-        <span className="kbc-table-selector kbc-table-selector-edit">
+        <span>
           <TableSelectorInput
             options={this.state.tables}
             onChange={this.onChange}
@@ -67,12 +65,11 @@ export default React.createClass({
             help={this.props.help}
             disabled={this.props.disabled}
           />
-
         </span>
       );
     } else {
       return (
-        <span className="kbc-table-selector kbc-table-selector-static">
+        <span>
           <TableLink tableId={this.props.value}>
             {this.props.value}
           </TableLink>

--- a/src/scripts/react/common/TableSelector.jsx
+++ b/src/scripts/react/common/TableSelector.jsx
@@ -43,11 +43,13 @@ export default React.createClass({
   },
 
   renderPencil() {
-    if (this.props.disabled) {
-      return null;
-    }
     return (
-      <Button bsStyle="link" onClick={this.props.onEdit} title="Rename table">
+      <Button
+        bsStyle="link"
+        onClick={this.props.onEdit}
+        title="Rename table"
+        disabled={this.props.disabled}
+      >
         <span className="kbc-icon-pencil"/>
       </Button>
     );


### PR DESCRIPTION
cistim dalsi custom styly.
Tohle slo snadno nastylovat bez custom class, cimz se zbavime dalsiho kusu custom css.

Vizualne se to lisi v paddingu, hover stylu a titlu (na hover) - viz screencast
Predtim mi to neprislo nejak vizualne promakany. To ted taky nebude. Pouziva to defaultni styly aplikace. Ale je to zvladnuty s min css a html.

Pred 
![tf1](https://user-images.githubusercontent.com/15363559/45691584-3c1fca80-bb59-11e8-8cf8-4508d3abf66a.gif)

Po
![tf2](https://user-images.githubusercontent.com/15363559/45691610-3fb35180-bb59-11e8-98c6-352896069555.gif)

Tahle zmena nepotrebuje zadny styly, takze po nasazeni tohoto muzeme mergnout vyhozeni stylu: https://github.com/keboola/indigo-ui/pull/268
