### PR TITLE
Upgrade react-textarea-autosize

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-remarkable": "^1.1.1",
     "react-router": "~0.13.3",
     "react-select": "^1.2.1",
-    "react-textarea-autosize": "^2.3.1",
+    "react-textarea-autosize": "^7.0.0",
     "remarkable": "^1.6.2",
     "remove-markdown": "^0.1.0",
     "sortablejs": "^1.7.0",

--- a/src/scripts/react/common/InlineEditArea.coffee
+++ b/src/scripts/react/common/InlineEditArea.coffee
@@ -5,7 +5,7 @@ _ = require 'underscore'
 Button = React.createFactory(require('react-bootstrap').Button)
 {Loader} = require('@keboola/indigo-ui')
 Markdown = React.createFactory(require('./Markdown').default)
-Textarea = require 'react-textarea-autosize'
+Textarea = React.createFactory(require('react-textarea-autosize').default)
 
 {div, span, textarea, button, a} = React.DOM
 
@@ -67,19 +67,16 @@ EditArea = React.createFactory React.createClass
   _onChange: (e) ->
     @props.onChange e.target.value
 
-  componentDidMount: ->
-    @refs.textArea.focus()
-
   render: ->
     div className: 'form-inline kbc-inline-edit kbc-inline-textarea',
-      React.createElement Textarea,
-        ref: 'textArea'
+      Textarea
+        autoFocus: true
         value: @props.text
         disabled: @props.isSaving
         placeholder: @props.placeholder
         onChange: @_onChange
         className: 'form-control'
-        rows: 2
+        minRows: 2
       span className: 'kbc-inline-edit-buttons',
         if @props.isSaving
           span null,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6557,7 +6557,7 @@ prop-types@^15.5.8:
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-prop-types@^15.6.1, prop-types@^15.6.2:
+prop-types@^15.6.0, prop-types@^15.6.1, prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   dependencies:
@@ -6905,9 +6905,11 @@ react-side-effect@^0.3.2:
   dependencies:
     fbjs "0.1.0-alpha.10"
 
-react-textarea-autosize@^2.3.1:
-  version "2.5.4"
-  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-2.5.4.tgz#8c7466a23100dc6e71db224e666f971b389cd26a"
+react-textarea-autosize@^7.0.0:
+  version "7.0.4"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-7.0.4.tgz#4e4be649b544a88713e7b5043f76950f35d3d503"
+  dependencies:
+    prop-types "^15.6.0"
 
 react-themeable@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Fixes #2085

**Fixed warning**
*React.findDOMNode is deprecated. Please use ReactDOM.findDOMNode from require('react-dom') instead.*

**Navíc**
Použití props autoFocus místo využití refs. 
Použití preferované minRows props místo rows.