### PR TITLE
feat(SidebarJobs): refactoring

### DIFF
--- a/src/scripts/modules/apify/react/Index/Index.jsx
+++ b/src/scripts/modules/apify/react/Index/Index.jsx
@@ -99,7 +99,12 @@ export default React.createClass({
               />
             </li>
           </ul>
-          <LatestJobs jobs={this.state.latestJobs} limit={3} />
+          <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           <LatestVersions
             limit={3}
             componentId={COMPONENT_ID}

--- a/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
+++ b/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
@@ -147,6 +147,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={componentId}
+            configId={this.state.configId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/components/react/components/SidebarJobs.jsx
+++ b/src/scripts/modules/components/react/components/SidebarJobs.jsx
@@ -3,6 +3,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import { Loader } from '@keboola/indigo-ui';
 import { Link } from 'react-router';
 import JobRow from './SidebarJobsRow';
+import { getQuery, getLegacyComponentQuery } from '../../../../utils/jobsQueryBuilder';
 
 export default React.createClass({
   mixins: [PureRenderMixin],
@@ -51,28 +52,23 @@ export default React.createClass({
     const jobs = this.props.jobs.get('jobs');
     const firstJob = jobs && jobs.first();
     const params = firstJob && firstJob.get('params');
-    let query = '';
 
     if (!params) {
       return null;
     }
 
-
-    if (params.get('component')) {
-      query += `+params.component:${this.props.componentId}`;
-    } else {
-      // legacy components
-      query += `+component:${this.props.componentId}`;
+    let queryFunction = getQuery;
+    // legacy components
+    if (!params.get('component')) {
+      queryFunction = getLegacyComponentQuery;
     }
-
-    query += ` +params.config:${this.props.configId}`;
 
     return (
       <div className="jobs-link" key="jobs-link">
         <Link
           to="jobs"
           query={{
-            q: query
+            q: queryFunction(this.props.componentId, this.props.configId)
           }}
         >
           Show all jobs

--- a/src/scripts/modules/components/react/components/SidebarJobs.jsx
+++ b/src/scripts/modules/components/react/components/SidebarJobs.jsx
@@ -9,6 +9,8 @@ export default React.createClass({
 
   propTypes: {
     jobs: React.PropTypes.object.isRequired,
+    componentId: React.PropTypes.string.isRequired,
+    configId: React.PropTypes.string.isRequired,
     limit: React.PropTypes.number
   },
 
@@ -49,24 +51,28 @@ export default React.createClass({
     const jobs = this.props.jobs.get('jobs');
     const firstJob = jobs && jobs.first();
     const params = firstJob && firstJob.get('params');
-    let component;
+    let query = '';
 
     if (!params) {
       return null;
     }
 
+
     if (params.get('component')) {
-      component = `+params.component:${params.get('component')}`;
+      query += `+params.component:${this.props.componentId}`;
     } else {
-      component = `+component:${firstJob.get('component')}`;
+      // legacy components
+      query += `+component:${this.props.componentId}`;
     }
+
+    query += ` +params.config:${this.props.configId}`;
 
     return (
       <div className="jobs-link" key="jobs-link">
         <Link
           to="jobs"
           query={{
-            q: `${component} +params.config:${params.get('config')}`
+            q: query
           }}
         >
           Show all jobs

--- a/src/scripts/modules/components/react/pages/GenericDetailEditable.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDetailEditable.jsx
@@ -112,6 +112,8 @@ export default React.createClass({
             {this.renderShinyAppLink()}
           </ul>
           <LatestJobs
+            componentId={this.state.componentId}
+            configId={this.state.config.get('id')}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/components/react/pages/GenericDetailStatic.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDetailStatic.jsx
@@ -83,6 +83,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={this.state.componentId}
+            configId={this.state.config.get('id')}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
@@ -278,6 +278,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={this.state.componentId}
+            configId={this.state.config.get('id')}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/configurations/react/pages/Index.jsx
+++ b/src/scripts/modules/configurations/react/pages/Index.jsx
@@ -191,6 +191,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={this.state.componentId}
+            configId={this.state.configurationId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/ex-adform/react/Index.jsx
+++ b/src/scripts/modules/ex-adform/react/Index.jsx
@@ -162,6 +162,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={this.state.componentId}
+            configId={this.state.config.get('id')}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -307,11 +307,13 @@ export default function(componentId) {
                 />
               </li>
             </ul>
-
-            <LatestJobs limit={3} jobs={this.state.latestJobs}/>
-
+            <LatestJobs
+              componentId={componentId}
+              configId={this.state.configId}
+              limit={3}
+              jobs={this.state.latestJobs}
+            />
             <SidebarVersions limit={3} componentId={componentId}/>
-
           </div>
         </div>
       );

--- a/src/scripts/modules/ex-dropbox-v2/react/Index.jsx
+++ b/src/scripts/modules/ex-dropbox-v2/react/Index.jsx
@@ -238,8 +238,16 @@ export default React.createClass({
             />
           </li>
         </ul>
-        <LatestJobs limit={3} jobs={this.state.latestJobs} />
-        <LatestVersions limit={3} componentId={componentId} />
+        <LatestJobs
+          componentId={componentId}
+          configId={this.state.configId}
+          limit={3}
+          jobs={this.state.latestJobs}
+        />
+        <LatestVersions
+          limit={3}
+          componentId={componentId}
+        />
       </div>
     );
   },

--- a/src/scripts/modules/ex-dropbox/react/Index.jsx
+++ b/src/scripts/modules/ex-dropbox/react/Index.jsx
@@ -311,8 +311,16 @@ export default React.createClass({
             />
           </li>
         </ul>
-        <LatestJobs limit={3} jobs={this.state.latestJobs} />
-        <LatestVersions limit={3} componentId={componentId} />
+        <LatestJobs
+          componentId={componentId}
+          configId={this.state.configId}
+          limit={3}
+          jobs={this.state.latestJobs}
+        />
+        <LatestVersions
+          limit={3}
+          componentId={componentId}
+        />
       </div>
     );
   },

--- a/src/scripts/modules/ex-email-attachments/react/Index.jsx
+++ b/src/scripts/modules/ex-email-attachments/react/Index.jsx
@@ -163,6 +163,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/ex-facebook/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/Index.jsx
@@ -141,7 +141,12 @@ export default function(COMPONENT_ID) {
                 />
               </li>
             </ul>
-            <LatestJobs jobs={this.state.latestJobs} limit={3} />
+            <LatestJobs
+              componentId={COMPONENT_ID}
+              configId={this.state.configId}
+              jobs={this.state.latestJobs}
+              limit={3}
+            />
             <LatestVersions
               limit={3}
               componentId={COMPONENT_ID}

--- a/src/scripts/modules/ex-google-analytics-v4/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/Index/Index.jsx
@@ -130,7 +130,12 @@ export default function(componentId) {
                 />
               </li>
             </ul>
-            <LatestJobs jobs={this.state.latestJobs} limit={3} />
+            <LatestJobs
+              componentId={componentId}
+              configId={this.state.configId}
+              jobs={this.state.latestJobs}
+              limit={3}
+            />
             <LatestVersions
               limit={3}
               componentId={componentId}

--- a/src/scripts/modules/ex-google-bigquery/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/Index/Index.jsx
@@ -123,7 +123,12 @@ export default React.createClass({
               />
             </li>
           </ul>
-          <LatestJobs jobs={this.state.latestJobs} limit={3} />
+          <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           <LatestVersions
             limit={3}
             componentId={COMPONENT_ID}

--- a/src/scripts/modules/ex-google-drive/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-drive/react/Index/Index.jsx
@@ -101,7 +101,12 @@ export default React.createClass({
               />
             </li>
           </ul>
-          <LatestJobs jobs={this.state.latestJobs} limit={3} />
+          <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           <LatestVersions
             limit={3}
             componentId={COMPONENT_ID}

--- a/src/scripts/modules/ex-mongodb/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-mongodb/react/pages/index/Index.jsx
@@ -153,7 +153,12 @@ export default function(componentId) {
               <DeleteConfigurationButton componentId={componentId} configId={configurationId} />
             </li>
           </ul>
-          <LatestJobs limit={3} jobs={this.state.latestJobs} />
+          <LatestJobs
+            componentId={componentId}
+            configId={this.state.configId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           <LatestVersions limit={3} componentId={componentId} />
         </div>
       );

--- a/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
@@ -155,6 +155,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/ex-twitter/react/Index.jsx
+++ b/src/scripts/modules/ex-twitter/react/Index.jsx
@@ -171,6 +171,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={this.state.component.get('id')}
+            configId={this.state.config.get('id')}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
@@ -159,6 +159,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={componentId}
+            configId={this.state.configId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
@@ -120,6 +120,8 @@ export default React.createClass({
             </li>
           </ul>
           <LatestJobs
+            componentId={COMPONENT_ID}
+            configId={this.state.configurationId}
             jobs={this.state.latestJobs}
             limit={3}
           />

--- a/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
@@ -318,7 +318,12 @@ export default React.createClass({
               </li>
             </ul>
           )}
-          <LatestJobs jobs={this.state.latestJobs} limit={3} />
+          <LatestJobs
+            componentId="gooddata-writer"
+            configId={this.state.writer.getIn(['config', 'id'])}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           <LatestVersions componentId="gooddata-writer" limit={3} />
         </div>
       </div>

--- a/src/scripts/modules/tde-exporter/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/tde-exporter/react/pages/Index/Index.jsx
@@ -127,7 +127,12 @@ export default React.createClass({
             <DeleteConfigurationButton componentId={componentId} configId={this.state.configId} />
           </li>
         </ul>
-        <LatestJobs jobs={this.state.latestJobs} limit={3} />
+        <LatestJobs
+          componentId={componentId}
+          configId={this.state.configId}
+          jobs={this.state.latestJobs}
+          limit={3}
+        />
         <LatestVersions componentId={componentId} limit={3} />
       </div>
     );

--- a/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.jsx
@@ -85,8 +85,13 @@ export default React.createClass({
               </a>
             </li>
           </ul>
-          <SidebarJobs jobs={this.state.latestJobs} limit={3} />
-          <SidebarVersions componentId="transformation" limit={3} />
+          <SidebarJobs
+            componentId="transformation"
+            configId={this.state.bucketId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
+          <SidebarVersions limit={3} />
         </div>
       </div>
     );

--- a/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-bucket/TransformationBucket.jsx
@@ -91,7 +91,7 @@ export default React.createClass({
             jobs={this.state.latestJobs}
             limit={3}
           />
-          <SidebarVersions limit={3} />
+          <SidebarVersions componentId="transformation" limit={3} />
         </div>
       </div>
     );

--- a/src/scripts/modules/wr-db/react/pages/index/Index.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/Index.jsx
@@ -257,7 +257,12 @@ export default componentId => {
               <DeleteConfigurationButton componentId={componentId} configId={this.state.configId} />
             </li>
           </ul>
-          <LatestJobs jobs={this.state.latestJobs} />
+          <LatestJobs
+            componentId={componentId}
+            configId={this.state.configId}
+            jobs={this.state.latestJobs}
+            limit={3}
+          />
           {dockerProxyApi(componentId) && <LatestVersions componentId={componentId} limit={3} />}
         </div>
       );

--- a/src/scripts/modules/wr-google-drive-old/react/pages/index/Index.jsx
+++ b/src/scripts/modules/wr-google-drive-old/react/pages/index/Index.jsx
@@ -210,7 +210,12 @@ export default React.createClass({
             <DeleteConfigurationButton componentId={componentId} configId={this.state.configId} />
           </li>
         </ul>
-        <LatestJobs jobs={this.state.latestJobs} />
+        <LatestJobs
+          componentId={componentId}
+          configId={this.state.configId}
+          limit={3}
+          jobs={this.state.latestJobs}
+        />
       </div>
     );
   },

--- a/src/scripts/modules/wr-google-drive/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/wr-google-drive/react/pages/Index/Index.jsx
@@ -112,7 +112,12 @@ export default function(COMPONENT_ID) {
                 />
               </li>
             </ul>
-            <LatestJobs jobs={this.state.latestJobs} limit={3} />
+            <LatestJobs
+              componentId={COMPONENT_ID}
+              configId={this.state.configId}
+              jobs={this.state.latestJobs}
+              limit={3}
+            />
             <LatestVersions
               limit={3}
               componentId={COMPONENT_ID}

--- a/src/scripts/modules/wr-google-sheets/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/wr-google-sheets/react/pages/Index/Index.jsx
@@ -112,7 +112,12 @@ export default function(COMPONENT_ID) {
                 />
               </li>
             </ul>
-            <LatestJobs jobs={this.state.latestJobs} limit={3} />
+            <LatestJobs
+              componentId={COMPONENT_ID}
+              configId={this.state.configId}
+              jobs={this.state.latestJobs}
+              limit={3}
+            />
             <LatestVersions
               limit={3}
               componentId={COMPONENT_ID}

--- a/src/scripts/utils/jobsQueryBuilder.js
+++ b/src/scripts/utils/jobsQueryBuilder.js
@@ -1,0 +1,7 @@
+export function getQuery(componentId, configId) {
+  return '+params.component:' + componentId + ' +params.config:' + configId;
+}
+
+export function getLegacyComponentQuery(componentId, configId) {
+  return '+component:' + componentId + ' +params.config:' + configId;
+}

--- a/src/scripts/utils/jobsQueryBuilder.spec.js
+++ b/src/scripts/utils/jobsQueryBuilder.spec.js
@@ -1,0 +1,14 @@
+import assert from 'assert';
+import { getQuery, getLegacyComponentQuery } from './jobsQueryBuilder';
+
+describe('getQuery', () => {
+  it('should return a valid query', () => {
+    assert.strictEqual('+params.component:component +params.config:config', getQuery('component', 'config'));
+  });
+});
+
+describe('getLegacyComponentQuery', () => {
+  it('should return a valid query', () => {
+    assert.strictEqual('+component:component +params.config:config', getLegacyComponentQuery('component', 'config'));
+  });
+});


### PR DESCRIPTION
`componentId` a `configId` se předává do komponenty přes props, nemusí se načítat z jobu. Potřebuju tam v https://github.com/keboola/kbc-ui/pull/1947 nacpat ještě `rowId`, který z jobu spolehlivě načíst nejde. 

Všechny změněný stránky jsem otestoval a šlapou. 