### PR TITLE
StorageApi - Bucket & FileUpload - remove onClick from link

### DIFF
--- a/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
@@ -16,7 +16,6 @@ export default React.createClass({
       <a
         target="_blank"
         href={this.bucketUrl()}
-        onClick={(e) => e.stopPropagation()}
       >{this.props.children}</a>
     );
   }

--- a/src/scripts/modules/components/react/components/StorageApiFileUploadsLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiFileUploadsLink.jsx
@@ -15,7 +15,6 @@ export default React.createClass({
       <a
         target="_blank"
         href={this.fileUploadsUrl()}
-        onClick={(e) => e.stopPropagation()}
       >{this.props.children}</a>
     );
   }

--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTableCell.jsx
@@ -24,7 +24,7 @@ const TableCell = React.createClass({
       const tableName = this.props.valueFn(this.props.row);
       const bucketId = defaultBucketStage + '.c-' + sanitizedComponentId + '-' + this.props.configurationId;
       if (!tableName) {
-        return (<span>
+        return (<span onClick={e => e.stopPropagation()}>
           Unable to determine table name.<br />
           Check bucket
           {' '}<StorageApiBucketLink bucketId={bucketId}>{bucketId}</StorageApiBucketLink>


### PR DESCRIPTION
Related #2313

Tady se mi nepodařilo se k tomu někdo doklikat. Abych to viděl v UI a koukal co udělá když vyhodím ten onclick. Dokázal by si mě navést?
Koukal jsem na podobnou komponentu "StorageApiTableLink" a tam onClick taky není, tak možné není prostě potřeba ani tu. Ale lepší by bylo to vidět co to dělá no.