### PR TITLE
Accept empty string when setting new query

### DIFF
--- a/src/scripts/modules/jobs/Routes.js
+++ b/src/scripts/modules/jobs/Routes.js
@@ -30,7 +30,7 @@ export default {
       if (params.jobId) {
         // job detail
         return Promise.resolve();
-      } else if (query.q && query.q !== currentQuery) {
+      } else if ((query.q || query.q === '') && query.q !== currentQuery) {
         JobsActionCreators.setQuery(query.q || '');
         return JobsActionCreators.loadJobsForce(0, true, false);
       } else {


### PR DESCRIPTION
Fixes #2356 

Proposed changes:

- Accept also empty string `query.q`
