### PR TITLE
Token actions in token detail

### DIFF
--- a/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
+++ b/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { fromJS } from 'immutable';
 import { Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
-import RefreshTokenModal from '../Index/RefreshTokenModal';
-import SendTokenModal from '../Index/SendTokenModal';
+import RefreshTokenModal from '../modals/RefreshTokenModal';
+import SendTokenModal from '../modals/SendTokenModal';
 import Confirm from '../../../../react/common/Confirm';
 import Tooltip from '../../../../react/common/Tooltip';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
@@ -16,9 +16,8 @@ export default React.createClass({
   mixins: [createStoreMixin(TokensStore)],
 
   getStateFromStores() {
-    const tokens = TokensStore.getAll();
     const tokenId = RoutesStore.getCurrentRouteParam('tokenId');
-    const token = tokens.find(t => t.get('id') === tokenId) || fromJS({});
+    const token = TokensStore.getAll().find(t => t.get('id') === tokenId) || fromJS({});
 
     return {
       tokenId,
@@ -168,11 +167,11 @@ export default React.createClass({
     const description = this.state.description;
 
     return TokensActions.deleteToken(this.state.token).then(() => {
+      RoutesStore.getRouter().transitionTo('tokens');
+
       ApplicationActionCreators.sendNotification({
         message: `Token ${description} has been removed`
       });
-
-      RoutesStore.getRouter().transitionTo('tokens');
     });
   },
 

--- a/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
+++ b/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
@@ -1,0 +1,192 @@
+import React from 'react';
+import { fromJS } from 'immutable';
+import { Button } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import RefreshTokenModal from '../Index/RefreshTokenModal';
+import SendTokenModal from '../Index/SendTokenModal';
+import Confirm from '../../../../react/common/Confirm';
+import Tooltip from '../../../../react/common/Tooltip';
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import TokensStore from '../../StorageTokensStore';
+import TokensActions from '../../actionCreators';
+import RoutesStore from '../../../../stores/RoutesStore';
+import ApplicationActionCreators from '../../../../actions/ApplicationActionCreators';
+
+export default React.createClass({
+  mixins: [createStoreMixin(TokensStore)],
+
+  componentDidUpdate(prevProps, prevState) {
+    this.checkNewTokenCreated(RoutesStore.getCurrentRouteParam('tokenId'), prevState.tokenId);
+  },
+
+  getStateFromStores() {
+    const tokens = TokensStore.getAll();
+    const tokenId = RoutesStore.getCurrentRouteParam('tokenId');
+    const token = tokens.find(t => t.get('id') === tokenId) || fromJS({});
+
+    return {
+      tokenId,
+      token,
+      description: token.get('description'),
+      isMaster: token.get('isMasterToken', false),
+      isDeleting: TokensStore.isDeletingToken(tokenId),
+      isSending: TokensStore.isSendingToken(tokenId),
+      isRefreshing: TokensStore.isRefreshingToken(tokenId)
+    };
+  },
+
+  getInitialState() {
+    return {
+      sendModal: false,
+      refreshModal: false
+    };
+  },
+
+  render() {
+    if (!this.state.token.count()) {
+      return null;
+    }
+
+    return (
+      <span>
+        {this.renderDeleteButton()}
+        {this.renderSendButton()}
+        {this.renderRefreshButton()}
+
+        {this.renderRefreshModal()}
+        {this.renderSendModal()}
+      </span>
+    );
+  },
+
+  renderDeleteButton() {
+    if (this.state.token.has('admin')) {
+      return null;
+    }
+
+    if (this.state.isDeleting) {
+      return (
+        <span className="btn btn-link">
+          <Loader />
+        </span>
+      );
+    }
+
+    return (
+      <Confirm
+        title="Delete Token"
+        text={`Do you really want to delete token ${this.state.description} (${this.state.tokenId})?`}
+        buttonLabel="Delete"
+        onConfirm={this.deleteToken}
+      >
+        <Tooltip placement="bottom" tooltip="Delete token" id="delete_token">
+          <Button className="btn btn-link">
+            <i className="kbc-icon-cup" />
+          </Button>
+        </Tooltip>
+      </Confirm>
+    );
+  },
+
+  renderSendButton() {
+    if (this.state.isMaster) {
+      return null;
+    }
+
+    return (
+      <Tooltip placement="bottom" tooltip="Send token via email" id="send_token">
+        <Button onClick={this.openSendModal} className="btn btn-link">
+          <i className="fa fa-share" />
+        </Button>
+      </Tooltip>
+    );
+  },
+
+  renderRefreshButton() {
+    return (
+      <Tooltip placement="bottom" tooltip="Refresh token" id="refresh_token">
+        <Button onClick={this.openRefreshModal} className="btn btn-link">
+          <i className="fa fa-refresh" />
+        </Button>
+      </Tooltip>
+    );
+  },
+
+  renderRefreshModal() {
+    return (
+      <RefreshTokenModal
+        token={this.state.token}
+        show={!!this.state.refreshModal}
+        onHideFn={this.closeRefreshModal}
+        onRefreshFn={this.refreshToken}
+        isRefreshing={!!this.state.isRefreshing}
+      />
+    );
+  },
+
+  renderSendModal() {
+    return (
+      <SendTokenModal
+        token={this.state.token}
+        show={!!this.state.sendModal}
+        onHideFn={this.closeSendModal}
+        onSendFn={this.sendToken}
+        isSending={!!this.state.isSending}
+      />
+    );
+  },
+
+  openSendModal() {
+    this.setState({
+      sendModal: true
+    });
+  },
+
+  closeSendModal() {
+    this.setState({
+      sendModal: false
+    });
+  },
+
+  openRefreshModal() {
+    this.setState({
+      refreshModal: true
+    });
+  },
+
+  closeRefreshModal() {
+    this.setState({
+      refreshModal: false
+    });
+  },
+
+  sendToken(params) {
+    return TokensActions.sendToken(this.state.tokenId, params).then(() =>
+      ApplicationActionCreators.sendNotification({
+        message: `Token ${this.state.description} sent to ${params.email}`
+      })
+    );
+  },
+
+  deleteToken() {
+    const description = this.state.description;
+
+    return TokensActions.deleteToken(this.state.token).then(() => {
+      ApplicationActionCreators.sendNotification({
+        message: `Token ${description} has been removed`
+      });
+
+      RoutesStore.getRouter().transitionTo('tokens');
+    });
+  },
+
+  refreshToken() {
+    return TokensActions.refreshToken(this.state.token);
+  },
+
+  checkNewTokenCreated(token, prevToken) {
+    if (token !== 'new-token' && prevToken === 'new-token') {
+      this.setState(this.getStateFromStores());
+    }
+  }
+});

--- a/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
+++ b/src/scripts/modules/tokens/react/components/TokenHeaderButtons.jsx
@@ -15,10 +15,6 @@ import ApplicationActionCreators from '../../../../actions/ApplicationActionCrea
 export default React.createClass({
   mixins: [createStoreMixin(TokensStore)],
 
-  componentDidUpdate(prevProps, prevState) {
-    this.checkNewTokenCreated(RoutesStore.getCurrentRouteParam('tokenId'), prevState.tokenId);
-  },
-
   getStateFromStores() {
     const tokens = TokensStore.getAll();
     const tokenId = RoutesStore.getCurrentRouteParam('tokenId');
@@ -182,11 +178,5 @@ export default React.createClass({
 
   refreshToken() {
     return TokensActions.refreshToken(this.state.token);
-  },
-
-  checkNewTokenCreated(token, prevToken) {
-    if (token !== 'new-token' && prevToken === 'new-token') {
-      this.setState(this.getStateFromStores());
-    }
   }
 });

--- a/src/scripts/modules/tokens/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/tokens/react/pages/Index/Index.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { Map } from 'immutable';
-import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import SettingsTabs from '../../../../../react/layout/SettingsTabs';
 import ApplicationStore from '../../../../../stores/ApplicationStore';

--- a/src/scripts/modules/tokens/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/tokens/react/pages/Index/Index.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Map} from 'immutable';
+import { Map } from 'immutable';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import SettingsTabs from '../../../../../react/layout/SettingsTabs';
@@ -10,7 +10,7 @@ import TokensStore from '../../../StorageTokensStore';
 import TokensTable from './TokensTable';
 
 export default React.createClass({
-  mixins: [createStoreMixin(TokensStore, BucketsStore)],
+  mixins: [createStoreMixin(TokensStore)],
 
   getStateFromStores() {
     const tokens = TokensStore.getAll();
@@ -21,8 +21,7 @@ export default React.createClass({
       isDeletingTokenFn: TokensStore.isDeletingToken,
       isSendingToken: TokensStore.isSendingToken,
       isRefreshingTokenFn: TokensStore.isRefreshingToken,
-      localState: TokensStore.localState(),
-      allBuckets: BucketsStore.getAll()
+      localState: TokensStore.localState()
     };
   },
 
@@ -35,7 +34,7 @@ export default React.createClass({
             <div className="tab-pane tab-pane-no-padding active">
               <TokensTable
                 localState={this.state.localState.get('TokensTable', Map())}
-                updateLocalState={(newState) => this.updateLocalState('TokensTable', newState)}
+                updateLocalState={newState => this.updateLocalState('TokensTable', newState)}
                 isDeletingFn={t => this.state.isDeletingTokenFn(t.get('id'))}
                 onDeleteFn={TokensActions.deleteToken}
                 onSendTokenFn={this.sendToken}
@@ -44,7 +43,6 @@ export default React.createClass({
                 isRefreshingFn={t => this.state.isRefreshingTokenFn(t.get('id'))}
                 currentAdmin={this.state.currentAdmin}
                 tokens={this.state.tokens}
-                allBuckets={this.state.allBuckets}
               />
             </div>
           </div>
@@ -57,11 +55,11 @@ export default React.createClass({
     return TokensActions.sendToken(token.get('id'), params).then(() =>
       ApplicationActionCreators.sendNotification({
         message: `Token ${token.get('description')} sent to ${params.email}`
-      }));
+      })
+    );
   },
 
   updateLocalState(key, newValue) {
     TokensActions.updateLocalState(this.state.localState.set(key, newValue));
   }
-
 });

--- a/src/scripts/modules/tokens/react/pages/Index/TokensTable.jsx
+++ b/src/scripts/modules/tokens/react/pages/Index/TokensTable.jsx
@@ -15,7 +15,6 @@ export default React.createClass({
 
   propTypes: {
     tokens: PropTypes.object.isRequired,
-    allBuckets: PropTypes.object.isRequired,
     currentAdmin: PropTypes.object.isRequired,
     onDeleteFn: PropTypes.func.isRequired,
     isDeletingFn: PropTypes.func.isRequired,

--- a/src/scripts/modules/tokens/routes.js
+++ b/src/scripts/modules/tokens/routes.js
@@ -4,6 +4,7 @@ import DetailPage from './react/pages/Detail/Detail';
 import tokensActions from './actionCreators';
 import StorageActions from '../components/StorageActionCreators';
 import TokensStore from './StorageTokensStore';
+import TokenHeaderButtons from './react/components/TokenHeaderButtons';
 
 export default {
   name: 'tokens',
@@ -21,6 +22,7 @@ export default {
       name: 'tokens-detail',
       path: ':tokenId',
       handler: DetailPage,
+      headerButtonsHandler: TokenHeaderButtons,
       title: routerState => {
         const tokenId = routerState.getIn(['params', 'tokenId']);
         const token = tokenId && TokensStore.getAll().find(t => t.get('id') === tokenId);

--- a/src/scripts/modules/tokens/routes.js
+++ b/src/scripts/modules/tokens/routes.js
@@ -2,7 +2,6 @@ import Index from './react/pages/Index/Index';
 import NewPage from './react/pages/New/New';
 import DetailPage from './react/pages/Detail/Detail';
 import tokensActions from './actionCreators';
-import StorageActions from '../components/StorageActionCreators';
 import TokensStore from './StorageTokensStore';
 
 export default {

--- a/src/scripts/modules/tokens/routes.js
+++ b/src/scripts/modules/tokens/routes.js
@@ -2,6 +2,7 @@ import Index from './react/pages/Index/Index';
 import NewPage from './react/pages/New/New';
 import DetailPage from './react/pages/Detail/Detail';
 import tokensActions from './actionCreators';
+import StorageActions from '../components/StorageActionCreators';
 import TokensStore from './StorageTokensStore';
 
 export default {


### PR DESCRIPTION
Fixes #2379

Tady to je takové problematické, myslím že by se modul Tokens mohl refaktorovat, ale nechtěl jsem do toho v rámci této úpravy nějak více šahat. Je tam problematické to že stránka "new-token" je stejná jako samotný detail toketu když mám ID. Pak se změní URL, ale nenačtou se znovu data apod. Jestli jsem to nedělal blbě.

Musel jsem to tam trochu obejít. Třeba naleznete lepší řešení. Ale myslím, že by bylo dobré ten modul upravit jako jsou jiné. Složky pages, modal, components. Udělat samostatnou stránku detail a samostatnou stránku new apod.

Jinak jsem teda přidal action do hlavičky nahoru doprava.
Koukal jsem že se načítá "buckets" ale nikde se to nepoužívalo, tak jsme to dal pryč.

![buttons](https://user-images.githubusercontent.com/12331181/48901793-e0263a80-ee56-11e8-9d15-722c65e1c74a.png)


