### PR TITLE
facebook/instagram/ads ex: suggest to use v3.1 as the latest fb api version

### DIFF
--- a/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import {Modal} from 'react-bootstrap';
+import {Modal, FormControl, FormGroup, ControlLabel, Form, Col} from 'react-bootstrap';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 
 export default React.createClass({
@@ -36,27 +36,37 @@ export default React.createClass({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <div className="form form-horizontal">
-            <div className="form-group">
-              <div className="col-sm-offset-1 col-sm-9">
-                <p>
-                  Facebook has its own specific platform {' '}
-                  <a
-                    href="https://developers.facebook.com/docs/apps/versions"
-                    target="_blank">versioning</a>. If you change the api version some api calls specified in queries may not work resulting in error, or no data as well as data with different columns might be retrieved. To review the api changes see <a href="https://developers.facebook.com/docs/apps/changelog" target="_blank"> changelog </a>. The most recent api version is {this.props.defaultVersion}.
-                </p>
-                <p>
-                Api Version <input
-                    id="version"
-                    type="text"
-                    className="form-control"
-                    value={value}
-                    onChange={this.handleVersionChange}
-                    style={{width: '100px', display: 'inline-block'}}/>
-                </p>
-              </div>
-            </div>
-          </div>
+          <p>
+            Facebook has its own specific platform {' '}
+            <a href="https://developers.facebook.com/docs/apps/versions" target="_blank">versioning</a>.
+            If you change the api version some api calls specified in queries may not work resulting in error,
+            or no data as well as data with different columns might be retrieved. To review the api changes
+            see <a href="https://developers.facebook.com/docs/apps/changelog" target="_blank">changelog</a>.
+            The most recent api version is {this.props.defaultVersion}.
+          </p>
+          <Form
+            horizontal
+            onSubmit={(e) => {
+              e.preventDefault();
+              this.handleSave();
+            }}
+          >
+            <FormGroup
+              controlId="facebook-api-version"
+            >
+              <Col componentClass={ControlLabel} sm={3}>
+                Api Version
+              </Col>
+              <Col sm={3}>
+                <FormControl
+                  type="text"
+                  value={value}
+                  onChange={this.handleVersionChange}
+                  size={8}
+                />
+              </Col>
+            </FormGroup>
+          </Form>
         </Modal.Body>
         <Modal.Footer>
           <ConfirmButtons

--- a/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import {Modal, FormControl, FormGroup, ControlLabel, Form, Col} from 'react-bootstrap';
+import { ExternalLink } from '@keboola/indigo-ui';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 
 export default React.createClass({
@@ -38,10 +39,10 @@ export default React.createClass({
         <Modal.Body>
           <p>
             Facebook has its own specific platform {' '}
-            <a href="https://developers.facebook.com/docs/apps/versions" target="_blank">versioning</a>.
+            <ExternalLink hree="https://developers.facebook.com/docs/apps/versions">versioning</ExternalLink>.
             If you change the api version some api calls specified in queries may not work resulting in error,
             or no data as well as data with different columns might be retrieved. To review the api changes
-            see <a href="https://developers.facebook.com/docs/apps/changelog" target="_blank">changelog</a>.
+            see <ExternalLink href="https://developers.facebook.com/docs/apps/changelog">changelog</ExternalLink>.
             The most recent api version is {this.props.defaultVersion}.
           </p>
           <Form

--- a/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/ApiVersionModal.jsx
@@ -63,6 +63,7 @@ export default React.createClass({
                   value={value}
                   onChange={this.handleVersionChange}
                   size={8}
+                  autoFocus
                 />
               </Col>
             </FormGroup>

--- a/src/scripts/modules/ex-facebook/storeProvisioning.js
+++ b/src/scripts/modules/ex-facebook/storeProvisioning.js
@@ -7,9 +7,9 @@ import OauthStore from '../oauth-v2/Store';
 export const storeMixins = [InstalledComponentStore, OauthStore];
 
 const DEFAULT_VERSIONS_MAP = {
-  'keboola.ex-instagram': 'v2.12',
-  'keboola.ex-facebook-ads': 'v2.12',
-  'keboola.ex-facebook': 'v2.12'
+  'keboola.ex-instagram': 'v3.1',
+  'keboola.ex-facebook-ads': 'v3.1',
+  'keboola.ex-facebook': 'v3.1'
 };
 
 const DEFAULT_BACKEND_VERSION = 'v2.12';


### PR DESCRIPTION
Mala uprava verzie fb api na `v3.1` ktoru ui ukazuje a doporucuje ako najnovsiu verziu fb api

![image](https://user-images.githubusercontent.com/1412120/45900804-173d8880-bde1-11e8-8daf-56dbb80bd809.png)


