### PR TITLE
Orchestrations overlapping desription + markdown rendering

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
 import { fromJS } from 'immutable';
+import { HelpBlock } from 'react-bootstrap';
 import ComponentConfigurationLink from '../../../../components/react/components/ComponentConfigurationLink';
 import TaskParametersEditModal from '../../modals/TaskParametersEdit';
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
 import Tooltip from '../../../../../react/common/Tooltip';
+import descriptionExcerpt from '../../../../../utils/descriptionExcerpt';
 
 export default React.createClass({
   propTypes: {
@@ -49,9 +51,11 @@ export default React.createClass({
               configId={this.props.task.getIn(['config', 'id'])}
             >
               {this.props.task.getIn(['config', 'name'])}
-              <div className="help-block">
-                <small>{this.props.task.getIn(['config', 'description'])}</small>
-              </div>
+              <HelpBlock>
+                <small className="kbc-break-all">
+                  {descriptionExcerpt(this.props.task.getIn(['config', 'description']))}
+                </small>
+              </HelpBlock>
             </ComponentConfigurationLink>
           ) : (
             'N/A'

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
@@ -1,10 +1,12 @@
 import React from 'react';
+import { HelpBlock } from 'react-bootstrap';
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../../react/common/ComponentName';
 import ComponentConfigurationLink from '../../../../components/react/components/ComponentConfigurationLink';
 import TaskParametersEditModal from '../../modals/TaskParametersEdit';
 import OrchestrationTaskRunButton from '../../components/OrchestrationTaskRunButton';
 import { Check } from '@keboola/indigo-ui';
+import descriptionExcerpt from '../../../../../utils/descriptionExcerpt';
 
 export default React.createClass({
   propTypes: {
@@ -35,9 +37,11 @@ export default React.createClass({
               configId={this.props.task.getIn(['config', 'id'])}
             >
               {this.props.task.getIn(['config', 'name'])}
-              <div className="help-block">
-                <small>{this.props.task.getIn(['config', 'description'])}</small>
-              </div>
+              <HelpBlock>
+                <small className="kbc-break-all">
+                  {descriptionExcerpt(this.props.task.getIn(['config', 'description']))}
+                </small>
+              </HelpBlock>
             </ComponentConfigurationLink>
           ) : (
             'N/A'


### PR DESCRIPTION
Fixes #2384
Fixes #2380

Místo "kbc-break-all" by se hodilo možná [toto](https://github.com/keboola/indigo-ui/pull/307). Ale to je spíše drobnost. 