### PR TITLE
orchestrations - check failed tasks with phases on job retry

### DIFF
--- a/src/scripts/modules/orchestrations/react/components/JobRetryButton.coffee
+++ b/src/scripts/modules/orchestrations/react/components/JobRetryButton.coffee
@@ -72,11 +72,13 @@ module.exports = React.createClass
   reactivateJobTasks: ->
     enabledTaskStatuses = @props.job.getIn(['results', 'tasks'], List()).filter((task) -> task.get('active'))
     jobSucceeded = @props.job.get('status') == 'success'
-    isFirstError = true
+    failedPhaseId = null
     enabledTaskStatuses.forEach((task) =>
-      if (task.get('status') != 'success')
-        isFirstError = false
-      @_handleTaskChange(task.set('active', jobSucceeded or !isFirstError))
+      isTaskFailed = task.get('status') != 'success'
+      if (isTaskFailed and !failedPhaseId)
+        failedPhaseId = task.get('phase')
+      previouslyFailed = failedPhaseId and failedPhaseId != task.get('phase')
+      @_handleTaskChange(task.set('active', jobSucceeded or isTaskFailed or previouslyFailed))
     )
 
   _handleRetrySelectStart: ->


### PR DESCRIPTION
vyplynulo z debaty v https://github.com/keboola/kbc-ui/pull/1968#issuecomment-429528304

Tyka sa retry modalu orchestracneho jobu. Zaskrtne task len ak:
- cela orchestracia bola success
- alebo task bol failed
- alebo ak task patri do nasledujucej fazi po failnutom jobe
