### PR TITLE
Job detail - Input/Output - unification

### DIFF
--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -326,8 +326,7 @@ module.exports = React.createClass
         @_renderParamsRow(job)
 
       React.createElement Panel,
-        header: accordionHeader((if isTransformation then 'Mapping' else 'Storage Stats'),
-          @state.activeAccordion == 'stats')
+        header: accordionHeader('Mapping', @state.activeAccordion == 'stats')
         eventKey: 'stats'
       ,
         React.createElement JobStatsContainer,

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.coffee
@@ -332,7 +332,6 @@ module.exports = React.createClass
         React.createElement JobStatsContainer,
           runId: job.get 'runId'
           autoRefresh: !job.get('endTime')
-          mode: if isTransformation then 'transformation' else 'default'
           jobMetrics: (if job.get('metrics') then job.get('metrics') else fromJS({}))
 
   _renderParamsRow: (job) ->

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
@@ -27,7 +27,7 @@ export default React.createClass({
           <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'export'])} />
         </div>
         <div className="col-md-4">
-          <h4>Output</h4>
+          <h4>Output {this.props.isLoading && <Loader/>}</h4>
           <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'import'])} />
         </div>
         <div className="col-md-4">

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
@@ -40,23 +40,21 @@ export default React.createClass({
   },
 
   render() {
-    const isTransformation = this.props.mode === MODE_TRANSFORMATION;
     const importedIds = this.extractTableIds('import');
     const exportedIds = this.extractTableIds('export');
     const allTablesIds = importedIds.concat(exportedIds);
+
     return (
       <div className="clearfix">
         <div className="col-md-4">
           <h4>
-            {isTransformation ? 'Input' : 'Imported Tables'} {this.importsTotal()} {this.loader()}
+            Input {this.exportsTotal()} {this.loader()}
           </h4>
-          <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', isTransformation ? 'export' : 'import'])}/>
+          <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'export'])} />
         </div>
         <div className="col-md-4">
-          <h4>
-            {isTransformation ? 'Output' : 'Exported Tables'} {this.exportsTotal()}
-          </h4>
-          <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', isTransformation ? 'import' : 'export'])}/>
+          <h4>Output {this.importsTotal()}</h4>
+          <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'import'])} />
         </div>
         <div className="col-md-4">
           <JobMetrics metrics={this.props.jobMetrics} />

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStats.jsx
@@ -5,39 +5,15 @@ import {Loader} from '@keboola/indigo-ui';
 
 import TablesList from './TablesList';
 import JobMetrics from './JobMetrics';
-import IntlMessageFormat from 'intl-messageformat';
-
-const MESSAGES = {
-  TOTAL_IMPORTS: '{totalCount, plural, ' +
-    '=1 {one import total}' +
-    'other {# imports total}}',
-  TOTAL_EXPORTS: '{totalCount, plural, ' +
-    '=1 {one export total}' +
-    'other {# exports total}}',
-  TOTAL_FILES: '{totalCount, plural, ' +
-    '=1 {one files total}' +
-    'other {# files total}}'
-};
-
-const MODE_TRANSFORMATION = 'transformation';
-const MODE_DEFAULT = 'default';
-
-function message(id, params) {
-  return new IntlMessageFormat(MESSAGES[id]).format(params);
-}
 
 export default React.createClass({
   propTypes: {
     stats: React.PropTypes.object.isRequired,
     isLoading: React.PropTypes.bool.isRequired,
-    mode: React.PropTypes.oneOf([MODE_DEFAULT, MODE_TRANSFORMATION]),
     jobMetrics: React.PropTypes.object.isRequired
   },
-  mixins: [PureRenderMixin],
 
-  loader() {
-    return this.props.isLoading ? <Loader/> : '';
-  },
+  mixins: [PureRenderMixin],
 
   render() {
     const importedIds = this.extractTableIds('import');
@@ -47,13 +23,11 @@ export default React.createClass({
     return (
       <div className="clearfix">
         <div className="col-md-4">
-          <h4>
-            Input {this.exportsTotal()} {this.loader()}
-          </h4>
+          <h4>Input {this.props.isLoading && <Loader/>}</h4>
           <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'export'])} />
         </div>
         <div className="col-md-4">
-          <h4>Output {this.importsTotal()}</h4>
+          <h4>Output</h4>
           <TablesList allTablesIds={allTablesIds} tables={this.props.stats.getIn(['tables', 'import'])} />
         </div>
         <div className="col-md-4">
@@ -63,24 +37,7 @@ export default React.createClass({
     );
   },
 
-  importsTotal() {
-    if (this.props.mode === MODE_TRANSFORMATION) {
-      return null;
-    }
-    const total = this.props.stats.getIn(['tables', 'import', 'totalCount']);
-    return total > 0 ? <small>{message('TOTAL_IMPORTS', {totalCount: total})}</small> : null;
-  },
-
-  exportsTotal() {
-    if (this.props.mode === MODE_TRANSFORMATION) {
-      return null;
-    }
-    const total = this.props.stats.getIn(['tables', 'export', 'totalCount']);
-    return total > 0 ? <small>{message('TOTAL_EXPORTS', {totalCount: total})}</small> : null;
-  },
-
   extractTableIds(tablesType) {
     return this.props.stats.getIn(['tables', tablesType, 'tables'], List()).map((t) => t.get('id'));
   }
-
 });

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
@@ -11,7 +11,6 @@ export default React.createClass({
   propTypes: {
     runId: React.PropTypes.string.isRequired,
     autoRefresh: React.PropTypes.bool.isRequired,
-    mode: React.PropTypes.string.isRequired,
     jobMetrics: React.PropTypes.object.isRequired
   },
 
@@ -85,7 +84,6 @@ export default React.createClass({
         <JobStats
           stats={this.state.stats}
           isLoading={this.state.isLoading}
-          mode={this.props.mode}
           jobMetrics={this.props.jobMetrics}
         />
       );


### PR DESCRIPTION
Fixes #2249

Proposed changes: Sjednocení výpis pro transformace, writery, extraktory

- label Storage Stats -> Mapping 
- writer má pouze "Input"
- extractor má pouze "Output"
- info labely za Input/Ouput vymazány 

Je tam úprava v JobsDetail.coffee, který je připraven na převod do jsx, tak kdyžtak ještě aktualizuji ten převod tam aby to sedělo.
