### PR TITLE
WR-DB - set all column datatype with options

### DIFF
--- a/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
+import ColumnRow from './ColumnRow';
 import Hint from '../../../../../react/common/Hint';
 import Tooltip from '../../../../../react/common/Tooltip';
 
 export default React.createClass({
   propTypes: {
     columns: React.PropTypes.object.isRequired,
-    renderRowFn: React.PropTypes.func.isRequired,
     filterColumnFn: React.PropTypes.func.isRequired,
     onToggleHideIgnored: React.PropTypes.func.isRequired,
     editButtons: React.PropTypes.object.isRequired,
@@ -22,35 +22,6 @@ export default React.createClass({
   },
 
   render() {
-    const columns = this.props.columns.filter(column => {
-      let fn = column;
-      if (this.props.editingColumns) {
-        fn = this.props.editingColumns.get(column.get('name'));
-      }
-      return this.props.filterColumnFn(fn);
-    });
-    const rows = columns.map((column, index) => {
-      const cname = column.get('name');
-      let editingColumn = null;
-      let isValid = true;
-      if (this.props.editingColumns) {
-        editingColumn = this.props.editingColumns.get(cname);
-        isValid = this.props.columnsValidation.get(cname, true);
-      }
-
-      return this.props.renderRowFn({
-        key: index,
-        isValid,
-        isSaving: this.props.isSaving,
-        column,
-        editingColumn,
-        dataTypes: this.props.dataTypes,
-        editColumnFn: this.props.editColumnFn,
-        dataPreview: this.props.dataPreview,
-        disabledFields: this.props.disabledColumnFields
-      });
-    });
-
     return (
       <div style={{ overflow: 'scroll' }}>
         <table className="table table-striped kbc-table-editor">
@@ -76,20 +47,54 @@ export default React.createClass({
               <th>{this.props.editButtons}</th>
             </tr>
           </thead>
-          <tbody>
-            {rows.count() > 0 ? (
-              rows
-            ) : (
-              <tr>
-                <td colSpan="6">
-                  <div className="text-center">No Columns.</div>
-                </td>
-              </tr>
-            )}
-          </tbody>
+          <tbody>{this._renderRows()}</tbody>
         </table>
       </div>
     );
+  },
+
+  _renderRows() {
+    const columns = this.props.columns.filter(column => {
+      let fn = column;
+      if (this.props.editingColumns) {
+        fn = this.props.editingColumns.get(column.get('name'));
+      }
+      return this.props.filterColumnFn(fn);
+    });
+
+    if (!columns.count()) {
+      return (
+        <tr>
+          <td colSpan="6">
+            <div className="text-center">No Columns.</div>
+          </td>
+        </tr>
+      );
+    }
+
+    return columns.map((column, index) => {
+      const cname = column.get('name');
+      let editingColumn = null;
+      let isValid = true;
+      if (this.props.editingColumns) {
+        editingColumn = this.props.editingColumns.get(cname);
+        isValid = this.props.columnsValidation.get(cname, true);
+      }
+
+      return (
+        <ColumnRow
+          key={index}
+          isValid={isValid}
+          isSaving={this.props.isSaving}
+          column={column}
+          editingColumn={editingColumn}
+          dataTypes={this.props.dataTypes}
+          editColumnFn={this.props.editColumnFn}
+          dataPreview={this.props.dataPreview}
+          disabledFields={this.props.disabledColumnFields}
+        />
+      );
+    });
   },
 
   _renderNullableHeader() {

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -369,9 +369,6 @@ export default componentId => {
             <select
               defaultValue={this.state.allColumnsDataTypeSize}
               onChange={e => {
-                this.setState({
-                  allColumnsDataTypeSize: e.target.value
-                });
                 this.state.editingColumns.map(column => {
                   this._onEditColumn(column.set('size', e.target.value));
                 });

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -7,7 +7,7 @@ import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import TableNameEdit from './TableNameEdit';
 import ColumnsEditor from './ColumnsEditor';
 import ColumnRow from './ColumnRow';
-import DataTypes from '../../../templates/dataTypes';
+import DataTypes, { defaultDataTypes } from '../../../templates/dataTypes';
 import columnTypeValidation from '../../../columnTypeValidation';
 
 import storageApi from '../../../../components/StorageApi';
@@ -24,16 +24,6 @@ import FiltersDescription from '../../../../components/react/components/generic/
 import IsDockerBasedFn from '../../../templates/dockerProxyApi';
 import IncrementalSetupModal from './IncrementalSetupModal';
 import {Alert} from 'react-bootstrap';
-
-const defaultDataTypes = [
-  'INT',
-  'BIGINT',
-  { VARCHAR: { defaultSize: '255' } },
-  'TEXT',
-  { DECIMAL: { defaultSize: '12,2' } },
-  'DATE',
-  'DATETIME'
-];
 
 export default componentId => {
   return React.createClass({
@@ -382,26 +372,15 @@ export default componentId => {
             <select
               defaultValue=""
               onChange={e => {
-                const size = e.target.value;
-
-                return this.state.editingColumns.map(ec => {
-                  let newColumn = ec.set('size', size);
-                  return this._onEditColumn(newColumn);
+                return this.state.editingColumns.map(column => {
+                  return this._onEditColumn(column.set('size', e.target.value));
                 });
               }}
             >
               {this.state.allColumnsDataTypeOptions.map(option => {
-                if (_.isObject(option)) {
-                  return (
-                    <option value={option.value} key={option.value}>
-                      {option.label}
-                    </option>
-                  );
-                }
-
                 return (
-                  <option value={option} key={option}>
-                    {option}
+                  <option value={option.value} key={option.value}>
+                    {option.label}
                   </option>
                 );
               })}

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -77,7 +77,10 @@ export default componentId => {
     },
 
     getInitialState() {
-      return { dataPreview: null };
+      return {
+        dataPreview: null,
+        allColumnsDataTypeOptions: []
+      };
     },
 
     _prepareColumns(configColumns, storageColumns) {
@@ -355,11 +358,16 @@ export default componentId => {
           <select
             defaultValue=""
             onChange={e => {
-              const { value } = e.target;
+              const dataType = e.target.value;
+
+              this.setState({
+                allColumnsDataTypeOptions: this._getDataTypeOptions(dataType)
+              });
+
               return this.state.editingColumns.map(ec => {
-                let newColumn = ec.set('type', value);
-                if (_.isString(this._getSizeParam(value))) {
-                  const defaultSize = this._getSizeParam(value);
+                let newColumn = ec.set('type', dataType);
+                if (_.isString(this._getSizeParam(dataType))) {
+                  const defaultSize = this._getSizeParam(dataType);
                   newColumn = newColumn.set('size', defaultSize);
                 } else {
                   newColumn = newColumn.set('size', '');
@@ -370,6 +378,36 @@ export default componentId => {
           >
             {options}
           </select>
+
+          {this.state.allColumnsDataTypeOptions.length > 0 && (
+            <select
+              defaultValue=""
+              onChange={e => {
+                const size = e.target.value;
+
+                return this.state.editingColumns.map(ec => {
+                  let newColumn = ec.set('size', size);
+                  return this._onEditColumn(newColumn);
+                });
+              }}
+            >
+              {this.state.allColumnsDataTypeOptions.map(option => {
+                if (_.isObject(option)) {
+                  return (
+                    <option value={option.value} key={option.value}>
+                      {option.label}
+                    </option>
+                  );
+                }
+
+                return (
+                  <option value={option} key={option}>
+                    {option}
+                  </option>
+                );
+              })}
+            </select>
+          )}
         </span>
       );
     },
@@ -419,6 +457,12 @@ export default componentId => {
       const dtypes = this._getComponentDataTypes();
       const dt = _.find(dtypes, d => _.isObject(d) && _.keys(d)[0] === dataType);
       return dt && dt[dataType] && dt[dataType].defaultSize;
+    },
+
+    _getDataTypeOptions(dataType) {
+      const dtypes = this._getComponentDataTypes();
+      const dt = _.find(dtypes, d => _.isObject(d) && _.keys(d)[0] === dataType);
+      return (dt && dt[dataType] && dt[dataType].options) || [];
     },
 
     _getDataTypes() {

--- a/src/scripts/modules/wr-db/templates/dataTypes.js
+++ b/src/scripts/modules/wr-db/templates/dataTypes.js
@@ -133,11 +133,7 @@ const snowflake = [
   {
     varchar: {
       defaultSize: '255',
-      options: [
-        { value: '255', label: '255 ' },
-        { value: '65535', label: '65535 ' },
-        { value: '16777213', label: '16M ' }
-      ]
+      options: [{ value: '255', label: '255' }, { value: '65535', label: '65535' }, { value: '16777216', label: '16M' }]
     }
   },
   { string: { defaultSize: '255' } },

--- a/src/scripts/modules/wr-db/templates/dataTypes.js
+++ b/src/scripts/modules/wr-db/templates/dataTypes.js
@@ -130,7 +130,7 @@ const snowflake = [
   'boolean',
   { char: { defaultSize: '255' } },
   { character: { defaultSize: '255' } },
-  { varchar: { defaultSize: '255' } },
+  { varchar: { defaultSize: '255', options: ['255', '65535', { value: '16777213', label: '16M ' }] } },
   { string: { defaultSize: '255' } },
   { text: { defaultSize: '16777216' } },
   { binary: { defaultSize: '255' } },

--- a/src/scripts/modules/wr-db/templates/dataTypes.js
+++ b/src/scripts/modules/wr-db/templates/dataTypes.js
@@ -130,7 +130,16 @@ const snowflake = [
   'boolean',
   { char: { defaultSize: '255' } },
   { character: { defaultSize: '255' } },
-  { varchar: { defaultSize: '255', options: ['255', '65535', { value: '16777213', label: '16M ' }] } },
+  {
+    varchar: {
+      defaultSize: '255',
+      options: [
+        { value: '255', label: '255 ' },
+        { value: '65535', label: '65535 ' },
+        { value: '16777213', label: '16M ' }
+      ]
+    }
+  },
   { string: { defaultSize: '255' } },
   { text: { defaultSize: '16777216' } },
   { binary: { defaultSize: '255' } },
@@ -187,6 +196,16 @@ const thoughtspot = [
   'date',
   'time',
   'datetime'
+];
+
+export const defaultDataTypes = [
+  'INT',
+  'BIGINT',
+  { VARCHAR: { defaultSize: '255' } },
+  'TEXT',
+  { DECIMAL: { defaultSize: '12,2' } },
+  'DATE',
+  'DATETIME'
 ];
 
 export default {

--- a/src/scripts/modules/wr-db/templates/dataTypes.js
+++ b/src/scripts/modules/wr-db/templates/dataTypes.js
@@ -130,16 +130,7 @@ const snowflake = [
   'boolean',
   { char: { defaultSize: '255' } },
   { character: { defaultSize: '255' } },
-  {
-    varchar: {
-      defaultSize: '255',
-      options: [
-        { value: '255', label: '255 ' },
-        { value: '65535', label: '65535 ' },
-        { value: '16777213', label: '16M ' }
-      ]
-    }
-  },
+  { varchar: { defaultSize: '255', options: ['255', '65535', { value: '16777213', label: '16M ' }] } },
   { string: { defaultSize: '255' } },
   { text: { defaultSize: '16777216' } },
   { binary: { defaultSize: '255' } },
@@ -196,16 +187,6 @@ const thoughtspot = [
   'date',
   'time',
   'datetime'
-];
-
-export const defaultDataTypes = [
-  'INT',
-  'BIGINT',
-  { VARCHAR: { defaultSize: '255' } },
-  'TEXT',
-  { DECIMAL: { defaultSize: '12,2' } },
-  'DATE',
-  'DATETIME'
 ];
 
 export default {


### PR DESCRIPTION
Fixes #1509

Ta table komponenta je už docela nepřehledná, ale zkusil jsme tam přihodit tu možnost definovat dodatečné možnosti pro daný typ.

Lze teda zapsat něco jako:
```js
{ varchar: { defaultSize: '255', options: ['255', '65535'] }
```
Tím se po zvolení varchar automaticky nastaví 255 + vypíše se další select kde lze volit jak 255 tak 65535.

![options](https://user-images.githubusercontent.com/12331181/48423132-5395c100-e760-11e8-8b11-2cfcd1fee1e3.png)

Je možné take definovat option jako objekt, pokud chci více "user frindly" popis velikosti. Příklad:
```js
{ varchar: { defaultSize: '255', options: ['255', '65535', { value: '16777213', label: '16M ' }] } }
```

Takto tam přibude možnost 16M ale value nastaví 16777213.
![object](https://user-images.githubusercontent.com/12331181/48423171-5ee8ec80-e760-11e8-83f0-3a52de2f3dde.png)

Pro test jsem přihodit do tohoto PR pouze ty tři možnosti pro varchar. Na ukázku. Pokud to bude OK řešení tak rád přidám další možnosti k jiným datovým typům.


