### PR TITLE
Component type in orchestration tasks

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
@@ -39,7 +39,7 @@ export default React.createClass({
             {this.props.component ? <ComponentIcon component={this.props.component} /> : ' '}
           </span>
           {this.props.component ? (
-            <ComponentName component={this.props.component} />
+            <ComponentName component={this.props.component} showType />
           ) : (
             this.props.task.get('componentUrl')
           )}

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
@@ -25,7 +25,7 @@ export default React.createClass({
             {this.props.component ? <ComponentIcon component={this.props.component} /> : ' '}
           </span>
           {this.props.component ? (
-            <ComponentName component={this.props.component} />
+            <ComponentName component={this.props.component} showType />
           ) : (
             this.props.task.get('componentUrl')
           )}

--- a/src/scripts/react/common/ComponentName.jsx
+++ b/src/scripts/react/common/ComponentName.jsx
@@ -1,9 +1,5 @@
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import { capitalize } from 'underscore.string';
-
-const shouldShowType = (component) => {
-  return component.get('type') === 'extractor' || component.get('type') === 'writer';
-};
 
 export default React.createClass({
   propTypes: {
@@ -23,9 +19,19 @@ export default React.createClass({
     return (
       <span>
         {this.componentName()}
-        {this.props.showType && shouldShowType(this.props.component) && (
-          <span>{' '}<small>{this.props.component.get('type')}</small></span>
-        )}
+        {this.props.showType && this.renderType()}
+      </span>
+    );
+  },
+
+  renderType() {
+    if (!this.shouldShowType()) {
+      return null;
+    }
+
+    return (
+      <span>
+        <small> {this.props.component.get('type')}</small>
       </span>
     );
   },
@@ -33,5 +39,9 @@ export default React.createClass({
   componentName() {
     const name = this.props.component.get('name');
     return this.props.capitalize ? capitalize(name) : name;
+  },
+
+  shouldShowType() {
+    return ['extractor', 'writer'].includes(this.props.component.get('type'));
   }
 });


### PR DESCRIPTION
Fixes #2153

Přidání typu komponenty za writery/extraktory. Jde o edit i detail.
Nejdříve jsme myslel, že by šla přidat ikonka další pro typ (ty default) ale přibyl by nový soupec a nevím zda by to bylo přehledné. Pak jsem viděl, že ComponentName umí zobrazit ten typ tak mi to přijde nejlepší takto jednoduše. Nebo jiné návrhy?

Před:
![pred](https://user-images.githubusercontent.com/12331181/49005730-b6775700-f167-11e8-89e3-7a09907019fd.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/49005732-ba0ade00-f167-11e8-883f-02eabbbd796d.png)