### PR TITLE
Fix orchestration deletion (use div instead of p)

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationsIndex.coffee
+++ b/src/scripts/modules/orchestrations/react/pages/orchestrations-index/OrchestrationsIndex.coffee
@@ -50,7 +50,7 @@ Index = React.createClass
     div className: 'row',
       h2 null,
         'Orchestrations allow you to group together related tasks and schedule their execution.'
-      p null,
+      div null,
         React.createElement NewOrchestrationButton
 
   _renderNotFound: ->


### PR DESCRIPTION
Fixes #2096 

Proposed changes:

- replaces p with div to avoid warning and wrong nesting (which caused app error)