### PR TITLE
React-Select - fix warning about props name

### DIFF
--- a/src/scripts/modules/components/react/components/SapiTableSelector.coffee
+++ b/src/scripts/modules/components/react/components/SapiTableSelector.coffee
@@ -48,7 +48,7 @@ module.exports = React.createClass
       disabled: @props.disabled
       name: 'source'
       clearable: @props.clearable
-      autofocus: @props.autoFocus
+      autoFocus: @props.autoFocus
       value: @props.value
       isLoading: @state.isTablesLoading
       placeholder: @props.placeholder

--- a/src/scripts/modules/components/react/components/generic/FileInputMappingEditor.coffee
+++ b/src/scripts/modules/components/react/components/generic/FileInputMappingEditor.coffee
@@ -73,7 +73,7 @@ module.exports = React.createClass
             SelectCreatable
               options: []
               name: 'tags'
-              autofocus: true
+              autoFocus: true
               value: @_getTags()
               disabled: @props.disabled
               placeholder: "Add tags"

--- a/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
+++ b/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
@@ -47,7 +47,7 @@ export default React.createClass({
               placeholder="Source table"
               onChange={this.handleChangeSource}
               options={this.getTables()}
-              autofocus
+              autoFocus
             />
             <span className="help-block">
               Select source table from Storage

--- a/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
+++ b/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
@@ -47,7 +47,7 @@ export default React.createClass({
               placeholder="Source table"
               onChange={this.handleChangeSource}
               options={this.getTables()}
-              autofocus
+              autoFocus
             />
             <span className="help-block">
               Select source table from Storage


### PR DESCRIPTION
**fix warning**
*The autofocus prop has changed to autoFocus, support will be removed after react-select@1.0*

