### PR TITLE
Orchestration - Detail - Tasks summary

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/OrchestrationDetail.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/OrchestrationDetail.jsx
@@ -8,8 +8,6 @@ import OrchestrationStore from '../../../stores/OrchestrationsStore';
 import OrchestrationJobsStore from '../../../stores/OrchestrationJobsStore';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import VersionsStore from '../../../../components/stores/VersionsStore';
-import InstalledComponentsStore from '../../../../components/stores/InstalledComponentsStore';
-import mergeTasksWithConfigurations from '../../../mergeTasksWithConfigruations';
 
 // React components
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
@@ -33,11 +31,10 @@ export default React.createClass({
     const versions = VersionsStore.getVersions('orchestrator', orchestrationId.toString());
     let tasks = List();
     phases.forEach(phase => (tasks = tasks.concat(phase.get('tasks'))));
-    const tasksWithConfig = mergeTasksWithConfigurations(tasks, InstalledComponentsStore.getAll(), true);
 
     return {
       orchestration: OrchestrationStore.get(orchestrationId),
-      tasks: tasksWithConfig,
+      tasks,
       isLoading: OrchestrationStore.getIsOrchestrationLoading(orchestrationId),
       filteredOrchestrations: OrchestrationStore.getFiltered(),
       filter: OrchestrationStore.getFilter(),

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/OrchestrationDetail.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/OrchestrationDetail.jsx
@@ -8,6 +8,8 @@ import OrchestrationStore from '../../../stores/OrchestrationsStore';
 import OrchestrationJobsStore from '../../../stores/OrchestrationJobsStore';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import VersionsStore from '../../../../components/stores/VersionsStore';
+import InstalledComponentsStore from '../../../../components/stores/InstalledComponentsStore';
+import mergeTasksWithConfigurations from '../../../mergeTasksWithConfigruations';
 
 // React components
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
@@ -31,10 +33,11 @@ export default React.createClass({
     const versions = VersionsStore.getVersions('orchestrator', orchestrationId.toString());
     let tasks = List();
     phases.forEach(phase => (tasks = tasks.concat(phase.get('tasks'))));
+    const tasksWithConfig = mergeTasksWithConfigurations(tasks, InstalledComponentsStore.getAll(), true);
 
     return {
       orchestration: OrchestrationStore.get(orchestrationId),
-      tasks,
+      tasks: tasksWithConfig,
       isLoading: OrchestrationStore.getIsOrchestrationLoading(orchestrationId),
       filteredOrchestrations: OrchestrationStore.getFiltered(),
       filter: OrchestrationStore.getFilter(),

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
@@ -20,11 +20,12 @@ export default React.createClass({
         ) : (
           <span>
             {this.props.tasks
+              .filter(task => task.getIn(['config', 'name'], false))
               .take(this.props.tasksCount)
               .map((task, index, tasks) => {
                 return (
                   <span key={task.get('id')}>
-                    {task.getIn(['config', 'name'], 'N/A')}
+                    {task.getIn(['config', 'name'])}
                     {index === tasks.size - 2 && !hasMoreTasks && ' and '}
                     {(index < tasks.size - 2 || (index === tasks.size - 2 && hasMoreTasks)) && ', '}
                   </span>

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
@@ -2,41 +2,32 @@ import React from 'react';
 
 export default React.createClass({
   propTypes: {
-    tasks: React.PropTypes.object.isRequired,
-    tasksCount: React.PropTypes.number
-  },
-
-  getDefaultProps() {
-    return { tasksCount: 3 };
+    tasks: React.PropTypes.object.isRequired
   },
 
   render() {
-    const hasMoreTasks = this.props.tasks.size > this.props.tasksCount;
-
+    if (this.props.tasks.size === 0) {
+      return (
+        <span>Orchestration has no assigned tasks</span>
+      );
+    }
     return (
       <span>
-        {this.props.tasks.size === 0 ? (
-          'Orchestration has no assigned tasks'
-        ) : (
-          <span>
-            {this.props.tasks
-              .filter(task => task.getIn(['config', 'name'], false))
-              .take(this.props.tasksCount)
-              .map((task, index, tasks) => {
-                return (
-                  <span key={task.get('id')}>
-                    {task.getIn(['config', 'name'])}
-                    {index === tasks.size - 2 && !hasMoreTasks && ' and '}
-                    {(index < tasks.size - 2 || (index === tasks.size - 2 && hasMoreTasks)) && ', '}
-                  </span>
-                );
-              })
-              .toArray()}
-            {hasMoreTasks &&
-              ` and ${this.props.tasks.size - this.props.tasksCount}` + String.fromCharCode(160) + 'more'}
-          </span>
-        )}
+        {this.renderCount(this.props.tasks.size, 'task')}
+        {' in '}
+        {this.renderCount(this.props.tasks.groupBy((task) => (task.get('phase'))).size, 'phase')}
       </span>
+    );
+  },
+
+  renderCount(count, name) {
+    if (count === 1) {
+      return (
+        <span>{count} {name}</span>
+      );
+    }
+    return (
+      <span>{count} {name}s</span>
     );
   }
 });

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import ComponentsStore from '../../../../components/stores/ComponentsStore';
-import ComponentName from '../../../../../react/common/ComponentName';
 
 export default React.createClass({
   propTypes: {
@@ -12,16 +10,12 @@ export default React.createClass({
     return { tasksCount: 3 };
   },
 
-  getInitialState() {
-    return { components: ComponentsStore.getAll() };
-  },
-
   render() {
     const hasMoreTasks = this.props.tasks.size > this.props.tasksCount;
 
     return (
       <span>
-        {this.props.tasks.size === 0 ? (
+        {this.props.tasks.count() === 0 ? (
           'Orchestration has no assigned tasks'
         ) : (
           <span>
@@ -30,11 +24,7 @@ export default React.createClass({
               .map((task, index, tasks) => {
                 return (
                   <span key={task.get('id')}>
-                    {this.state.components.get(task.get('component')) ? (
-                      <ComponentName component={this.state.components.get(task.get('component'))} />
-                    ) : (
-                      <span>{task.get('componentUrl') ? task.get('componentUrl') : task.get('component')}</span>
-                    )}
+                    {task.getIn(['config', 'name'], 'N/A')}
                     {index === tasks.size - 2 && !hasMoreTasks && ' and '}
                     {(index < tasks.size - 2 || (index === tasks.size - 2 && hasMoreTasks)) && ', '}
                   </span>

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-detail/TasksSummary.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
 
     return (
       <span>
-        {this.props.tasks.count() === 0 ? (
+        {this.props.tasks.size === 0 ? (
           'Orchestration has no assigned tasks'
         ) : (
           <span>


### PR DESCRIPTION
Fixes #2173 
Related #2174

Místo názvu komponenty vypisujeme název konfigurace. Jestli je to teda preferovaná varianta.

Je tam navíc kontrola zda název je k dispozici, převážně kvůli #2174. Ale nevím zda to může nastat i jinak, proto jsem to tam nechal. Nevím zda to dát pryč a hodit tam třeba taky 'N/A' nebo něco takového. Protože takto to může taky mást když budou třeba jen 2 tasky z toho jeden bez jména. Zobrazí to pouze jeden. Pokud jich bude 10 a jeden bude problematický, tak to tak nevadí, protože to vypíše existují tyto + další. 