### PR TITLE
Wr-db - Disable table actions when updating or deleting

### DIFF
--- a/src/scripts/modules/wr-db/react/pages/index/Index.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/Index.jsx
@@ -276,6 +276,7 @@ export default componentId => {
           tableDbName={this._getConfigTable(table.get('id')).get('name')}
           isTableExported={this._isTableExported(table.get('id'))}
           isPending={this._isPendingTable(table.get('id'))}
+          isUpdating={this._isUpdating()}
           componentId={componentId}
           onExportChangeFn={() => {
             return this._handleExportChange(table.get('id'));
@@ -325,6 +326,10 @@ export default componentId => {
 
     _isPendingTable(tableId) {
       return this.state.updatingTables.has(tableId);
+    },
+
+    _isUpdating() {
+      return this.state.updatingTables.count() || this.state.deletingTables.count();
     },
 
     _prepareTableUploadData() {

--- a/src/scripts/modules/wr-db/react/pages/index/Index.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/Index.jsx
@@ -329,7 +329,7 @@ export default componentId => {
     },
 
     _isUpdating() {
-      return this.state.updatingTables.count() || this.state.deletingTables.count();
+      return !!(this.state.updatingTables.count() || this.state.deletingTables.count());
     },
 
     _prepareTableUploadData() {

--- a/src/scripts/modules/wr-db/react/pages/index/TableRow.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/TableRow.jsx
@@ -96,24 +96,32 @@ export default React.createClass({
           <Loader />
         </span>
       );
-    } else {
+    }
+
+    if (this.props.isUpdating) {
       return (
-        <Confirm
-          key={this.props.table.get('id')}
-          title={`Remove ${this.props.table.get('id')}`}
-          text="You are about to remove the table from the configuration."
-          buttonLabel="Remove"
-          onConfirm={() => {
-            return this.props.deleteTableFn(this.props.table.get('id'));
-          }}
-        >
-          <Tooltip tooltip="Remove table from configuration" placement="top">
-            <button disabled={this.props.isUpdating} className="btn btn-link">
-              <i className="kbc-icon-cup" />
-            </button>
-          </Tooltip>
-        </Confirm>
+        <button disabled className="btn btn-link">
+          <i className="kbc-icon-cup" />
+        </button>
       );
     }
+
+    return (
+      <Confirm
+        key={this.props.table.get('id')}
+        title={`Remove ${this.props.table.get('id')}`}
+        text="You are about to remove the table from the configuration."
+        buttonLabel="Remove"
+        onConfirm={() => {
+          return this.props.deleteTableFn(this.props.table.get('id'));
+        }}
+      >
+        <Tooltip tooltip="Remove table from configuration" placement="top">
+          <button className="btn btn-link">
+            <i className="kbc-icon-cup" />
+          </button>
+        </Tooltip>
+      </Confirm>
+    );
   }
 });

--- a/src/scripts/modules/wr-db/react/pages/index/TableRow.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/TableRow.jsx
@@ -17,6 +17,7 @@ export default React.createClass({
     tableExists: React.PropTypes.bool.isRequired,
     isTableExported: React.PropTypes.bool.isRequired,
     isPending: React.PropTypes.bool.isRequired,
+    isUpdating: React.PropTypes.bool.isRequired,
     isV2: React.PropTypes.bool.isRequired,
     onExportChangeFn: React.PropTypes.func.isRequired,
     table: React.PropTypes.object.isRequired,
@@ -57,6 +58,7 @@ export default React.createClass({
             isActive={this.props.isTableExported}
             isPending={this.props.isPending}
             onChange={this.props.onExportChangeFn}
+            buttonDisabled={this.props.isUpdating}
           />
           {this.props.tableExists && (
             <Tooltip tooltip="Upload table to Dropbox">
@@ -66,6 +68,7 @@ export default React.createClass({
                 mode="button"
                 icon="fa fa-play fa-fw"
                 component={this.props.componentId}
+                disabled={this.props.isUpdating}
                 runParams={() => {
                   const tableId = this.props.table.get('id');
                   const { configId } = this.props;
@@ -105,7 +108,7 @@ export default React.createClass({
           }}
         >
           <Tooltip tooltip="Remove table from configuration" placement="top">
-            <button className="btn btn-link">
+            <button disabled={this.props.isUpdating} className="btn btn-link">
               <i className="kbc-icon-cup" />
             </button>
           </Tooltip>


### PR DESCRIPTION
Fixes #1678

Tady mi dávalo smysl "zakázat" všechny ty akce pokud mažu nebo nastavuji ten export. Je to blbost?
Upravím pouze na ten "export toggle button" pokud má být pouze to.
