### PR TITLE
Unpause all notifications on route change

### DIFF
--- a/src/scripts/stores/NotificationsStore.coffee
+++ b/src/scripts/stores/NotificationsStore.coffee
@@ -52,4 +52,12 @@ Dispatcher.register (payload) ->
             notifications.delete index
           NotificationsStore.emitChange()
 
+    when Constants.ActionTypes.ROUTER_ROUTE_CHANGE_SUCCESS
+      _store = _store
+        .update 'notifications', (notifications) ->
+          notifications.map( (notf) ->
+            notf.set('paused', false)
+          )
+      NotificationsStore.emitChange()
+
 module.exports = NotificationsStore


### PR DESCRIPTION
Related to #2028 

Proposed changes:

- This will set all notifications to `paused: false` after route change