### PR TITLE
QueryNav - remove kbc-container class

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryNav.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryNav.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
 
   render() {
     return (
-      <div className="kbc-container">
+      <div>
         <div className="layout-master-detail-search">
           <SearchBar query={this.props.filter} onChange={this.handleFilterChange} />
         </div>

--- a/src/scripts/modules/ex-google-analytics-v4/react/QueryDetail/QueryNav.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/QueryDetail/QueryNav.jsx
@@ -13,7 +13,7 @@ export default React.createClass({
   },
   render() {
     return (
-      <div className="kbc-container">
+      <div>
         <div className="layout-master-detail-search">
           <SearchBar
             query={this.props.filter}

--- a/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryNav.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryNav.jsx
@@ -13,7 +13,7 @@ export default React.createClass({
   },
   render() {
     return (
-      <div className="kbc-container">
+      <div>
         <div className="layout-master-detail-search">
           <SearchBar
             query={this.props.filter}

--- a/src/scripts/modules/ex-mongodb/react/pages/query-detail/QueryNav.jsx
+++ b/src/scripts/modules/ex-mongodb/react/pages/query-detail/QueryNav.jsx
@@ -19,7 +19,7 @@ export default React.createClass({
 
   render() {
     return (
-      <div className="kbc-container">
+      <div>
         <div className="layout-master-detail-search">
           <SearchBar query={this.props.filter} onChange={this.handleFilterChange} />
         </div>


### PR DESCRIPTION
Query komponenty jsou použity jako chilldren divu, kde je tato třída již použita.
Je tam teda duplicitní. Nemá to žádný vliv na funkčnost jelikož ta třídy je stylována stylem parent > kbc-container. Ale to tak nemusí být vždy. 

PS: řeším nějaké CSS a toho jsem si všimnul navíc, může to předejít nějakým problémům v budoucnu 