### PR TITLE
DockerSandboxModal - reset state when close modal

### DIFF
--- a/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
@@ -81,7 +81,7 @@ var JupyterSandbox = React.createClass({
         <span>
           <CreateDockerSandboxModal
             show={this.state.showModal}
-            close={this.closeModal}
+            close={this.handleClose}
             create={this._createCredentials}
             tables={this.tablesList()}
             type="Jupyter"
@@ -134,8 +134,11 @@ var JupyterSandbox = React.createClass({
   _dropCredentials: function() {
     return CredentialsActionCreators.dropJupyterSandboxCredentials();
   },
-  closeModal() {
-    this.setState({ showModal: false });
+  handleClose() {
+    this.setState({
+      showModal: false,
+      sandboxConfiguration: Immutable.Map()
+    });
   },
   openModal() {
     this.setState({ showModal: true });

--- a/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
@@ -81,7 +81,7 @@ var RStudioSandbox = React.createClass({
         <span>
           <CreateDockerSandboxModal
             show={this.state.showModal}
-            close={this.closeModal}
+            close={this.handleClose}
             create={this._createCredentials}
             tables={this.tablesList()}
             type="RStudio"
@@ -133,8 +133,11 @@ var RStudioSandbox = React.createClass({
   _dropCredentials: function() {
     return CredentialsActionCreators.dropRStudioSandboxCredentials();
   },
-  closeModal() {
-    this.setState({ showModal: false });
+  handleClose() {
+    this.setState({
+      showModal: false,
+      sandboxConfiguration: Immutable.Map()
+    });
   },
   openModal() {
     this.setState({ showModal: true });


### PR DESCRIPTION
Jde o RStudio a Jupyter sandbox.

Byl tam bug že dám "New Sandbox" -> otevře se modal, "Create sandbox" je disabled protože nemám vybranou žádnou tabulku. Tak nějakou vyberu, ale pak zavřu modal. Po znovuotevření nemám vybranou žádnou tabulku ale "Create sandbox" už není disabled. Aplikace si pomaluje tu předešlou zvolenou tabulku, jen to nezobrazí. Myslím že by to ani ukázat neměla, spíš po kliku na close to celé resetovat.

![bug](https://user-images.githubusercontent.com/12331181/48255809-0509bf00-e40e-11e8-9a59-16f4adf86ed4.png)


