### PR TITLE
Orchestration - Failed job - specific error messages

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router';
 import ComponentsStore from '../../../../components/stores/ComponentsStore';
-import { Panel, PanelGroup } from 'react-bootstrap';
+import { Panel, PanelGroup, Alert } from 'react-bootstrap';
 import ComponentConfigurationLink from '../../../../components/react/components/ComponentConfigurationLink';
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
@@ -117,12 +117,9 @@ export default React.createClass({
     }
 
     return (
-      <div className="alert alert-danger">
-        <p>
-          <strong>Validation error</strong>
-        </p>
-        <p>{message}</p>
-      </div>
+      <Alert bsStyle="danger">
+        <strong>Validation error: </strong> {message}
+      </Alert>
     );
   }
 });

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -109,17 +109,14 @@ export default React.createClass({
   },
 
   renderSpecificErrorMessage(task) {
-    const specificErrorMessages = ['Orchestrations can be started only 2 times for current id.'];
     const message = task.getIn(['response', 'message'], '');
-
-    if (!specificErrorMessages.includes(message)) {
-      return null;
+    if (message === 'Orchestrations can be started only 2 times for current id.') {
+      return (
+        <Alert bsStyle="danger">
+          Maximum orchestration nesting level (2) was exceeded.
+        </Alert>
+      );
     }
-
-    return (
-      <Alert bsStyle="danger">
-        <strong>Validation error: </strong> {message}
-      </Alert>
-    );
+    return null;
   }
 });

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -6,7 +6,7 @@ import ComponentConfigurationLink from '../../../../components/react/components/
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
 import Duration from '../../../../../react/common/Duration';
-import { Tree } from '@keboola/indigo-ui';
+import { Tree, AlertBlock } from '@keboola/indigo-ui';
 import JobStatusLabel from '../../../../../react/common/JobStatusLabel';
 import date from '../../../../../utils/date';
 
@@ -103,7 +103,23 @@ export default React.createClass({
             Go to job detail
           </Link>
         )}
+        {this.renderSpecificErrorMesssage(task)}
       </Panel>
+    );
+  },
+
+  renderSpecificErrorMesssage(task) {
+    const specificErrorMessages = ['Orchestrations can be started only 2 times for current id.'];
+    const message = task.getIn(['response', 'message'], '');
+
+    if (!specificErrorMessages.includes(message)) {
+      return null;
+    }
+
+    return (
+      <AlertBlock type="danger" title="Validation error">
+        <p>{message}</p>
+      </AlertBlock>
     );
   }
 });

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -103,12 +103,12 @@ export default React.createClass({
             Go to job detail
           </Link>
         )}
-        {this.renderSpecificErrorMesssage(task)}
+        {this.renderSpecificErrorMessage(task)}
       </Panel>
     );
   },
 
-  renderSpecificErrorMesssage(task) {
+  renderSpecificErrorMessage(task) {
     const specificErrorMessages = ['Orchestrations can be started only 2 times for current id.'];
     const message = task.getIn(['response', 'message'], '');
 

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-job-detail/JobTasks.jsx
@@ -6,7 +6,7 @@ import ComponentConfigurationLink from '../../../../components/react/components/
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
 import Duration from '../../../../../react/common/Duration';
-import { Tree, AlertBlock } from '@keboola/indigo-ui';
+import { Tree } from '@keboola/indigo-ui';
 import JobStatusLabel from '../../../../../react/common/JobStatusLabel';
 import date from '../../../../../utils/date';
 
@@ -117,9 +117,12 @@ export default React.createClass({
     }
 
     return (
-      <AlertBlock type="danger" title="Validation error">
+      <div className="alert alert-danger">
+        <p>
+          <strong>Validation error</strong>
+        </p>
         <p>{message}</p>
-      </AlertBlock>
+      </div>
     );
   }
 });


### PR DESCRIPTION
Fixes #2233

Toto je spíše hotfix. Jde o nástřel zda je takto "divoce" vůbec průchozí. 

Pouze poskytnutí nějaké informace uživateli, že nastala nějaká konkrétní chyba. Je tam napevno ta hláška vepsána, takže to rozhodně není ideální. Když je to napevno je tu možnost i nějak více popsat oč jde a přidat to do hlášky (není v tomto PR).

Nejsem si případně jistý ani tím nadpisem: "Validation error" - rád upravím

před:
![pred](https://user-images.githubusercontent.com/12331181/47574652-60cd4600-d940-11e8-8733-9b3cab0d33d1.png)

po:
![po](https://user-images.githubusercontent.com/12331181/47575832-3f218e00-d943-11e8-9948-65f474a15232.png)
