### PR TITLE
Fix alignment of ConfirmButtons

### DIFF
--- a/src/scripts/modules/tokens/react/pages/New/New.jsx
+++ b/src/scripts/modules/tokens/react/pages/New/New.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
             ) : (
               <div className="form form-horizontal">
                 <FormGroup>
-                  <Col sm={12} className="text-right">
+                  <Col sm={12}>
                     <ConfirmButtons
                       saveButtonType="submit"
                       isSaving={this.state.isSaving}
@@ -53,6 +53,7 @@ export default React.createClass({
                       onSave={this.handleSave}
                       saveLabel="Create"
                       showCancel={false}
+                      className="pull-right"
                     />
                   </Col>
                 </FormGroup>

--- a/src/scripts/react/common/EditButtons.jsx
+++ b/src/scripts/react/common/EditButtons.jsx
@@ -39,6 +39,7 @@ export default React.createClass({
           saveLabel={this.props.saveLabel}
           onCancel={this.props.onCancel}
           onSave={this.props.onSave}
+          className="pull-right"
         />
       );
     }


### PR DESCRIPTION
Fixes #2403 

Proposed changes:

- add `pull-right` class to ConfirmButtons not used in modals
