### PR TITLE
Force load installed component data after create new Orchestration

### DIFF
--- a/src/scripts/modules/orchestrations/ActionCreators.js
+++ b/src/scripts/modules/orchestrations/ActionCreators.js
@@ -13,6 +13,7 @@ import OrchestrationJobsStore from './stores/OrchestrationJobsStore';
 import Promise from 'bluebird';
 import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 import VersionsActionCreators from '../components/VersionsActionCreators';
+import InstalledComponentsActionCreators from '../components/InstalledComponentsActionCreators';
 
 const rephaseTasks = tasks => {
   const isNullPhase = phase => phase === null || phase === 0 || typeof phase === 'undefined';
@@ -187,13 +188,20 @@ export default {
   },
 
   createOrchestration(data) {
-    return orchestrationsApi.createOrchestration(data).then(newOrchestration => {
-      dispatcher.handleViewAction({
-        type: constants.ActionTypes.ORCHESTRATION_CREATE_SUCCESS,
-        orchestration: newOrchestration
+    let newOrchestration = {};
+    return orchestrationsApi
+      .createOrchestration(data)
+      .then(orchestration => {
+        newOrchestration = orchestration;
+        return InstalledComponentsActionCreators.loadInstalledComponentsForce();
+      })
+      .then(() => {
+        dispatcher.handleViewAction({
+          type: constants.ActionTypes.ORCHESTRATION_CREATE_SUCCESS,
+          orchestration: newOrchestration
+        });
+        return RoutesStore.getRouter().transitionTo('orchestration', { orchestrationId: newOrchestration.id });
       });
-      return RoutesStore.getRouter().transitionTo('orchestration', { orchestrationId: newOrchestration.id });
-    });
   },
 
   /*


### PR DESCRIPTION
Fixes #2174

Tady jsem se inspiroval u Transformations, tam když se vytvoří nový bucket zavolá se: `InstalledComponentsActionCreators.loadComponentsForce()` . Když jsem to samé udělal u Orchestrations, tak to fungovalo. Zkusil jsem upravit volání na: `InstalledComponentsActionCreators.loadInstalledComponentsForce()` kde se nevolá něco o smazaných komponentách, takže o volání méně a taky funguje. Ještě jsem zkoušel zavolat update jen pro jednu danou komponentu: `InstalledComponentsActionCreators.loadComponentConfigDataForce` ale toto mi už nefungovalo. Nevím proč.

Pokud to je lgtm úprava. Tak nevím zda může jít ta kontrola u editování pryč (zda existuje config), je možný že takto tam již bude vždy.