### PR TITLE
JSON editor validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Keboola Connection UI",
   "author": "Martin Halamicek",
   "dependencies": {
-    "@json-editor/json-editor": "^1.3.4",
+    "@json-editor/json-editor": "^1.3.5",
     "@keboola/indigo-ui": "^8.0.0",
     "aws-sdk": "^2.437.0",
     "bluebird": "^3.5.3",

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -26,6 +26,10 @@ export default createReactClass({
     };
   },
 
+  componentWillUnmount() {
+    this.props.onCancel();
+  },
+
   render() {
     return (
       <div className="edit kbc-configuration-editor">
@@ -33,7 +37,7 @@ export default createReactClass({
           <SaveButtons
             isSaving={this.props.isSaving}
             isChanged={this.props.isChanged}
-            onSave={this.handleSave}
+            onSave={this.props.onSave}
             disabled={!this.props.isValid}
             onReset={this.props.onCancel} />
         </div>
@@ -49,7 +53,6 @@ export default createReactClass({
     }
     return (
       <JSONSchemaEditor
-        ref="paramsEditor"
         schema={this.props.schema}
         value={Immutable.fromJS(JSON.parse(this.props.data))}
         onChange={this.handleParamsChange}
@@ -94,14 +97,5 @@ export default createReactClass({
     if (!value.equals(Immutable.fromJS(JSON.parse(this.props.data)))) {
       this.props.onChange(JSON.stringify(value));
     }
-  },
-
-  handleSave() {
-    if (this.refs.paramsEditor) {
-      // json-editor doesn't trigger onChange handler on each key stroke
-      // so sometimes not actualized data were saved https://github.com/keboola/kbc-ui/issues/501
-      this.handleParamsChange(this.refs.paramsEditor.getCurrentValue());
-    }
-    this.props.onSave();
   }
 });

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -26,10 +26,6 @@ export default createReactClass({
     };
   },
 
-  componentWillUnmount() {
-    this.props.onCancel();
-  },
-
   render() {
     return (
       <div className="edit kbc-configuration-editor">

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -54,8 +54,6 @@ export default createReactClass({
         onChange={this.handleParamsChange}
         readOnly={this.props.isSaving}
         isChanged={this.props.isChanged}
-        disableCollapse={true}
-        disableProperties={true}
       />
     );
   },

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -14,9 +14,7 @@ export default createReactClass({
     onChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool.isRequired,
     onValidation: PropTypes.func,
-    isChanged: PropTypes.bool,
-    disableProperties: PropTypes.bool,
-    disableCollapse: PropTypes.bool
+    isChanged: PropTypes.bool
   },
 
   getInitialState() {
@@ -28,9 +26,7 @@ export default createReactClass({
   getDefaultProps() {
     return {
       readOnly: false,
-      schema: Map(),
-      disableProperties: false,
-      disableCollapse: false
+      schema: Map()
     };
   },
 
@@ -61,19 +57,13 @@ export default createReactClass({
       iconlib: 'fontawesome4',
       disable_array_delete_last_row: true,
       disable_array_reorder: true,
-      disable_collapse: this.props.disableCollapse,
+      disable_array_add: true,
+      disable_array_delete: true,
+      disable_collapse: true,
       disable_edit_json: true,
-      disable_properties: this.props.disableProperties,
+      disable_properties: true,
       show_errors: 'always'
     };
-
-    if (nextReadOnly) {
-      options.disable_array_add = true;
-      options.disable_collapse = true;
-      options.disable_edit_json = true;
-      options.disable_properties = true;
-      options.disable_array_delete = true;
-    }
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
 
@@ -115,10 +105,6 @@ export default createReactClass({
 
   componentDidMount() {
     this.initJsonEditor(this.props.value, this.props.readOnly);
-  },
-
-  getCurrentValue() {
-    return fromJS(this.jsoneditor.getValue());
   },
 
   render() {

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -57,12 +57,12 @@ export default createReactClass({
       iconlib: 'fontawesome4',
       disable_array_delete_last_row: true,
       disable_array_reorder: true,
-      disable_array_add: true,
-      disable_array_delete: true,
-      disable_collapse: true,
+      disable_collapse: false,
       disable_edit_json: true,
-      disable_properties: true,
-      show_errors: 'always'
+      disable_properties: false,
+      object_layout: 'normal',
+      show_errors: 'always',
+      prompt_before_delete: false
     };
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { Map, fromJS } from 'immutable';
@@ -16,7 +16,6 @@ export default createReactClass({
     onValidation: PropTypes.func,
     isChanged: PropTypes.bool,
     disableProperties: PropTypes.bool,
-    showErrors: PropTypes.oneOf(['interaction', 'change', 'always', 'never']),
     disableCollapse: PropTypes.bool
   },
 
@@ -31,8 +30,7 @@ export default createReactClass({
       readOnly: false,
       schema: Map(),
       disableProperties: false,
-      disableCollapse: false,
-      showErrors: 'interaction'
+      disableCollapse: false
     };
   },
 
@@ -56,46 +54,35 @@ export default createReactClass({
       this.jsoneditor.destroy();
     }
 
-    let options = {
+    const options = {
       schema: this.props.schema.toJS(),
       startval: nextValue.toJS(),
       theme: 'bootstrap3',
       iconlib: 'fontawesome4',
-      custom_validators: [],
+      ajax: false,
+      disable_array_add: false,
+      disable_array_delete: false,
       disable_array_delete_last_row: true,
       disable_array_reorder: true,
       disable_collapse: this.props.disableCollapse,
       disable_edit_json: true,
       disable_properties: this.props.disableProperties,
       object_layout: 'normal',
-      show_errors: this.props.showErrors,
-      prompt_before_delete: false
+      required_by_default: false,
+      show_errors: 'interaction'
     };
-
-    options.custom_validators.push((schema, value, path) => {
-      let errors = [];
-      if (schema.type === 'string' && schema.template) {
-        if (schema.template !== value) {
-          errors.push({
-            path: path,
-            property: 'value',
-            message: 'Value does not match schema template'
-          });
-        }
-      }
-      return errors;
-    });
 
     if (nextReadOnly) {
       options.disable_array_add = true;
-      options.disable_array_delete = true;
       options.disable_collapse = true;
+      options.disable_edit_json = true;
       options.disable_properties = true;
+      options.disable_array_delete = true;
     }
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
 
-    // When the value of the editor changes, update the JSON output and TODO validation message
+    // When the value of the editor changes, update the JSON output and validation message
     this.jsoneditor.on('change', () => {
       // editor calls onChange after its init causing isChanged = true without any user input. This will prevent calling onChange after editors init
       if (this.state.blockOnChangeOnce) {

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -67,8 +67,6 @@ export default createReactClass({
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
 
-    this.jsoneditor.on('ready', this.checkHiddenRows);
-
     // When the value of the editor changes, update the JSON output and validation message
     this.jsoneditor.on('change', () => {
       // editor calls onChange after its init causing isChanged = true without any user input. This will prevent calling onChange after editors init
@@ -113,15 +111,5 @@ export default createReactClass({
         <div ref="jsoneditor" />
       </form>
     );
-  },
-
-  checkHiddenRows() {
-    const selector = '.kbc-configuration-editor .row > div:not(.col-md-12)';
-
-    Array.from(document.querySelectorAll(selector)).forEach(el => {
-      if (el.style.display === 'none') {
-        el.parentNode.style.display = 'none';
-      }
-    });
   }
 });

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -13,8 +13,10 @@ export default createReactClass({
     schema: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     readOnly: PropTypes.bool.isRequired,
+    onValidation: PropTypes.func,
     isChanged: PropTypes.bool,
     disableProperties: PropTypes.bool,
+    showErrors: PropTypes.oneOf(['interaction', 'change', 'always', 'never']),
     disableCollapse: PropTypes.bool
   },
 
@@ -29,7 +31,8 @@ export default createReactClass({
       readOnly: false,
       schema: Map(),
       disableProperties: false,
-      disableCollapse: false
+      disableCollapse: false,
+      showErrors: 'interaction'
     };
   },
 
@@ -65,7 +68,7 @@ export default createReactClass({
       disable_edit_json: true,
       disable_properties: this.props.disableProperties,
       object_layout: 'normal',
-      show_errors: 'always',
+      show_errors: this.props.showErrors,
       prompt_before_delete: false
     };
 
@@ -100,6 +103,10 @@ export default createReactClass({
       } else {
         const json = this.jsoneditor.getValue();
         this.props.onChange(fromJS(json));
+      }
+
+      if (this.props.onValidation) {
+        this.props.onValidation(this.jsoneditor.validate());
       }
     });
 

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -57,9 +57,9 @@ export default createReactClass({
       iconlib: 'fontawesome4',
       disable_array_delete_last_row: true,
       disable_array_reorder: true,
-      disable_collapse: false,
+      disable_collapse: true,
       disable_edit_json: true,
-      disable_properties: false,
+      disable_properties: true,
       object_layout: 'normal',
       show_errors: 'always',
       prompt_before_delete: false

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -69,7 +69,7 @@ export default createReactClass({
       disable_properties: this.props.disableProperties,
       object_layout: 'normal',
       required_by_default: false,
-      show_errors: 'interaction'
+      show_errors: 'always'
     };
 
     if (nextReadOnly) {
@@ -82,15 +82,18 @@ export default createReactClass({
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
 
+    this.jsoneditor.on('ready', this.checkHiddenRows);
+
     // When the value of the editor changes, update the JSON output and validation message
     this.jsoneditor.on('change', () => {
       // editor calls onChange after its init causing isChanged = true without any user input. This will prevent calling onChange after editors init
       if (this.state.blockOnChangeOnce) {
         this.setState({ blockOnChangeOnce: false });
-      } else {
-        const json = this.jsoneditor.getValue();
-        this.props.onChange(fromJS(json));
+        return;
       }
+
+      const json = this.jsoneditor.getValue();
+      this.props.onChange(fromJS(json));
 
       if (this.props.onValidation) {
         this.props.onValidation(this.jsoneditor.validate());
@@ -129,5 +132,15 @@ export default createReactClass({
         <div ref="jsoneditor" />
       </form>
     );
+  },
+
+  checkHiddenRows() {
+    const selector = '.kbc-configuration-editor .row > div:not(.col-md-12)';
+
+    Array.from(document.querySelectorAll(selector)).forEach(el => {
+      if (el.style.display === 'none') {
+        el.parentNode.style.display = 'none';
+      }
+    });
   }
 });

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -59,16 +59,11 @@ export default createReactClass({
       startval: nextValue.toJS(),
       theme: 'bootstrap3',
       iconlib: 'fontawesome4',
-      ajax: false,
-      disable_array_add: false,
-      disable_array_delete: false,
       disable_array_delete_last_row: true,
       disable_array_reorder: true,
       disable_collapse: this.props.disableCollapse,
       disable_edit_json: true,
       disable_properties: this.props.disableProperties,
-      object_layout: 'normal',
-      required_by_default: false,
       show_errors: 'always'
     };
 

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -30,6 +30,7 @@ export default createReactClass({
     };
   },
 
+  editorRef: null,
   jsoneditor: null,
 
   componentWillReceiveProps(nextProps) {
@@ -65,7 +66,7 @@ export default createReactClass({
       prompt_before_delete: false
     };
 
-    this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
+    this.jsoneditor = new JSONEditor(this.editorRef, options);
 
     // When the value of the editor changes, update the JSON output and validation message
     this.jsoneditor.on('change', () => {
@@ -108,7 +109,7 @@ export default createReactClass({
   render() {
     return (
       <form autoComplete="off">
-        <div ref="jsoneditor" />
+        <div ref={editor => this.editorRef = editor} />
       </form>
     );
   }

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -42,6 +42,10 @@ export default createReactClass({
     };
   },
 
+  componentWillUnmount() {
+    this.props.onCancel();
+  },
+
   renderJSONSchemaEditor() {
     // empty json schema does not render
     if (!this.props.paramsSchema.get('properties') || this.props.paramsSchema.get('properties').count() === 0) {
@@ -49,7 +53,6 @@ export default createReactClass({
     }
     return (
       <JSONSchemaEditor
-        ref="paramsEditor"
         isChanged={this.props.isChanged}
         schema={this.props.paramsSchema}
         value={this.props.editingParams}
@@ -70,7 +73,7 @@ export default createReactClass({
             <SaveButtons
               isSaving={this.props.isSaving}
               isChanged={this.props.isChanged}
-              onSave={this.handleSave}
+              onSave={this.props.onSave}
               disabled={!this.props.isValid || this.state.hasEditorErrors}
               onReset={this.props.onCancel} />
           </div>
@@ -152,14 +155,5 @@ export default createReactClass({
   switchToTemplateEditor() {
     this.setState({showJsonEditor: false});
     this.props.onChangeEditingMode(false);
-  },
-
-  handleSave() {
-    if (this.refs.paramsEditor) {
-      // json-editor doesn't trigger onChange handler on each key stroke
-      // so sometimes not actualized data were saved https://github.com/keboola/kbc-ui/issues/501
-      this.handleParamsChange(this.refs.paramsEditor.getCurrentValue());
-    }
-    this.props.onSave();
   }
 });

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -37,7 +37,8 @@ export default createReactClass({
 
   getInitialState() {
     return {
-      showJsonEditor: this.props.isEditingString || !this.props.isTemplate
+      showJsonEditor: this.props.isEditingString || !this.props.isTemplate,
+      hasEditorErrors: false
     };
   },
 
@@ -53,9 +54,11 @@ export default createReactClass({
         schema={this.props.paramsSchema}
         value={this.props.editingParams}
         onChange={this.handleParamsChange}
+        onValidation={this.handleEditorValidation}
         readOnly={this.props.isSaving}
         disableCollapse={true}
         disableProperties={true}
+        showErrors="always"
       />
     );
   },
@@ -69,7 +72,7 @@ export default createReactClass({
               isSaving={this.props.isSaving}
               isChanged={this.props.isChanged}
               onSave={this.handleSave}
-              disabled={!this.props.isValid}
+              disabled={!this.props.isValid || this.state.hasEditorErrors}
               onReset={this.props.onCancel} />
           </div>
           {
@@ -134,6 +137,12 @@ export default createReactClass({
     if (!value.equals(this.props.editingParams.toMap())) {
       this.props.onChangeParams(value);
     }
+  },
+
+  handleEditorValidation(errors) {
+    this.setState({
+      hasEditorErrors: errors.length > 0
+    });
   },
 
   switchToJsonEditor() {

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -58,7 +58,6 @@ export default createReactClass({
         readOnly={this.props.isSaving}
         disableCollapse={true}
         disableProperties={true}
-        showErrors="always"
       />
     );
   },

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -59,8 +59,6 @@ export default createReactClass({
         onChange={this.handleParamsChange}
         onValidation={this.handleEditorValidation}
         readOnly={this.props.isSaving}
-        disableCollapse={true}
-        disableProperties={true}
       />
     );
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,10 +934,10 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@json-editor/json-editor@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@json-editor/json-editor/-/json-editor-1.3.4.tgz#730ce407e9816370a513f48fe9b74eb191149200"
-  integrity sha512-w4SGutLq8wnQzQoidw7QlQmOq3bknf8xbLrK4TX48eVcAXuDxwnY/ikdjAiJkCSiB+ecK/7qo/Vxzv50AV3p/A==
+"@json-editor/json-editor@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@json-editor/json-editor/-/json-editor-1.3.5.tgz#b8ec91b2ad53d65a031c90941e3c3bbd084bc321"
+  integrity sha512-maU/05CzSvW5waIqWXhhiekLhDKwu8cOkGESIVyV2UrONedRzO/qk+WBFKkBbLmm5TeyRnkwVL6CkKNyaa2d4w==
 
 "@keboola/indigo-ui@^8.0.0":
   version "8.0.0"


### PR DESCRIPTION
Fixed #604

Přidaná nepovinná props **onValidation** , kam se posílají chyby validace při změně. Může se použít pro zamezení uložení pokud není vše v pořádku.

Bylo potřeba vymazat vlastní validaci, která tam byla přítomna, která vždy končila chybou. Je možné, že byla důležitá a stopne to toto PR, tak to zmiňuji hned tu. Mě se nepovedlo dohledat, k čemu sloužila.
Jde o validaci:

```js
options.custom_validators.push(function(schema, value, path) {
  var errors = [];
  if (schema.type === 'string' && schema.template) {
    if (schema.template !== value) {
      errors.push({
        path: path,
        property: 'value',
        message: 'Value does not match schema template'
      });
    }
  }
  return errors;
});
```

Před: (Zendesk extractor)
![pred](https://user-images.githubusercontent.com/12331181/47848155-b9cc2c80-ddcd-11e8-8131-61102c60ccc2.png)

Po: (Zendesk extractor)
![po](https://user-images.githubusercontent.com/12331181/47848159-bcc71d00-ddcd-11e8-9c21-59628a84009d.png)

