### PR TITLE
Orchestrations - PropTypes

### DIFF
--- a/src/scripts/modules/orchestrations/react/components/OrchestrationTaskRunButton.jsx
+++ b/src/scripts/modules/orchestrations/react/components/OrchestrationTaskRunButton.jsx
@@ -7,8 +7,7 @@ export default React.createClass({
     task: React.PropTypes.object.isRequired,
     notify: React.PropTypes.bool,
     tooltipPlacement: React.PropTypes.string,
-    onRun: React.PropTypes.func.isRequired,
-    buttonStyle: React.PropTypes.object.isRequired
+    onRun: React.PropTypes.func.isRequired
   },
 
   getDefaultProps() {

--- a/src/scripts/modules/orchestrations/react/modals/MoveTasksModal.jsx
+++ b/src/scripts/modules/orchestrations/react/modals/MoveTasksModal.jsx
@@ -64,6 +64,7 @@ export default React.createClass({
         <Modal.Footer>
           <ConfirmButtons
             saveLabel="Move"
+            isSaving={false}
             isDisabled={!this.isValid()}
             onCancel={this.closeModal}
             onSave={this.handleSave}

--- a/src/scripts/modules/orchestrations/react/modals/Phase.jsx
+++ b/src/scripts/modules/orchestrations/react/modals/Phase.jsx
@@ -6,7 +6,7 @@ import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 export default React.createClass({
   mixins: [PureRenderMixin],
   propTypes: {
-    phaseId: PropTypes.object.isRequired,
+    phaseId: PropTypes.string,
     existingIds: PropTypes.object.isRequired,
     onPhaseUpdate: React.PropTypes.func.isRequired,
     onHide: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/orchestrations/react/modals/RunOrchestration.coffee
+++ b/src/scripts/modules/orchestrations/react/modals/RunOrchestration.coffee
@@ -68,6 +68,7 @@ module.exports = React.createClass
 
         ModalFooter null,
           React.createElement ConfirmButtons,
+            isSaving: false
             isDisabled: !@_isValid()
             saveLabel: 'Run'
             onCancel: @_handleCancel

--- a/src/scripts/modules/orchestrations/react/modals/Schedule.coffee
+++ b/src/scripts/modules/orchestrations/react/modals/Schedule.coffee
@@ -19,7 +19,7 @@ module.exports = React.createClass
   displayName: 'Schedule'
   propTypes:
     orchestrationId: React.PropTypes.number.isRequired
-    crontabRecord: React.PropTypes.string.isRequired
+    crontabRecord: React.PropTypes.string
 
   getInitialState: ->
     crontabRecord: @props.crontabRecord || '0 0 * * *'

--- a/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.coffee
+++ b/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.coffee
@@ -105,7 +105,6 @@ TaskParametersEdit = React.createClass
 
   _handleSet: ->
     @close()
-    if @props.isEditable
-      @props.onSet @state.parameters
+    @props.onSet @state.parameters
 
 module.exports = TaskParametersEdit

--- a/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.coffee
+++ b/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.coffee
@@ -18,7 +18,8 @@ TaskParametersEdit = React.createClass
   displayName: 'TaskParametersEdit'
   propTypes:
     parameters: React.PropTypes.object.isRequired
-    onSet: React.PropTypes.func.isRequired
+    onSet: React.PropTypes.func
+    isEditable: React.PropTypes.bool
 
   getInitialState: ->
     parameters: @props.parameters
@@ -104,6 +105,7 @@ TaskParametersEdit = React.createClass
 
   _handleSet: ->
     @close()
-    @props.onSet @state.parameters
+    if @props.isEditable
+      @props.onSet @state.parameters
 
 module.exports = TaskParametersEdit

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.coffee
@@ -54,7 +54,6 @@ module.exports = React.createClass
       td null,
         div className: 'pull-right',
           TaskParametersEditModal
-            onSet: @_handleParametersChange
             isEditable: false
             parameters: @props.task.get('actionParameters').toJS()
 

--- a/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationRow.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationRow.coffee
@@ -26,13 +26,13 @@ OrchestrationRow = React.createClass(
 
     buttons.push(OrchestrationDeleteButton(
       orchestration: @props.orchestration
-      isPending: @props.pendingActions.get 'delete'
+      isPending: @props.pendingActions.get 'delete', false
       key: 'delete'
     ))
 
     buttons.push(OrchestrationActiveButton(
       orchestration: @props.orchestration
-      isPending: @props.pendingActions.get 'active'
+      isPending: @props.pendingActions.get 'active', false
       key: 'activate'
     ))
 


### PR DESCRIPTION
Úprava či doplnění PropTypes. 

**OrchestrationDeleteButton** a **OrchestrationActiveButton** mají povinný prop _isPending_ - doplnění false

**Schedule** vypadá že _crontabRecord_ má default variantu "0 0 * * *", ale je required. Což hází warning když se tam nepošle.

**ConfirmButtons** má povinný props _isSaving_ , u těch modalů vypadá že se zavírájí po kliku tak jsem doplnil napevno false.

**Phase** mělo povinný props _phaseId_ . Zaprvé je definovaný jako object, ale posílá se tam asi jen string. Ten modal se vykresluje i když žádná "phase" není vytvořena. Tak _phaseId_ je null, hází to warning. Nevím zda teda vyhodit required nebo modal vykreslelovat, až když _phaseId_  máme. 