### PR TITLE
Orchestration tasks - job detail

### DIFF
--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -343,7 +343,7 @@ module.exports = React.createClass
     message =  job.getIn ['result', 'message'] if result
     div null,
       div {className: 'col-md-6', style: {'wordWrap': 'break-word'}},
-        h4 null, 'Params '
+        h4 null, 'Parameters '
         React.createElement Tree, {data: job.get('params')}
       div {className: 'col-md-6'},
         h4 null,'Results '

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import { Link } from 'react-router';
 import ComponentsStore from '../../../../components/stores/ComponentsStore';
 import { Panel, PanelGroup } from 'react-bootstrap';
 import ComponentConfigurationLink from '../../../../components/react/components/ComponentConfigurationLink';
@@ -90,12 +90,10 @@ export default React.createClass({
             <Tree data={task.get('runParameters')} />
           </div>
         )}
-        {task.getIn(['response', 'params']) &&
-          task.getIn(['response', 'params']).size && (
-          <div>
-            <h5>Response parameters</h5>
-            <Tree data={task.getIn(['response', 'params'])} />
-          </div>
+        {task.getIn(['response', 'id']) && (
+          <Link to="jobDetail" params={{ jobId: task.getIn(['response', 'id']) }}>
+            Go to job detail
+          </Link>
         )}
       </Panel>
     );

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -69,18 +69,24 @@ export default React.createClass({
 
     return (
       <Panel header={header} key={task.get('id')} eventKey={task.get('id')}>
-        {task.get('startTime') && <div className="pull-right">{date.format(task.get('startTime'))}</div>}
+        {task.getIn(['response', 'startTime']) && (
+          <p>
+            <strong>{'Start time '}</strong>
+            {date.format(task.getIn(['response', 'startTime']))}
+          </p>
+        )}
+        {task.getIn(['response', 'endTime']) && (
+          <p>
+            <strong>{'End time '}</strong>
+            {date.format(task.getIn(['response', 'endTime']))}
+          </p>
+        )}
         {task.has('config') && (
           <p>
             <strong>{'Configuration '}</strong>
             <ComponentConfigurationLink componentId={task.get('component')} configId={task.getIn(['config', 'id'])}>
               {task.getIn(['config', 'name'])}
             </ComponentConfigurationLink>
-          </p>
-        )}
-        {task.get('runUrl') && (
-          <p>
-            <strong>POST</strong> {task.get('runUrl')}
           </p>
         )}
         {task.get('runParameters') &&

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -72,13 +72,13 @@ export default React.createClass({
         {task.getIn(['response', 'startTime']) && (
           <p>
             <strong>{'Start time '}</strong>
-            {date.format(task.getIn(['response', 'startTime']))}
+            {date.format(task.getIn(['startTime']))}
           </p>
         )}
         {task.getIn(['response', 'endTime']) && (
           <p>
             <strong>{'End time '}</strong>
-            {date.format(task.getIn(['response', 'endTime']))}
+            {date.format(task.getIn(['endTime']))}
           </p>
         )}
         {task.has('config') && (

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -71,17 +71,17 @@ export default React.createClass({
       <Panel header={header} key={task.get('id')} eventKey={task.get('id')}>
         {task.get('startTime') && <div className="pull-right">{date.format(task.get('startTime'))}</div>}
         {task.has('config') && (
-          <div>
+          <p>
             <strong>{'Configuration '}</strong>
             <ComponentConfigurationLink componentId={task.get('component')} configId={task.getIn(['config', 'id'])}>
               {task.getIn(['config', 'name'])}
             </ComponentConfigurationLink>
-          </div>
+          </p>
         )}
         {task.get('runUrl') && (
-          <div>
+          <p>
             <strong>POST</strong> {task.get('runUrl')}
-          </div>
+          </p>
         )}
         {task.get('runParameters') &&
           task.get('runParameters').size && (
@@ -90,11 +90,11 @@ export default React.createClass({
             <Tree data={task.get('runParameters')} />
           </div>
         )}
-        {task.get('response') &&
-          task.get('response').size && (
+        {task.getIn(['response', 'params']) &&
+          task.getIn(['response', 'params']).size && (
           <div>
-            <h5>Response</h5>
-            <Tree data={task.get('response')} />
+            <h5>Response parameters</h5>
+            <Tree data={task.getIn(['response', 'params'])} />
           </div>
         )}
       </Panel>

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -86,7 +86,9 @@ export default React.createClass({
         {task.get('runParameters') &&
           task.get('runParameters').size && (
           <div>
-            <h5>Parameters</h5>
+            <p>
+              <strong>Parameters</strong>
+            </p>
             <Tree data={task.get('runParameters')} />
           </div>
         )}


### PR DESCRIPTION
Fixes #2156

Hlavní co tak se vymazal ten strom "response". Místo toho se přidal odkaz na detail jobu. Ten nevím jak moc zobrazit. Hodil jsem ho pod to jako obyčejný odkaz prozatím. 

Dále se sjednotil pojem Parameters. Jak graficky tak aby sedělo názvosloví na detailu jobu (Params vs Parameters).

Ještě jsem tam přehodit nějaký `divy` za `p` aby bylo rovnoměrné odsazení.

Před:
![pred](https://user-images.githubusercontent.com/12331181/47500760-fba42280-d863-11e8-8b35-49f40ea978e3.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/47500765-ffd04000-d863-11e8-91ad-474b72e27618.png)

Info navíc:
Ten čas v pravo koukám do kódu je startTime. Ale je to takové že kdybych neměl kód tak nevím. Zda je to start nebo konec nebo co to značí. 
Myslím že by to mohlo být vlevo jako ostatní s popisem Start time, a případně pod to hodit i End time. Nebo to vyhodit a tuto informaci nechat na detailu.