### PR TITLE
Init docker-compose service with watch poll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log
 /.dir-locals.el
 /yarn-error.log
 .vscode
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,19 @@ services:
     stdin_open: true
     command: sh -c 'yarn && yarn start'
 
+  node-poll:
+    build: .
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./:/code
+    working_dir: /code
+    tty: true
+    stdin_open: true
+    command: sh -c 'yarn && yarn start-poll'
+    environment:
+      - WATCH_POLL_MS
+
   node-cached:
     build: .
     ports:

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https",
+    "start-poll": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https --watch-poll $WATCH_POLL_MS",
     "start-http": "webpack-dev-server --config webpack/dev-server.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline",
     "start-projects-list": "webpack-dev-server --config webpack/dev-server-projects-list.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https",
     "start-settings-users": "webpack-dev-server --config webpack/dev-server-setting-user.config.js --hot --progress --colors --host 0.0.0.0 --port 3000 --inline --https",


### PR DESCRIPTION
Changes:

- Init new service (`node-poll`) with configurable watch poll
- new `yarn start-poll` command