### PR TITLE
Use OAuth v3 if enabled by project feature

### DIFF
--- a/src/scripts/modules/oauth-v2/ActionCreators.js
+++ b/src/scripts/modules/oauth-v2/ActionCreators.js
@@ -6,16 +6,16 @@ import * as Constants from './Constants';
 import Immutable from 'immutable';
 
 export default {
-  loadCredentials(componentId, id) {
+  loadCredentials(componentId, id, version) {
     if (oauthStore.hasCredentials(componentId, id)) {
       return Promise.resolve();
     }
-    return this.loadCredentialsForce(componentId, id);
+    return this.loadCredentialsForce(componentId, id, version);
   },
 
-  loadCredentialsForce(componentId, id) {
+  loadCredentialsForce(componentId, id, version) {
     return oauthApi
-      .getCredentials(componentId, id)
+      .getCredentials(componentId, id, version)
       .then(function(result) {
         dispatcher.handleViewAction({
           type: Constants.ActionTypes.OAUTHV2_LOAD_CREDENTIALS_SUCCESS,
@@ -60,7 +60,7 @@ export default {
       });
   },
 
-  deleteCredentials(componentId, id) {
+  deleteCredentials(componentId, id, version) {
     dispatcher.handleViewAction({
       type: Constants.ActionTypes.OAUTHV2_DELETE_CREDENTIALS_START,
       componentId,
@@ -68,7 +68,7 @@ export default {
     });
 
     return oauthApi
-      .deleteCredentials(componentId, id)
+      .deleteCredentials(componentId, id, version)
       .then(result =>
         dispatcher.handleViewAction({
           type: Constants.ActionTypes.OAUTHV2_DELETE_CREDENTIALS_SUCCESS,

--- a/src/scripts/modules/oauth-v2/Api.js
+++ b/src/scripts/modules/oauth-v2/Api.js
@@ -1,20 +1,27 @@
 import request from '../../utils/request';
 import ApplicationStore from '../../stores/ApplicationStore';
 import ComponentsStore from '../components/stores/ComponentsStore';
+import ServicesStore from '../services/Store';
 
-function createUrl(path) {
-  const baseUrl = ComponentsStore.getComponent('keboola.oauth-v2').get('uri');
-  return baseUrl + '/' + path;
+function createUrl(path, version) {
+  return getBaseUrl(version) + '/' + path;
 }
 
-function createRequest(method, path) {
-  return request(method, createUrl(path))
+function getBaseUrl(version) {
+  if (version !== 2 && ApplicationStore.hasCurrentProjectFeature('oauth-v3')) {
+    return ServicesStore.getService('oauth').get('url');
+  }
+  return ComponentsStore.getComponent('keboola.oauth-v2').get('uri');
+}
+
+function createRequest(method, path, version) {
+  return request(method, createUrl(path, version))
     .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString());
 }
 
 module.exports = {
-  getCredentials: function(componentId, id) {
-    return createRequest('GET', 'credentials/' + componentId + '/' + id)
+  getCredentials: function(componentId, id, version) {
+    return createRequest('GET', 'credentials/' + componentId + '/' + id, version)
       .promise().then(function(response) {
         return response.body;
       });
@@ -33,8 +40,8 @@ module.exports = {
       });
   },
 
-  deleteCredentials: function(componentId, id) {
-    return createRequest('DELETE', 'credentials/' + componentId + '/' + id)
+  deleteCredentials: function(componentId, id, version) {
+    return createRequest('DELETE', 'credentials/' + componentId + '/' + id, version)
       .promise().then(function(response) {
         return response.body;
       });

--- a/src/scripts/modules/oauth-v2/Api.js
+++ b/src/scripts/modules/oauth-v2/Api.js
@@ -2,13 +2,15 @@ import request from '../../utils/request';
 import ApplicationStore from '../../stores/ApplicationStore';
 import ComponentsStore from '../components/stores/ComponentsStore';
 import ServicesStore from '../services/Store';
+import {Constants} from './Constants';
 
 function createUrl(path, version) {
   return getBaseUrl(version) + '/' + path;
 }
 
 function getBaseUrl(version) {
-  if (version !== 2 && ApplicationStore.hasCurrentProjectFeature('oauth-v3')) {
+  if (version !== Constants.OAUTH_VERSION_DEFAULT
+    && ApplicationStore.hasCurrentProjectFeature(Constants.OAUTH_V3_FEATURE)) {
     return ServicesStore.getService('oauth').get('url');
   }
   return ComponentsStore.getComponent('keboola.oauth-v2').get('uri');

--- a/src/scripts/modules/oauth-v2/Api.js
+++ b/src/scripts/modules/oauth-v2/Api.js
@@ -9,7 +9,7 @@ function createUrl(path, version) {
 }
 
 function getBaseUrl(version) {
-  if (version !== Constants.OAUTH_VERSION_DEFAULT
+  if (version !== Constants.OAUTH_VERSION_FALLBACK
     && ApplicationStore.hasCurrentProjectFeature(Constants.OAUTH_V3_FEATURE)) {
     return ServicesStore.getService('oauth').get('url');
   }

--- a/src/scripts/modules/oauth-v2/Constants.js
+++ b/src/scripts/modules/oauth-v2/Constants.js
@@ -9,3 +9,9 @@ export const ActionTypes = keyMirror({
   OAUTHV2_POST_CREDENTIALS_SUCCESS: null,
   OAUTHV2_POST_CREDENTIALS_START: null
 });
+
+export const Constants = {
+  OAUTH_VERSION_3: 3,
+  OAUTH_VERSION_DEFAULT: 2,
+  OAUTH_V3_FEATURE: 'oauth-v3'
+};

--- a/src/scripts/modules/oauth-v2/Constants.js
+++ b/src/scripts/modules/oauth-v2/Constants.js
@@ -12,6 +12,6 @@ export const ActionTypes = keyMirror({
 
 export const Constants = {
   OAUTH_VERSION_3: 3,
-  OAUTH_VERSION_DEFAULT: 2,
+  OAUTH_VERSION_FALLBACK: 2,
   OAUTH_V3_FEATURE: 'oauth-v3'
 };

--- a/src/scripts/modules/oauth-v2/OauthUtils.js
+++ b/src/scripts/modules/oauth-v2/OauthUtils.js
@@ -102,7 +102,7 @@ export function createRedirectRouteSimple(componentId) {
 export function loadCredentialsFromConfig(componentId, configId) {
   const configuration = installedComponentsStore.getConfigData(componentId, configId);
   const id = configuration.getIn(configOauthPath);
-  const version = configuration.getIn(configOauthPathVersion, Constants.OAUTH_VERSION_DEFAULT);
+  const version = configuration.getIn(configOauthPathVersion, Constants.OAUTH_VERSION_FALLBACK);
 
   if (id) {
     return OauthActions.loadCredentials(componentId, id, version);
@@ -113,7 +113,7 @@ export function loadCredentialsFromConfig(componentId, configId) {
 export function deleteCredentialsAndConfigAuth(componentId, configId) {
   const configData = installedComponentsStore.getConfigData(componentId, configId);
   const credentialsId = configData.getIn(configOauthPath);
-  const version = configData.getIn(configOauthPathVersion, Constants.OAUTH_VERSION_DEFAULT);
+  const version = configData.getIn(configOauthPathVersion, Constants.OAUTH_VERSION_FALLBACK);
   const credentials = OauthStore.getCredentials(componentId, credentialsId, version);
   const authorizedFor = credentials.get('authorizedFor');
   return OauthActions.deleteCredentials(componentId, credentialsId, version)

--- a/src/scripts/modules/oauth-v2/react/AuthorizationForm.jsx
+++ b/src/scripts/modules/oauth-v2/react/AuthorizationForm.jsx
@@ -2,9 +2,10 @@ import React, {PropTypes} from 'react';
 import ApplicationStore from '../../../stores/ApplicationStore';
 import ServicesStore from '../../services/Store';
 import ComponentsStore from '../../components/stores/ComponentsStore';
+import {Constants} from '../Constants';
 
 function getOauthUrl() {
-  if (ApplicationStore.hasCurrentProjectFeature('oauth-v3')) {
+  if (ApplicationStore.hasCurrentProjectFeature(Constants.OAUTH_V3_FEATURE)) {
     return ServicesStore.getService('oauth').get('url');
   }
   return ComponentsStore.getComponent('keboola.oauth-v2').get('uri');

--- a/src/scripts/modules/oauth-v2/react/AuthorizationForm.jsx
+++ b/src/scripts/modules/oauth-v2/react/AuthorizationForm.jsx
@@ -1,9 +1,16 @@
 import React, {PropTypes} from 'react';
-import ComponentsStore from '../../components/stores/ComponentsStore';
 import ApplicationStore from '../../../stores/ApplicationStore';
+import ServicesStore from '../../services/Store';
+import ComponentsStore from '../../components/stores/ComponentsStore';
+
+function getOauthUrl() {
+  if (ApplicationStore.hasCurrentProjectFeature('oauth-v3')) {
+    return ServicesStore.getService('oauth').get('url');
+  }
+  return ComponentsStore.getComponent('keboola.oauth-v2').get('uri');
+}
 
 export default React.createClass({
-
   propTypes: {
     componentId: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
@@ -12,7 +19,7 @@ export default React.createClass({
   },
 
   render() {
-    const oauthUrl = ComponentsStore.getComponent('keboola.oauth-v2').get('uri');
+    const oauthUrl = getOauthUrl();
     const actionUrl = `${oauthUrl}/authorize/${this.props.componentId}`;
     const token = ApplicationStore.getSapiTokenString();
     const returnUrl = `${window.location.href}/${this.props.returnUrlSuffix}`;


### PR DESCRIPTION
Fixes https://github.com/keboola/kbc-ui/issues/2065

Proposed changes:
- If KBC project has enabled feature `oauth-v3` use new OAuth API endpoint from `Services` (e.g. oauth.keboola.com for US)
- To properly display and reset existing configs, old endpoint must be used for GET and DELETE requests. In case the old config is reset, it is deleted and new API is used in the following authorisation process. That's why the `version` parameter is passed to the `getCredentials` and `deleteCredentials` method.