### PR TITLE
Hint - added mandatory id to popover

### DIFF
--- a/src/scripts/react/common/Hint.jsx
+++ b/src/scripts/react/common/Hint.jsx
@@ -1,5 +1,6 @@
 import React, {PropTypes} from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import { slugify } from 'underscore.string';
 import {OverlayTrigger, Popover} from 'react-bootstrap';
 
 export default React.createClass({
@@ -19,7 +20,7 @@ export default React.createClass({
 
   popover() {
     return (
-      <Popover title={this.props.title}>
+      <Popover id={`hint-${slugify(this.props.title)}`} title={this.props.title}>
         {this.props.children}
       </Popover>
     );

--- a/src/scripts/react/common/Hint.jsx
+++ b/src/scripts/react/common/Hint.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
-import { slugify } from 'underscore.string';
+import _ from 'underscore';
 import {OverlayTrigger, Popover} from 'react-bootstrap';
 
 export default React.createClass({
@@ -20,7 +20,7 @@ export default React.createClass({
 
   popover() {
     return (
-      <Popover id={`hint-${slugify(this.props.title)}`} title={this.props.title}>
+      <Popover id={_.uniqueId('hint_')} title={this.props.title}>
         {this.props.children}
       </Popover>
     );


### PR DESCRIPTION
Odstranění warningu.

Myslím že není potřeba speciální props na toto. Hint jsem viděl použit dvakrát, a myslím, že to je vždy na stránce jen jednou pro "konkrétní" nápovědu, takže i Nadpis bude většinou unikátní. Ještě jsme k tomu hodit "hint-" aby to i náhodou nekolidovalo s jiným ID.