### PR TITLE
Load configs data when component is restored from trash

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -390,7 +390,10 @@ module.exports = {
         configurationId: configurationId,
         transition: transition
       });
-      return actions.loadInstalledComponentsForce().then(function() {
+      return Promise.all([
+        actions.loadInstalledComponentsForce(),
+        actions.loadComponentConfigsDataForce(componentId)
+      ]).then(function() {
         return ApplicationActionCreators.sendNotification({
           message: configurationRestoredNotification(componentId, configurationId, configuration)
         });


### PR DESCRIPTION
Fixes #1130

Když obnovuji komponentu z koše, vyžádám si taky konfigurace pro daný modul, tím se zbavím toho probliknutí v Transformacích a asi dalších modulech.

Pokud se opraví https://github.com/keboola/kbc-ui/pull/2239 bude asi možné načíst pouze jednu konkrétní konfiguraci. V současné tobě to nefunguje.
