### PR TITLE
feat: partial run job label

### DIFF
--- a/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
+++ b/src/scripts/modules/components/react/components/SidebarJobsRow.coffee
@@ -5,6 +5,7 @@ JobStatusCircle = React.createFactory(require('../../../../react/common/JobStatu
 FinishedWithIcon = React.createFactory(require('../../../../react/common/FinishedWithIcon').default)
 DurationWithIcon = React.createFactory(require('../../../../react/common/DurationWithIcon').default)
 ImmutableRendererMixin = require 'react-immutable-render-mixin'
+JobPartialRunLabel = React.createFactory(require('../../../../react/common/JobPartialRunLabel').default)
 
 Link = React.createFactory(require('react-router').Link)
 
@@ -28,6 +29,8 @@ JobNavRow = React.createClass
           JobStatusCircle status: @props.job.get('status')
         span className: 'td',
           div null,
+            JobPartialRunLabel
+              job: @props.job
             @props.job.getIn ['token', 'description']
           div null,
             small className: 'pull-left',

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import {Link} from 'react-router';
 import JobStatusLabel from '../../../../../react/common/JobStatusLabel';
+import JobPartialRunLabel from '../../../../../react/common/JobPartialRunLabel';
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
 import Duration from '../../../../../react/common/Duration';
@@ -27,6 +28,7 @@ export default React.createClass({
           <ComponentIcon component={component} size="32"/> <ComponentName component={component} showType />
         </div>
         <div className="td">
+          <JobPartialRunLabel job={this.props.job} />
           { this.jobConfiguration() }
         </div>
         <div className="td">

--- a/src/scripts/react/common/JobPartialRunLabel.jsx
+++ b/src/scripts/react/common/JobPartialRunLabel.jsx
@@ -1,0 +1,25 @@
+import React, {PropTypes} from 'react';
+
+
+export default React.createClass({
+  propTypes: {
+    job: PropTypes.object.isRequired
+  },
+
+  render() {
+    if (
+      this.props.job.hasIn(['params', 'row'])
+      || this.props.job.hasIn(['params', 'transformations']) && this.props.job.getIn(['params', 'transformations']).count() > 0
+      || this.props.job.hasIn(['params', 'phases']) && this.props.job.getIn(['params', 'phases']).count() > 0) {
+      return (
+        <span>
+          <span className="label label-default">
+            partial
+          </span>
+          {' '}
+        </span>
+      );
+    }
+    return null;
+  }
+});


### PR DESCRIPTION
Vytaženo z https://github.com/keboola/kbc-ui/pull/1947

Proposed changes:

Pokud není konfigurace (transformační bucket) puštěná celá, tak se
- v seznamu jobů zobrazí šedivý `partial` label nalevo od názvu konfigurace
- v detailu konfigurace zobrazí šedivý `partial` label nalevo od tokenu

U orchestrací to teď nejde zobrazit, muselo by se to uložit při založení jobu

![image](https://user-images.githubusercontent.com/497675/48481822-1e947780-e80f-11e8-83ab-6486231c1fa3.png)

![image](https://user-images.githubusercontent.com/497675/48481831-26541c00-e80f-11e8-9dbe-adf53b3b2b36.png)

![image](https://user-images.githubusercontent.com/497675/48481922-74691f80-e80f-11e8-8304-a31447033676.png)


![image](https://user-images.githubusercontent.com/497675/48481914-6f0bd500-e80f-11e8-852d-74d90ecbf6aa.png)


