### PR TITLE
Update diff js

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "d3": "~3.5.6",
     "dagre-d3": "git+https://git@github.com/keboola/dagre-d3.git#6b444d10ddb5276789b4b2bc1eafcd22a767968a",
     "deep-equal": "^1.0.1",
-    "diff": "^2.2.3",
+    "diff": "^3.5.0",
     "dimple": "git+https://github.com/PMSI-AlignAlytics/dimple.git",
     "filesize": "~2.0.4",
     "flux": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,11 +2569,7 @@ detective@^4.3.1:
     acorn "^3.1.0"
     defined "^1.0.0"
 
-diff@^2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"
-
-diff@^3.2.0:
+diff@^3.2.0, diff@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
 


### PR DESCRIPTION
Pouze aktualizace. 

Zkoumal jsem toto https://github.com/keboola/kbc-ui/issues/980 a jako první jsem aktualizoval knihovnu. Bohužel pak jsem to nedořešil. Tak to šlo pryč, aktualizace může myslím zůstat, neviděl jsem v [changelogu](https://github.com/kpdecker/jsdiff/blob/master/release-notes.md) žádný BC break pro náš kód.