### PR TITLE
Header - remove unused state

### DIFF
--- a/src/scripts/react/layout/Header.jsx
+++ b/src/scripts/react/layout/Header.jsx
@@ -23,14 +23,12 @@ export default React.createClass({
 
   getStateFromStores() {
     const componentId = RoutesStore.getCurrentRouteComponentId();
-    const component = ComponentsStore.getComponent(componentId);
 
     return {
       breadcrumbs: RoutesStore.getBreadcrumbs(),
       currentRouteConfig: RoutesStore.getCurrentRouteConfig(),
       isRoutePending: RoutesStore.getIsPending(),
-      currentRouteComponentId: RoutesStore.getCurrentRouteComponentId(),
-      component,
+      component: ComponentsStore.getComponent(componentId),
       currentRouteParams: RoutesStore.getRouterState().get('params'),
       currentRouteQuery: RoutesStore.getRouterState().get('query')
     };


### PR DESCRIPTION
Koukal jsem na toto issue #1473 ale není to tak lehké.

Tak posílám akorát malinký update, kde jsem si všiml, že se dvakrát volá `RoutesStore.getCurrentRouteComponentId` kde podruhé to je pro state, který není využit.