### PR TITLE
Version buttons - diff icon

### DIFF
--- a/src/scripts/react/common/DiffMenuItem.jsx
+++ b/src/scripts/react/common/DiffMenuItem.jsx
@@ -49,7 +49,7 @@ export default React.createClass({
             onSelect={this.openModal}
             disabled={this.props.isDisabled}
           >
-            <em className="fa fa-fw fa-files-o" />
+            <em className="fa fa-fw fa-exchange" />
             Compare
             <VersionsDiffModal
               onClose={this.closeModal}

--- a/src/scripts/react/common/DiffVersionButton.jsx
+++ b/src/scripts/react/common/DiffVersionButton.jsx
@@ -57,12 +57,12 @@ export default React.createClass({
         >
           {this.props.isSmall ? (
             <small>
-              <em className="fa fa-fw fa-files-o" />
+              <em className="fa fa-fw fa-exchange" />
               {this.props.buttonText}
             </small>
           ) : (
             <span className="text-muted">
-              <em className="fa fa-fw fa-files-o" />
+              <em className="fa fa-fw fa-exchange" />
               {this.props.buttonText}
             </span>
           )}


### PR DESCRIPTION
Fixes #2130

V současnoti měla akce "zkopírování do schánky" a "zobrazit změnu oproti poslední konfiguraci" stejnou ikonku.  Teď bude mít diff vlastní (inspirace v PhpStorm by @ujovlado ) 

původní: https://fontawesome.com/v4.7.0/icon/files-o
nová: https://fontawesome.com/v4.7.0/icon/exchange