### PR TITLE
Fix for null datatypeName

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -242,7 +242,7 @@ export default React.createClass({
       } else {
         basetype = basetype.get(0);
       }
-      let datatypeName = null;
+      let datatypeName, length = null;
 
       let datatype = this.snowflakeDatatypesMap.map((mappedDatatype) => {
         if (mappedDatatype.get('basetype') === basetype.get('value')) {
@@ -251,9 +251,11 @@ export default React.createClass({
         }
       });
       const mapType = datatype.get(datatypeName);
-      let length = mapType.get('size') ? datatypeLength.get('value') : null;
-      if (mapType.has('maxLength') && length > mapType.get('maxLength')) {
-        length = mapType.get('maxLength');
+      if (mapType) {
+        length = mapType.get('size') ? datatypeLength.get('value') : null;
+        if (mapType.has('maxLength') && length > mapType.get('maxLength')) {
+          length = mapType.get('maxLength');
+        }
       }
       return Immutable.fromJS({
         column: colname,


### PR DESCRIPTION
Fixes #2275 

Proposed changes:

- there's a chance that `datatypeName` is `null` and further work with immutable will fail


~I'm afraid that it'll need more checks. Looks like there are situations where additional values can ended unset (e.g. `datatypeLength`).~
