### PR TITLE
Events - initial events check 

### DIFF
--- a/src/scripts/modules/sapi-events/EventsService.js
+++ b/src/scripts/modules/sapi-events/EventsService.js
@@ -186,6 +186,9 @@ class EventsService {
   _setEvents(events) {
     this._isLoading = false;
     this._events = this._convertEvents(events);
+    if (events.length < this._limit) {
+      this._hasMore = false;
+    }
     return this._emitChange();
   }
 


### PR DESCRIPTION
Furt může nastat situace kdy počet událostí = limit. Pak tam tlačítko bude ikdyž po kliku nenačtě nic navíc. 
Toto upravuje alespoň veškeré situace, kdy hned při úvodním načtení mám méně eventů jako je limit. Pak tlačítko "Load more" nezobrazím hned.