### PR TITLE
Allow submit "version copy" form without writing name

### DIFF
--- a/src/scripts/modules/components/react/pages/Versions.jsx
+++ b/src/scripts/modules/components/react/pages/Versions.jsx
@@ -94,8 +94,8 @@ export default function(componentIdValue, configIdParam = 'config', readOnlyMode
             onPrepareVersionsDiffData={() => this.prepareVersionsDiffData(version, previousVersion)}
             isLast={allVersions.first().get('version') === version.get('version')}
             onChangeName={(name) => VersionsActionCreators.changeNewVersionName(this.state.componentId, this.state.configId, version.get('version'), name)}
-            onCopy={createVersionOnCopy(this.state.componentId, this.state.configId, version.get('version'), this.state.newVersionNames.get(version.get('version')))}
-            onRollback={createVersionOnRollback(this.state.componentId, this.state.configId, version.get('version'))}
+            onCopy={createVersionOnCopy(this.state.componentId, this.state.configId, version, this.state.newVersionNames.get(version.get('version')))}
+            onRollback={createVersionOnRollback(this.state.componentId, this.state.configId, version)}
           />
         );
       }, this).toArray();

--- a/src/scripts/react/common/CopyVersionModal.jsx
+++ b/src/scripts/react/common/CopyVersionModal.jsx
@@ -4,6 +4,7 @@ import {Modal} from 'react-bootstrap';
 import moment from 'moment';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import ConfirmButtons from './ConfirmButtons';
+import defaultCopyVersionName from '../../utils/defaultCopyVersionName';
 
 export default React.createClass({
   mixins: [ImmutableRenderMixin],
@@ -37,6 +38,7 @@ export default React.createClass({
               label="New configuration name"
               labelClassName="col-xs-5"
               wrapperClassName="col-xs-7"
+              placeholder={defaultCopyVersionName(this.props.version)}
               value={this.props.newVersionName}
               onChange={this.onChange}
               autoFocus={true}
@@ -46,7 +48,6 @@ export default React.createClass({
         <Modal.Footer>
           <ConfirmButtons
             isSaving={false}
-            isDisabled={!this.isValid()}
             cancelLabel="Cancel"
             saveLabel="Copy"
             saveStyle="success"
@@ -60,14 +61,8 @@ export default React.createClass({
     );
   },
 
-  isValid() {
-    return !(this.props.newVersionName === '' || !this.props.newVersionName);
-  },
-
   handleSubmit(e) {
     e.preventDefault();
-    if (this.isValid()) {
-      this.props.onCopy();
-    }
+    this.props.onCopy();
   }
 });

--- a/src/scripts/utils/createVersionOnCopy.js
+++ b/src/scripts/utils/createVersionOnCopy.js
@@ -1,16 +1,19 @@
 import VersionsActionCreators from '../modules/components/VersionsActionCreators';
 import InstalledComponentsActionCreators from '../modules/components/InstalledComponentsActionCreators';
+import defaultCopyVersionName from './defaultCopyVersionName';
 
-export default function(componentId, configId, version, name) {
-  return function() {
-    var reloadCallback = function(component) {
-      var promises = [];
+export default (componentId, configId, version, name) => {
+  return () => {
+    const versionId = version.get('version');
+    const versionName = name || defaultCopyVersionName(version);
+    const reloadCallback = (component) => {
+      const promises = [];
       if (componentId === 'transformation') {
         promises.push(InstalledComponentsActionCreators.loadComponentConfigsData(component));
       }
       promises.push(InstalledComponentsActionCreators.loadComponentsForce());
       return promises;
     };
-    VersionsActionCreators.copyVersion(componentId, configId, version, name, reloadCallback);
+    VersionsActionCreators.copyVersion(componentId, configId, versionId, versionName, reloadCallback);
   };
-}
+};

--- a/src/scripts/utils/createVersionOnRollback.js
+++ b/src/scripts/utils/createVersionOnRollback.js
@@ -1,10 +1,11 @@
 import VersionsActionCreators from '../modules/components/VersionsActionCreators';
 import InstalledComponentsActionCreators from '../modules/components/InstalledComponentsActionCreators';
 
-export default function(componentId, configId, versionId) {
-  return function() {
-    var reloadCallback = function(component, config) {
-      var promises = [];
+export default (componentId, configId, version) => {
+  return () => {
+    const versionId = version.get('version');
+    const reloadCallback = (component, config) => {
+      const promises = [];
       if (componentId === 'transformation') {
         promises.push(InstalledComponentsActionCreators.loadComponentConfigsData(component));
       }
@@ -13,4 +14,4 @@ export default function(componentId, configId, versionId) {
     };
     VersionsActionCreators.rollbackVersion(componentId, configId, versionId, reloadCallback);
   };
-}
+};

--- a/src/scripts/utils/defaultCopyVersionName.js
+++ b/src/scripts/utils/defaultCopyVersionName.js
@@ -1,0 +1,2 @@
+
+export default (version) => `${version.get('name')} (Copy)`;


### PR DESCRIPTION
Fixes #2070

S tímto si teda vůbec nejsem jistý. Zkoušel jsem to vyřešit pouze v komponentě CopyVersionModal, ale nebylo to ono. Musel bych tam mít state, nebo bych musel upravovat globální state a nastavovat zda jsem default name už jednou nastavit (abych to nedělal furt dokola když to člověk vymaže).

Nakonec mi jako nejvýhodnější přišla tato úprava.
Možnost odeslat formulář bez vyplněného jména. Kde se použije ten "placeholder" tam (což si právě nejsem jistý zda je v pořádku). Ta logika pak šla do "createVersionOnCopy". Musel jsem upravit trošku api té funkce. Úplně stejně jsem upravil "createVersionOnRollback" kde to nemá žádný jiný význam, než jen aby to bylo shodné s tím prvním.