### PR TITLE
apify: fix saving editting crawler

### DIFF
--- a/src/scripts/modules/apify/react/Index/SetupModal.jsx
+++ b/src/scripts/modules/apify/react/Index/SetupModal.jsx
@@ -66,7 +66,14 @@ export default React.createClass({
     const action = this.getAction();
     if (action === 'crawler') {
       const crawlerId = paramsToSave.get('crawlerId');
-      const crawler = this.localState(['crawlers', 'data']).find((c) => c.get('id') === crawlerId);
+      const savedCrawlerList = fromJS([{
+        id: crawlerId,
+        settingsLink: paramsToSave.get('settingsLink'),
+        customId: paramsToSave.get('customId')
+      }]);
+      const crawler = this
+        .localState(['crawlers', 'data'], savedCrawlerList)
+        .find((c) => c.get('id') === crawlerId);
       paramsToSave = Map({
         crawlerId: paramsToSave.get('crawlerId'),
         customId: crawler.get('customId'),


### PR DESCRIPTION
Pri ukladani rozeditovaneho crawleru to spadlo natom ze nebol nacitany zoznam crawlerov z api a tym padom pripraveny objekt crawleru na ulozenie. Na nacitanie zoznamu sa musi preklikat na posledny tab(specification). Fix spociva v tom ze sa pri ukladani rozeditovaneho crawleru pripravi zoznam crawlerov s uloznym crawlerom a ten sa pouzije ako default ak zoznam nacitany z api neexistuje.
Fixes #2052 

 note: omylom som to pushol do mastru a potom revertol takze tento PR obsahuje revert revertu toho commitu :)
