### PR TITLE
Transformation input/output mapping reset state after modal is closed

### DIFF
--- a/src/scripts/modules/transformations/react/modals/InputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/InputMapping.jsx
@@ -67,17 +67,13 @@ export default React.createClass({
     return (
       <span>
         { this.renderOpenButton() }
-        <Modal onHide={this.close} show={this.state.showModal} bsSize="large" onChange={() => null}>
+        <Modal onHide={this.handleCancel} show={this.state.showModal} bsSize="large">
           <Modal.Header closeButton={true}>
-            <Modal.Title>
-              {title}
-            </Modal.Title>
+            <Modal.Title>{title}</Modal.Title>
           </Modal.Header>
-
           <Modal.Body>
             {this.editor()}
           </Modal.Body>
-
           <Modal.Footer>
             <ConfirmButtons
               saveLabel={this.props.mode === MODE_CREATE ? 'Create Input' : 'Save'}

--- a/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
@@ -74,11 +74,7 @@ export default React.createClass({
     return (
       <span>
         { this.renderOpenButton() }
-        <Modal
-          onHide={this.close}
-          show={this.state.showModal}
-          bsSize="large"
-        >
+        <Modal onHide={this.handleCancel} show={this.state.showModal} bsSize="large">
           <Modal.Header closeButton={true}>
             <Modal.Title>{title}</Modal.Title>
           </Modal.Header>


### PR DESCRIPTION
Fixes #1830

Upravil jsem tedy input mapping (stejně tak output, aby to bylo konzistentní), že křížek nebo kliknutí bokem se chová stejně jako Cancel tlačítko dole.