### PR TITLE
strict configrows search

### DIFF
--- a/src/scripts/modules/configurations/react/components/ConfigurationRows.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRows.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import immutableMixin from 'react-immutable-render-mixin';
-import fuzzy from 'fuzzy';
 import {SearchBar} from '@keboola/indigo-ui';
 import Immutable from 'immutable';
 import ConfigurationRowsTable from './ConfigurationRowsTable';
@@ -44,9 +43,6 @@ export default React.createClass({
           );
         }
       ],
-      filter: function(row, query) {
-        return fuzzy.test(query, row.get('name')) || fuzzy.test(query, row.get('description'));
-      },
       objectName: 'Row'
     };
   },

--- a/src/scripts/modules/configurations/utils/createRoute.js
+++ b/src/scripts/modules/configurations/utils/createRoute.js
@@ -10,7 +10,6 @@ import InstalledComponentsStore from '../../components/stores/InstalledComponent
 import ComponentsStore from '../../components/stores/ComponentsStore';
 import ConfigurationRowsStore from '../ConfigurationRowsStore';
 import _ from 'lodash';
-import fuzzy from 'fuzzy';
 import Immutable from 'immutable';
 import {createTablesRoute} from '../../table-browser/routes';
 import {loadCredentialsFromConfig as loadOauthCredentials} from '../../oauth-v2/OauthUtils';
@@ -36,7 +35,8 @@ const defaults = {
     },
     columns: [],
     searchFilter: function(row, query) {
-      return fuzzy.test(query, row.get('name')) || fuzzy.test(query, row.get('description'));
+      const lowerCaseQuery = query.toLowerCase();
+      return row.get('name').toLowerCase().match(lowerCaseQuery) || row.get('description').toLowerCase().match(lowerCaseQuery);
     }
   }
 };

--- a/src/scripts/modules/configurations/utils/createRoute.js
+++ b/src/scripts/modules/configurations/utils/createRoute.js
@@ -13,6 +13,7 @@ import _ from 'lodash';
 import Immutable from 'immutable';
 import {createTablesRoute} from '../../table-browser/routes';
 import {loadCredentialsFromConfig as loadOauthCredentials} from '../../oauth-v2/OauthUtils';
+import matchByWords from '../../../utils/matchByWords';
 
 // defaults
 const defaults = {
@@ -36,7 +37,8 @@ const defaults = {
     columns: [],
     searchFilter: function(row, query) {
       const lowerCaseQuery = query.toLowerCase();
-      return row.get('name').toLowerCase().match(lowerCaseQuery) || row.get('description').toLowerCase().match(lowerCaseQuery);
+      return matchByWords(row.get('name').toLowerCase(), lowerCaseQuery) ||
+             matchByWords(row.get('description').toLowerCase(), lowerCaseQuery);
     }
   }
 };

--- a/src/scripts/utils/matchByWords.js
+++ b/src/scripts/utils/matchByWords.js
@@ -1,12 +1,6 @@
 export default function(inputString, query) {
   const queryWords = query.trim().split(' ');
-  const result = queryWords.reduce(
-    (memo, word) => {
-      const fromIndex = memo.lastMatch && inputString.indexOf(word, memo.fromIndex);
-      const lastMatch = memo.lastMatch && fromIndex >= 0;
-      return { lastMatch, fromIndex };
-    },
-    { fromIndex: 0, lastMatch: true }
-  );
-  return result.lastMatch;
+  return queryWords.reduce((memo, word) => {
+    return memo && inputString.indexOf(word) >= 0;
+  }, true);
 }

--- a/src/scripts/utils/matchByWords.js
+++ b/src/scripts/utils/matchByWords.js
@@ -1,0 +1,12 @@
+export default function(inputString, query) {
+  const queryWords = query.trim().split(' ');
+  const result = queryWords.reduce(
+    (memo, word) => {
+      const fromIndex = memo.lastMatch && inputString.indexOf(word, memo.fromIndex);
+      const lastMatch = memo.lastMatch && fromIndex >= 0;
+      return { lastMatch, fromIndex };
+    },
+    { fromIndex: 0, lastMatch: true }
+  );
+  return result.lastMatch;
+}

--- a/src/scripts/utils/matchByWords.spec.js
+++ b/src/scripts/utils/matchByWords.spec.js
@@ -1,0 +1,56 @@
+import assert from 'assert';
+import matchByWords from './matchByWords';
+
+
+describe('test matchByWords', () => {
+  it('should match empty query', () => {
+    assert.ok(matchByWords(' some input string with spaces  ', ''));
+    assert.ok(matchByWords('someinputstringwithoutspace', ''));
+    assert.ok(matchByWords('', ''));
+  });
+
+  it('should strict match one word query', () => {
+    assert.ok(matchByWords('some input param string', 'param'));
+    assert.ok(matchByWords('some input param string', 'param  '));
+    assert.ok(matchByWords('some input param string', ' param  '));
+  });
+
+  it('should not fuzzy match word', () => {
+    assert.ok(!matchByWords('some input param string', 'taram'));
+    assert.ok(!matchByWords('some input param string', 'taram  '));
+    assert.ok(!matchByWords('some input param string', ' taram  '));
+    assert.ok(!matchByWords('some input param string', ' mara  '));
+  });
+
+  it('should match words in order', () => {
+    assert.ok(matchByWords('some input param string', 'some param'));
+    assert.ok(matchByWords('some input param string', '  some   param  '));
+    assert.ok(matchByWords('some input param string', ' some  string   '));
+  });
+
+  it('should not match more words', () => {
+    assert.ok(!matchByWords('some input param string', ' string param'));
+    assert.ok(!matchByWords('some input param string', '  blabla   param  '));
+    assert.ok(!matchByWords('some input param string', ' some  blablag   '));
+    assert.ok(!matchByWords('some input param string', ' total  blablag   '));
+  });
+
+  it('should not fuzzy match more words', () => {
+    assert.ok(!matchByWords('some input param string', ' prm str'));
+    assert.ok(!matchByWords('some input param string', '  param   sti  '));
+    assert.ok(!matchByWords('some input param string', ' sm  st '));
+  });
+
+  it('should fuzzy match by single characters', () => {
+    assert.ok(matchByWords('some input param string', ' p r m str'));
+    assert.ok(matchByWords('some input param string', '  param   st i  '));
+    assert.ok(matchByWords('some input param string', ' som  s g '));
+  });
+
+  it('should not fuzzy match by single characters', () => {
+    assert.ok(!matchByWords('some input param string', ' string p r m str'));
+    assert.ok(!matchByWords('some input param string', ' i g put'));
+    assert.ok(!matchByWords('some input param string', ' igput  s'));
+    assert.ok(!matchByWords('some input param string', ' input  e'));
+  });
+});

--- a/src/scripts/utils/matchByWords.spec.js
+++ b/src/scripts/utils/matchByWords.spec.js
@@ -24,12 +24,12 @@ describe('test matchByWords', () => {
 
   it('should match words in order', () => {
     assert.ok(matchByWords('some input param string', 'some param'));
+    assert.ok(matchByWords('some input param string', ' string param'));
     assert.ok(matchByWords('some input param string', '  some   param  '));
     assert.ok(matchByWords('some input param string', ' some  string   '));
   });
 
   it('should not match more words', () => {
-    assert.ok(!matchByWords('some input param string', ' string param'));
     assert.ok(!matchByWords('some input param string', '  blabla   param  '));
     assert.ok(!matchByWords('some input param string', ' some  blablag   '));
     assert.ok(!matchByWords('some input param string', ' total  blablag   '));
@@ -42,15 +42,16 @@ describe('test matchByWords', () => {
   });
 
   it('should fuzzy match by single characters', () => {
+    assert.ok(matchByWords('some input param string', ' string p r m str'));
     assert.ok(matchByWords('some input param string', ' p r m str'));
     assert.ok(matchByWords('some input param string', '  param   st i  '));
     assert.ok(matchByWords('some input param string', ' som  s g '));
+    assert.ok(matchByWords('some input param string', ' i g put'));
+
+    assert.ok(matchByWords('some input param string', ' input  e'));
   });
 
   it('should not fuzzy match by single characters', () => {
-    assert.ok(!matchByWords('some input param string', ' string p r m str'));
-    assert.ok(!matchByWords('some input param string', ' i g put'));
     assert.ok(!matchByWords('some input param string', ' igput  s'));
-    assert.ok(!matchByWords('some input param string', ' input  e'));
   });
 });

--- a/src/scripts/utils/matchByWords.spec.js
+++ b/src/scripts/utils/matchByWords.spec.js
@@ -4,54 +4,54 @@ import matchByWords from './matchByWords';
 
 describe('test matchByWords', () => {
   it('should match empty query', () => {
-    assert.ok(matchByWords(' some input string with spaces  ', ''));
-    assert.ok(matchByWords('someinputstringwithoutspace', ''));
-    assert.ok(matchByWords('', ''));
+    assert.strictEqual(matchByWords(' some input string with spaces  ', ''), true);
+    assert.strictEqual(matchByWords('someinputstringwithoutspace', ''), true);
+    assert.strictEqual(matchByWords('', ''), true);
   });
 
   it('should strict match one word query', () => {
-    assert.ok(matchByWords('some input param string', 'param'));
-    assert.ok(matchByWords('some input param string', 'param  '));
-    assert.ok(matchByWords('some input param string', ' param  '));
+    assert.strictEqual(matchByWords('some input param string', 'param'), true);
+    assert.strictEqual(matchByWords('some input param string', 'param  '), true);
+    assert.strictEqual(matchByWords('some input param string', ' param  '), true);
   });
 
   it('should not fuzzy match word', () => {
-    assert.ok(!matchByWords('some input param string', 'taram'));
-    assert.ok(!matchByWords('some input param string', 'taram  '));
-    assert.ok(!matchByWords('some input param string', ' taram  '));
-    assert.ok(!matchByWords('some input param string', ' mara  '));
+    assert.strictEqual(matchByWords('some input param string', 'taram'), false);
+    assert.strictEqual(matchByWords('some input param string', 'taram  '), false);
+    assert.strictEqual(matchByWords('some input param string', ' taram  '), false);
+    assert.strictEqual(matchByWords('some input param string', ' mara  '), false);
   });
 
   it('should match words in order', () => {
-    assert.ok(matchByWords('some input param string', 'some param'));
-    assert.ok(matchByWords('some input param string', ' string param'));
-    assert.ok(matchByWords('some input param string', '  some   param  '));
-    assert.ok(matchByWords('some input param string', ' some  string   '));
+    assert.strictEqual(matchByWords('some input param string', 'some param'), true);
+    assert.strictEqual(matchByWords('some input param string', ' string param'), true);
+    assert.strictEqual(matchByWords('some input param string', '  some   param  '), true);
+    assert.strictEqual(matchByWords('some input param string', ' some  string   '), true);
   });
 
   it('should not match more words', () => {
-    assert.ok(!matchByWords('some input param string', '  blabla   param  '));
-    assert.ok(!matchByWords('some input param string', ' some  blablag   '));
-    assert.ok(!matchByWords('some input param string', ' total  blablag   '));
+    assert.strictEqual(matchByWords('some input param string', '  blabla   param  '), false);
+    assert.strictEqual(matchByWords('some input param string', ' some  blablag   '), false);
+    assert.strictEqual(matchByWords('some input param string', ' total  blablag   '), false);
   });
 
   it('should not fuzzy match more words', () => {
-    assert.ok(!matchByWords('some input param string', ' prm str'));
-    assert.ok(!matchByWords('some input param string', '  param   sti  '));
-    assert.ok(!matchByWords('some input param string', ' sm  st '));
+    assert.strictEqual(matchByWords('some input param string', ' prm str'), false);
+    assert.strictEqual(matchByWords('some input param string', '  param   sti  '), false);
+    assert.strictEqual(matchByWords('some input param string', ' sm  st '), false);
   });
 
   it('should fuzzy match by single characters', () => {
-    assert.ok(matchByWords('some input param string', ' string p r m str'));
-    assert.ok(matchByWords('some input param string', ' p r m str'));
-    assert.ok(matchByWords('some input param string', '  param   st i  '));
-    assert.ok(matchByWords('some input param string', ' som  s g '));
-    assert.ok(matchByWords('some input param string', ' i g put'));
+    assert.strictEqual(matchByWords('some input param string', ' string p r m str'), true);
+    assert.strictEqual(matchByWords('some input param string', ' p r m str'), true);
+    assert.strictEqual(matchByWords('some input param string', '  param   st i  '), true);
+    assert.strictEqual(matchByWords('some input param string', ' som  s g '), true);
+    assert.strictEqual(matchByWords('some input param string', ' i g put'), true);
 
-    assert.ok(matchByWords('some input param string', ' input  e'));
+    assert.strictEqual(matchByWords('some input param string', ' input  e'), true);
   });
 
   it('should not fuzzy match by single characters', () => {
-    assert.ok(!matchByWords('some input param string', ' igput  s'));
+    assert.strictEqual(matchByWords('some input param string', ' igput  s'), false);
   });
 });


### PR DESCRIPTION
Fixes #2341 

defaultne sa teraz pouzia match na lowercased name/description namiesto fuzzy.test.

pred 
![image](https://user-images.githubusercontent.com/1412120/48495295-f79a6d80-e82f-11e8-916f-09c090651597.png)
po
![image](https://user-images.githubusercontent.com/1412120/48496514-6d073d80-e832-11e8-9d92-1fa8736e50dc.png)

