### PR TITLE
NotificationAccess - add class to better access in CSS

### DIFF
--- a/src/scripts/react/common/NotificationsAccess.jsx
+++ b/src/scripts/react/common/NotificationsAccess.jsx
@@ -7,7 +7,7 @@ export default React.createClass({
 
   render() {
     return (
-      <a href={this.props.notifications.get('url')}>
+      <a href={this.props.notifications.get('url')} className="kbc-notification-access">
         <span className="kbc-notification-icon fa fa-bell">
           {this.badge()}
         </span>


### PR DESCRIPTION
related #2099

V současné době je to stylované typem "parent > a". U budoucího mobilního sidebaru to je ještě "horší": "parent > a:nth-child(2)" nebo "parent > a:not(.menu-toggle)", protože tam je nově Toggle button. Takto to budu moci stylovat pomocí názvu třídy.