### PR TITLE
Events table - show component column

### DIFF
--- a/src/scripts/modules/sapi-events/react/EventsTable.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTable.jsx
@@ -1,13 +1,11 @@
-
 import React from 'react';
 import TableRow from './EventsTableRow';
-import {Loader} from '@keboola/indigo-ui';
+import { Loader } from '@keboola/indigo-ui';
 import PureRendererMixin from 'react-immutable-render-mixin';
-
-const {div} = React.DOM;
 
 export default React.createClass({
   mixins: [PureRendererMixin],
+
   propTypes: {
     events: React.PropTypes.object.isRequired,
     link: React.PropTypes.object.isRequired,
@@ -20,34 +18,32 @@ export default React.createClass({
       <div className="table table-striped table-hover">
         <div className="thead">
           <div className="tr">
-            <div className="th">
-              Created
-            </div>
-            <div className="th">
-              Event {this.props.isLoading ? React.createElement(Loader) : null}
-            </div>
+            <div className="th">Created</div>
+            <div className="th">Component</div>
+            <div className="th">Event {this.props.isLoading ? React.createElement(Loader) : null}</div>
           </div>
         </div>
-        <div className="tbody">
-          {this._body()}
-        </div>
+        <div className="tbody">{this._body()}</div>
       </div>
     );
   },
 
   _body() {
-    return this.props.events.map( function(event) {
-      return React.createElement(TableRow, {
-        onClick: this._handleEventSelect.bind(this, event),
-        event,
-        link: this.props.link,
-        key: event.get('id')
-      });
-    }, this).toArray();
+    return this.props.events
+      .map(event => {
+        return (
+          <TableRow
+            key={event.get('id')}
+            onClick={this._handleEventSelect.bind(this, event)}
+            event={event}
+            link={this.props.link}
+          />
+        );
+      })
+      .toArray();
   },
 
   _handleEventSelect(selectedEvent) {
     return this.props.onEventSelect(selectedEvent);
   }
 });
-

--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -1,17 +1,19 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import {Link} from 'react-router';
+import { Link } from 'react-router';
 import _ from 'underscore';
 import classnames from 'classnames';
-import {format} from '../../../utils/date';
-import {NewLineToBr} from '@keboola/indigo-ui';
+import { format } from '../../../utils/date';
+import { NewLineToBr } from '@keboola/indigo-ui';
 
 export default React.createClass({
+  mixin: [PureRenderMixin],
+
   propTypes: {
     event: PropTypes.object.isRequired,
     link: PropTypes.object.isRequired
   },
-  mixin: [PureRenderMixin],
+
   render() {
     const classmap = {
       error: 'bg-danger',
@@ -19,11 +21,11 @@ export default React.createClass({
       success: 'bg-success'
     };
     const rowClass = classnames('td', classmap[this.props.event.get('type')]);
+
     return (
       <Link {...this.linkProps()}>
-        <div className={rowClass}>
-          {format(this.props.event.get('created'))}
-        </div>
+        <div className={rowClass}>{format(this.props.event.get('created'))}</div>
+        <div className={rowClass}>{this.props.event.get('component')}</div>
         <div className={rowClass}>
           <NewLineToBr text={this.props.event.get('message')} />
         </div>
@@ -32,7 +34,8 @@ export default React.createClass({
   },
 
   linkProps() {
-    const {link, event} = this.props;
+    const { link, event } = this.props;
+
     return {
       to: link.to,
       params: link.params,
@@ -42,5 +45,4 @@ export default React.createClass({
       className: 'tr'
     };
   }
-
 });


### PR DESCRIPTION
Fixes #2160

Zobrazení názvu komponenty v events logu.

Ta komponenta je teda na více místech. Tak nevím zda to omezit pomocí nějaké props nebo to takto nechat všude. Je to:
- orchestrace job detail - původní issue
- přímo v jobs detail
- ještě na stránce detailů tokenů

