### PR TITLE
Update bluebird

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@json-editor/json-editor": "^1.2.1",
     "@keboola/indigo-ui": "^7.4.7",
     "aws-sdk": "^2.4.7",
-    "bluebird": "~2.3.11",
+    "bluebird": "^3.5.3",
     "byte-converter": "^0.1.4",
     "classnames": "^2.2.6",
     "codemirror": "~5.8",

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -27,6 +27,13 @@ import initializeData from './initializeData';
 
 import ErrorNotification from './react/common/ErrorNotification';
 
+// Promise global config
+Promise.config({
+  warnings: false,
+  cancellation: true,
+  longStackTraces: true
+})
+
 /*
   Bootstrap and start whole application
   appOptions:
@@ -57,7 +64,6 @@ const startApp = appOptions => {
     location: appOptions.locationMode === 'history' ? Router.HistoryLocation : Router.HashLocation
   });
 
-  Promise.longStackTraces();
   // error thrown during application live not on route chage
   Promise.onPossiblyUnhandledRejection(e => {
     const error = Error.create(e);
@@ -120,7 +126,6 @@ const startApp = appOptions => {
 
     // wait for data and trigger render
     return (pendingPromise = Promise.all(promises)
-      .cancellable()
       .then(() => {
         RouterActionCreators.routeChangeSuccess(state);
         ReactDOM.render(<Handler />, appOptions.rootNode);

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -28,10 +28,9 @@ import initializeData from './initializeData';
 import ErrorNotification from './react/common/ErrorNotification';
 
 // Promise global config
+// Note: long stack traces and warnings are enabled in dev env by default
 Promise.config({
-  warnings: false,
-  cancellation: true,
-  longStackTraces: true
+  cancellation: true
 });
 
 /*

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -108,6 +108,7 @@ const startApp = appOptions => {
 
     if (pendingPromise) {
       pendingPromise.cancel();
+      console.log('cancelled route');
     }
 
     RouterActionCreators.routeChangeStart(state);
@@ -136,13 +137,13 @@ const startApp = appOptions => {
           return callback;
         }));
       })
-      .catch(Promise.CancellationError, () => console.log('cancelled route'))
       .catch(error => {
         // render error page
         console.log('route change error', error);
         RouterActionCreators.routeChangeError(error);
         return ReactDOM.render(<Handler isError={true} />, appOptions.rootNode);
-      }));
+      })
+    );
   });
 };
 

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -32,7 +32,7 @@ Promise.config({
   warnings: false,
   cancellation: true,
   longStackTraces: true
-})
+});
 
 /*
   Bootstrap and start whole application

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -10,7 +10,7 @@ request.serialize['application/x-www-form-urlencoded'] = function(data) {
 
 Request.prototype.promise = function() {
   const req = this;
-  const promise = new Promise(function(resolve, reject) {
+  return new Promise(function(resolve, reject) {
     return req
       .then(
         responseOk => {
@@ -28,7 +28,6 @@ Request.prototype.promise = function() {
         return reject(error);
       });
   });
-  return promise.cancellable();
 };
 
 module.exports = function(method, url) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1436,9 +1436,9 @@ bluebird@^3.5.1:
   version "3.5.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.2.tgz#1be0908e054a751754549c270489c1505d4ab15a"
 
-bluebird@~2.3.11:
-  version "2.3.11"
-  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.3.11.tgz#15bb78ed32abf27b090640c0f85e4b91f615c8b6"
+bluebird@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.3.tgz#7d01c6f9616c9a51ab0f8c549a79dfe6ec33efa7"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"


### PR DESCRIPTION
Toto asi nebude tak snadné. Ale aktuální knihovna je 4 roky stará (**2014-10-31**). 
Pokud člověk projde [changelog](http://bluebirdjs.com/docs/changelog.html) (je toho dost), tak se tam několikrát píše o navýšení výkonu o 10+% nebo lepší optimalizace nároků na paměť.

Mezi verzi 2 a 3 jsou tyto BC:

>Promisifier APIs.
Cancellation redesign.
Promise progression has been completely removed.
.spread's second argument has been removed.
.done causes an irrecoverable fatal error in Node.js environments now. See #471 for rationale.
Errors created with Promise.reject or reject callback of new Promise are no longer marked as OperationalErrors.

Co jsem koukal tak by se nás nemuselo nic týkat.

Jinak základní nastavení se přeneslo to metody config. Musí se třeba povolit `cancellation` aby se zachovalo původní chování. 

Celkově jsem tam dal toto abych zachoval současné chování:
```js
Promise.config({
  warnings: false, // vypne kupu hlášek že ne všude vracíme promise apod
  cancellation: true, // zapne možnost volat cancel(), zachování původního chování
  longStackTraces: true // toto bylo taky zaplé původně
})
```

Na to `longStackTraces ` by se mohlo mrknout více. Protože podle dokumentace by taková věc neměla jít do produkce. Protože prý výkon i nárok na pamět se může zhoršit násobně. Více info [tu](http://bluebirdjs.com/docs/api/promise.longstacktraces.html).
Asi by se to mělo pouštět pouze při vývoji. 


Ještě je v app.coffee třeba toto, ale to funguje stále stejně, takže by se nemuselo nic měnit.
```js
Promise.onPossiblyUnhandledRejectio....
```

Poslední co tak je tak taková změn v knihovně:
```js
// 2.x
Promise.promisify(fn, ctx);
// 3.0
Promise.promisify(fn, {context: ctx});
```
V aplikaci se promisify používá pouze na jednom místě u CSV, kde je pouze ten první parametr. Takže opět by to mělo být ok.
