### PR TITLE
Development - WebWorkers -  window is not defined

### DIFF
--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -65,12 +65,15 @@ module.exports = function(options) {
     mode: isDevelopment ? 'development' : 'production',
     devtool: isDevelopment ? 'eval' : 'source-map',
     entry: entry,
-    output: {
-      path: path.resolve(__dirname, isDevelopment ? '../dist' : '../dist/' + process.env.KBC_REVISION),
-      filename: isDevelopment ? '[name].js' : '[name].min.js',
-      publicPath: isDevelopment ? '/scripts/' : '',
-      library: 'kbcApp'
-    },
+    output: Object.assign(
+      {
+        path: path.resolve(__dirname, isDevelopment ? '../dist' : '../dist/' + process.env.KBC_REVISION),
+        filename: isDevelopment ? '[name].js' : '[name].min.js',
+        publicPath: isDevelopment ? '/scripts/' : '',
+        library: 'kbcApp'
+      },
+      isDevelopment ? { globalObject: 'this' } : {}
+    ),
     plugins: plugins,
     resolve: {
       extensions: ['*', '.js', '.jsx', '.coffee']


### PR DESCRIPTION
Dostával jsem při vývoji chybu: `window is not defined`. Která se odehrávala při parsování SQL queries na jednotlivé query. Díky tomu jsem to tam začal celé přepisovat, ale to je jedno. Zase jsem to vrátil.

Vypadá to na nějaký bug ve Webpacku 4. [Toto](https://github.com/webpack/webpack/issues/6525) by mělo pomoci ale zatím to není v produkci.

[Tady](https://github.com/webpack/webpack/issues/6642) issue na stejné téma. Použil jsem ten jejich fix: `output.globalObject: "this"`. V produkci vypadá, že je vše OK takže jsem to přihodil do konfigu pouze pro vývoj.