### PR TITLE
[ex-db-generic] Only delete configRow if it exists

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -327,8 +327,12 @@ export function createActions(componentId) {
       const newQueries = store.getQueries().filter((q) => q.get('id') !== qid);
       const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
       const diffMsg = 'Delete query ' + store.getQueryName(qid);
-      if (store.isRowConfiguration() && !store.getNewQuery(qid)) {
-        return deleteConfigRow(configId, qid.toString(), ['pending', qid, 'deleteQuery'], diffMsg);
+      if (store.isRowConfiguration()) {
+        if (!store.isNewQuery(qid)) {
+          return deleteConfigRow(configId, qid.toString(), ['pending', qid, 'deleteQuery'], diffMsg);
+        } else {
+          return;
+        }
       }
       return saveConfigData(configId, newData, ['pending', qid, 'deleteQuery'], diffMsg);
     },

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -327,7 +327,7 @@ export function createActions(componentId) {
       const newQueries = store.getQueries().filter((q) => q.get('id') !== qid);
       const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
       const diffMsg = 'Delete query ' + store.getQueryName(qid);
-      if (store.isRowConfiguration()) {
+      if (store.isRowConfiguration() && !store.getNewQuery(qid)) {
         return deleteConfigRow(configId, qid.toString(), ['pending', qid, 'deleteQuery'], diffMsg);
       }
       return saveConfigData(configId, newData, ['pending', qid, 'deleteQuery'], diffMsg);

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -328,11 +328,10 @@ export function createActions(componentId) {
       const newData = store.configData.setIn(['parameters', 'tables'], newQueries);
       const diffMsg = 'Delete query ' + store.getQueryName(qid);
       if (store.isRowConfiguration()) {
-        if (!store.isNewQuery(qid)) {
-          return deleteConfigRow(configId, qid.toString(), ['pending', qid, 'deleteQuery'], diffMsg);
-        } else {
+        if (store.isNewQuery(qid)) {
           return;
         }
+        return deleteConfigRow(configId, qid.toString(), ['pending', qid, 'deleteQuery'], diffMsg);
       }
       return saveConfigData(configId, newData, ['pending', qid, 'deleteQuery'], diffMsg);
     },


### PR DESCRIPTION
Fixes #2251 

Proposed changes:

- only delete configRow if it is not a new query
