### PR TITLE
Use component icon + friendly name in events logs

### DIFF
--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -31,8 +31,12 @@ export default React.createClass({
       <Link {...this.linkProps()}>
         <div className={classnames('td', 'text-nowrap', status)}>{format(this.props.event.get('created'))}</div>
         <div className={classnames('td', 'text-nowrap', status)}>
-          <ComponentIcon component={component} size="32" resizeToSize="16" />
-          <ComponentName component={component} showType={true} />
+          {component.get('name') && (
+            <span>
+              <ComponentIcon component={component} size="32" resizeToSize="16" />
+              <ComponentName component={component} showType={true} capitalize={true} />
+            </span>
+          )}
         </div>
         <div className={classnames('td', status)}>
           <NewLineToBr text={this.props.event.get('message')} />

--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -31,7 +31,8 @@ export default React.createClass({
       <Link {...this.linkProps()}>
         <div className={classnames('td', 'text-nowrap', status)}>{format(this.props.event.get('created'))}</div>
         <div className={classnames('td', 'text-nowrap', status)}>
-          <ComponentIcon component={component} size="32" /> <ComponentName component={component} showType={true} />
+          <ComponentIcon component={component} size="32" resizeToSize="16" />{' '}
+          <ComponentName component={component} showType={true} />
         </div>
         <div className={classnames('td', status)}>
           <NewLineToBr text={this.props.event.get('message')} />

--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -1,10 +1,13 @@
 import React, { PropTypes } from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
+import ComponentsStore from '../../components/stores/ComponentsStore';
 import { Link } from 'react-router';
 import _ from 'underscore';
 import classnames from 'classnames';
 import { format } from '../../../utils/date';
 import { NewLineToBr } from '@keboola/indigo-ui';
+import ComponentName from '../../../react/common/ComponentName';
+import ComponentIcon from '../../../react/common/ComponentIcon';
 
 const classmap = {
   error: 'bg-danger',
@@ -13,7 +16,7 @@ const classmap = {
 };
 
 export default React.createClass({
-  mixin: [PureRenderMixin],
+  mixins: [PureRenderMixin],
 
   propTypes: {
     event: PropTypes.object.isRequired,
@@ -22,11 +25,14 @@ export default React.createClass({
 
   render() {
     const status = classmap[this.props.event.get('type')];
+    const component = this.getComponent();
 
     return (
       <Link {...this.linkProps()}>
         <div className={classnames('td', 'text-nowrap', status)}>{format(this.props.event.get('created'))}</div>
-        <div className={classnames('td', 'text-nowrap', status)}>{this.props.event.get('component')}</div>
+        <div className={classnames('td', 'text-nowrap', status)}>
+          <ComponentIcon component={component} size="32" /> <ComponentName component={component} showType={true} />
+        </div>
         <div className={classnames('td', status)}>
           <NewLineToBr text={this.props.event.get('message')} />
         </div>
@@ -45,5 +51,16 @@ export default React.createClass({
       }),
       className: 'tr'
     };
+  },
+
+  getComponent() {
+    const componentId = this.props.event.get('component');
+    const component = ComponentsStore.getComponent(componentId);
+
+    if (!component) {
+      return ComponentsStore.unknownComponent(componentId);
+    }
+
+    return component;
   }
 });

--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -31,7 +31,7 @@ export default React.createClass({
       <Link {...this.linkProps()}>
         <div className={classnames('td', 'text-nowrap', status)}>{format(this.props.event.get('created'))}</div>
         <div className={classnames('td', 'text-nowrap', status)}>
-          <ComponentIcon component={component} size="32" resizeToSize="16" />{' '}
+          <ComponentIcon component={component} size="32" resizeToSize="16" />
           <ComponentName component={component} showType={true} />
         </div>
         <div className={classnames('td', status)}>

--- a/src/scripts/react/common/ComponentName.jsx
+++ b/src/scripts/react/common/ComponentName.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import { capitalize } from 'underscore.string';
 
 const shouldShowType = (component) => {
   return component.get('type') === 'extractor' || component.get('type') === 'writer';
@@ -7,24 +8,30 @@ const shouldShowType = (component) => {
 export default React.createClass({
   propTypes: {
     component: PropTypes.object.isRequired,
-    showType: PropTypes.bool
+    showType: PropTypes.bool,
+    capitalize: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      showType: false
+      showType: false,
+      capitalize: false
     };
   },
 
   render() {
-    const { component, showType } = this.props;
     return (
       <span>
-        {component.get('name')}
-        {showType && shouldShowType(component) && (
+        {this.componentName()}
+        {this.props.showType && shouldShowType(this.props.component) && (
           <span>{' '}<small>{this.props.component.get('type')}</small></span>
         )}
       </span>
     );
+  },
+
+  componentName() {
+    const name = this.props.component.get('name');
+    return this.props.capitalize ? capitalize(name) : name;
   }
 });


### PR DESCRIPTION
Fixes #2276

Před:
![pred](https://user-images.githubusercontent.com/12331181/48049009-8dcdf400-e19d-11e8-8fb0-bbe8ebe144af.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/48049005-8ad30380-e19d-11e8-84ef-800d6639185c.png)
