### PR TITLE
Storage explorer - INIT

### DIFF
--- a/src/scripts/modules/storage-explorer/Routes.js
+++ b/src/scripts/modules/storage-explorer/Routes.js
@@ -1,7 +1,37 @@
-import Index from './react/Index/Index';
+import Index from './react/pages/Index/Index';
+import Table from './react/pages/Table/Table';
+import Bucket from './react/pages/Bucket/Bucket';
+import StorageActions from '../components/StorageActionCreators';
+import TablesStore from '../components/stores/StorageTablesStore';
 
 export default {
   name: 'storage-explorer',
   title: 'Storage Explorer',
-  defaultRouteHandler: Index
+  defaultRouteHandler: Index,
+  requireData: [() => StorageActions.loadBuckets(), () => StorageActions.loadTables()],
+  childRoutes: [
+    {
+      name: 'storage-explorer-bucket',
+      path: ':bucketId',
+      defaultRouteHandler: Bucket,
+      title(routerState) {
+        return `Bucket ${routerState.getIn(['params', 'bucketId'])}`;
+      },
+      childRoutes: [
+        {
+          name: 'storage-explorer-table',
+          path: ':tableName',
+          defaultRouteHandler: Table,
+          title(routerState) {
+            const bucketId = routerState.getIn(['params', 'bucketId']);
+            const tableName = routerState.getIn(['params', 'tableName']);
+            const table = TablesStore.getAll().find(item => {
+              return item.getIn(['bucket', 'id']) === bucketId && item.get('name') === tableName;
+            });
+            return table.get('name');
+          }
+        }
+      ]
+    }
+  ]
 };

--- a/src/scripts/modules/storage-explorer/Routes.js
+++ b/src/scripts/modules/storage-explorer/Routes.js
@@ -1,0 +1,7 @@
+import Index from './react/Index/Index';
+
+export default {
+  name: 'storage-explorer',
+  title: 'Storage Explorer',
+  defaultRouteHandler: Index
+};

--- a/src/scripts/modules/storage-explorer/react/Index/Index.jsx
+++ b/src/scripts/modules/storage-explorer/react/Index/Index.jsx
@@ -1,14 +1,18 @@
 import React from 'react';
+import { Col } from 'react-bootstrap';
+import Buckets from '../components/Buckets';
+import Events from '../components/Events';
 
 export default React.createClass({
   render() {
     return (
       <div className="container-fluid">
-        <div className="kbc-main-content">
-          <div className="kbc-inner-padding">
-            <h2>Storage Explorer</h2>
-          </div>
-        </div>
+        <Col sm={3} className="kbc-main-sidebar">
+          <Buckets />
+        </Col>
+        <Col sm={9} className="kbc-main-content">
+          <Events />
+        </Col>
       </div>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/Index/Index.jsx
+++ b/src/scripts/modules/storage-explorer/react/Index/Index.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+export default React.createClass({
+  render() {
+    return (
+      <div className="container-fluid">
+        <div className="kbc-main-content">
+          <div className="kbc-inner-padding">
+            <h2>Storage Explorer</h2>
+          </div>
+        </div>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default React.createClass({
+  render() {
+    return null;
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
+import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import matchByWords from '../../../../utils/matchByWords';
 import BucketsStore from '../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../components/stores/StorageTablesStore';
 import StorageActionCreators from '../../../components/StorageActionCreators';
-import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
 import BucketsList from './BucketsList';
 
 export default React.createClass({
@@ -49,13 +50,7 @@ export default React.createClass({
     if (this.state.searchQuery) {
       const search = this.state.searchQuery.toLowerCase();
 
-      buckets = buckets.filter(
-        bucket =>
-          bucket
-            .get('id')
-            .toLowerCase()
-            .indexOf(search) > -1
-      );
+      buckets = buckets.filter(bucket => matchByWords(bucket.get('id').toLowerCase(), search));
     }
 
     return buckets.sortBy(bucket => bucket.get('name').toLowerCase());

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -1,7 +1,73 @@
 import React from 'react';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import BucketsStore from '../../../components/stores/StorageBucketsStore';
+import TablesStore from '../../../components/stores/StorageTablesStore';
+import StorageActionCreators from '../../../components/StorageActionCreators';
+import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
+import BucketsList from './BucketsList';
 
 export default React.createClass({
+  mixins: [ImmutableRenderMixin, createStoreMixin(BucketsStore, TablesStore)],
+
+  getStateFromStores() {
+    return {
+      allBuckets: BucketsStore.getAll(),
+      allTables: TablesStore.getAll(),
+      isLoading: BucketsStore.getIsLoading()
+    };
+  },
+
+  getInitialState() {
+    return {
+      searchQuery: ''
+    };
+  },
+
   render() {
-    return null;
+    return (
+      <div className="kbc-main-content">
+        <div className="kbc-inner-padding">
+          <SearchBar query={this.state.searchQuery} onChange={this.handleQueryChange} />
+
+          <h3 style={{ marginBottom: 0 }}>
+            <div className="pull-right">
+              <RefreshIcon onClick={this.handleRefresh} isLoading={this.state.isLoading} />
+            </div>
+            Buckets
+          </h3>
+        </div>
+
+        <BucketsList buckets={this.filteredBuckets()} tables={this.state.allTables} />
+      </div>
+    );
+  },
+
+  filteredBuckets() {
+    let buckets = this.state.allBuckets;
+
+    if (this.state.searchQuery) {
+      const search = this.state.searchQuery.toLowerCase();
+
+      buckets = buckets.filter(
+        bucket =>
+          bucket
+            .get('id')
+            .toLowerCase()
+            .indexOf(search) > -1
+      );
+    }
+
+    return buckets.sortBy(bucket => bucket.get('name').toLowerCase());
+  },
+
+  handleRefresh() {
+    StorageActionCreators.loadBucketsForce();
+  },
+
+  handleQueryChange(query) {
+    this.setState({
+      searchQuery: query
+    });
   }
 });

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -1,0 +1,49 @@
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
+import { Panel } from 'react-bootstrap';
+
+export default React.createClass({
+  propTypes: {
+    buckets: PropTypes.object.isRequired,
+    tables: PropTypes.object.isRequired
+  },
+
+  render() {
+    if (!this.props.buckets.count()) {
+      <p>No buckets found.</p>;
+    }
+
+    return <div>{this.props.buckets.map(this.renderBucketPanel).toArray()}</div>;
+  },
+
+  renderBucketPanel(bucket) {
+    return (
+      <Panel header={bucket.get('id')} key={bucket.get('id')} collapsible={true}>
+        {this.renderTables(bucket)}
+      </Panel>
+    );
+  },
+
+  renderTables(bucket) {
+    const tables = this.props.tables.filter(table => {
+      return table.getIn(['bucket', 'id']) === bucket.get('id');
+    });
+
+    if (!tables.count()) {
+      return <p>No tables.</p>;
+    }
+
+    return tables.map(this.renderTable).toArray();
+  },
+
+  renderTable(table) {
+    const bucketId = table.getIn(['bucket', 'id']);
+    const tableName = table.get('name');
+
+    return (
+      <Link to="storage-explorer-table" params={{ bucketId, tableName }} key={table.get('id')}>
+        <p>{tableName}</p>
+      </Link>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -10,7 +10,7 @@ export default React.createClass({
 
   render() {
     if (!this.props.buckets.count()) {
-      <p>No buckets found.</p>;
+      return <p>No buckets found.</p>;
     }
 
     return <div>{this.props.buckets.map(this.renderBucketPanel).toArray()}</div>;

--- a/src/scripts/modules/storage-explorer/react/components/Events.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Events.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import PureRendererMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { List } from 'immutable';
 import { Button } from 'react-bootstrap';
 import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
@@ -7,7 +7,7 @@ import { factory as eventsFactory } from '../../../sapi-events/EventsService';
 import EventsTable from './EventsTable';
 
 export default React.createClass({
-  mixins: [PureRendererMixin],
+  mixins: [ImmutableRenderMixin],
 
   getInitialState() {
     return {
@@ -48,7 +48,7 @@ export default React.createClass({
   },
 
   renderMoreButton() {
-    if (!this.state.hasMore) {
+    if (!this.state.events || !this.state.hasMore) {
       return null;
     }
 

--- a/src/scripts/modules/storage-explorer/react/components/Events.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Events.jsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import PureRendererMixin from 'react-immutable-render-mixin';
+import { List } from 'immutable';
+import { Button } from 'react-bootstrap';
+import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
+import { factory as eventsFactory } from '../../../sapi-events/EventsService';
+import EventsTable from './EventsTable';
+
+export default React.createClass({
+  mixins: [PureRendererMixin],
+
+  getInitialState() {
+    return {
+      events: List(),
+      isLoadingMore: false,
+      isLoading: false,
+      hasMore: true,
+      searchQuery: ''
+    };
+  },
+
+  componentDidMount() {
+    this.createEventsService();
+    this._events.load();
+  },
+
+  componentWillUnmount() {
+    this.destroyEventsService();
+  },
+
+  render() {
+    return (
+      <div>
+        <div className="kbc-inner-padding">
+          <h2>
+            Events <RefreshIcon onClick={this.handleRefresh} isLoading={this.state.isLoading} />
+          </h2>
+          <SearchBar
+            query={this.state.searchQuery}
+            onChange={this.handleQueryChange}
+            onSubmit={this.handleSearchSubmit}
+          />
+        </div>
+        <EventsTable events={this.state.events} />
+        {this.renderMoreButton()}
+      </div>
+    );
+  },
+
+  renderMoreButton() {
+    if (!this.state.hasMore) {
+      return null;
+    }
+
+    return (
+      <div className="kbc-block-with-padding">
+        <Button onClick={this.handleLoadMore} disabled={this.state.isLoadingMore}>
+          {this.state.isLoadingMore ? 'Loading ...' : 'Load more'}
+        </Button>
+      </div>
+    );
+  },
+
+  createEventsService() {
+    this._events = eventsFactory();
+    this._events.addChangeListener(this.handleChange);
+  },
+
+  destroyEventsService() {
+    this._events.removeChangeListener(this.handleChange);
+    this._events.reset();
+  },
+
+  handleChange() {
+    if (this.isMounted()) {
+      this.setState({
+        searchQuery: this._events.getQuery(),
+        events: this._events.getEvents(),
+        isLoading: this._events.getIsLoading(),
+        isLoadingMore: this._events.getIsLoadingOlder(),
+        hasMore: this._events.getHasMore(),
+        errorMessage: this._events.getErrorMessage()
+      });
+    }
+  },
+
+  handleRefresh() {
+    this._events.load();
+  },
+
+  handleLoadMore() {
+    this._events.loadMore();
+  },
+
+  handleQueryChange(query) {
+    this.setState({
+      searchQuery: query
+    });
+  },
+
+  handleSearchSubmit() {
+    this._events.setQuery(this.state.searchQuery);
+    this._events.load();
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -1,0 +1,66 @@
+import React, { PropTypes } from 'react';
+import PureRendererMixin from 'react-immutable-render-mixin';
+import ComponentsStore from '../../../components/stores/ComponentsStore';
+import { Table } from 'react-bootstrap';
+import { NewLineToBr } from '@keboola/indigo-ui';
+import { format } from '../../../../utils/date';
+import ComponentName from '../../../../react/common/ComponentName';
+import ComponentIcon from '../../../../react/common/ComponentIcon';
+
+export default React.createClass({
+  mixins: [PureRendererMixin],
+
+  propTypes: {
+    events: PropTypes.object.isRequired
+  },
+
+  render() {
+    if (!this.props.events.count()) {
+      return null;
+    }
+
+    return (
+      <Table responsive stripped hover>
+        <thead>
+          <tr>
+            <th>Created</th>
+            <th>Component</th>
+            <th>Event</th>
+            <th>Creator</th>
+          </tr>
+        </thead>
+        <tbody>{this.props.events.map(this.renderRow)}</tbody>
+      </Table>
+    );
+  },
+
+  renderRow(event) {
+    const component = this.getComponent(event.get('component'));
+
+    return (
+      <tr>
+        <td>{format(event.get('created'))}</td>
+        <td>
+          <span>
+            <ComponentIcon component={component} size="32" resizeToSize="16" />
+            <ComponentName component={component} showType={true} capitalize={true} />
+          </span>
+        </td>
+        <td>
+          <NewLineToBr text={event.get('message')} />
+        </td>
+        <td>{event.getIn(['token', 'name'])}</td>
+      </tr>
+    );
+  },
+
+  getComponent(componentId) {
+    const component = ComponentsStore.getComponent(componentId);
+
+    if (!component) {
+      return ComponentsStore.unknownComponent(componentId);
+    }
+
+    return component;
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -6,6 +6,7 @@ import { NewLineToBr } from '@keboola/indigo-ui';
 import { format } from '../../../../utils/date';
 import ComponentName from '../../../../react/common/ComponentName';
 import ComponentIcon from '../../../../react/common/ComponentIcon';
+import EventDetailModal from '../modals/EventDetailModal';
 
 export default React.createClass({
   mixins: [PureRendererMixin],
@@ -14,23 +15,33 @@ export default React.createClass({
     events: PropTypes.object.isRequired
   },
 
+  getInitialState() {
+    return {
+      eventDetail: null
+    };
+  },
+
   render() {
     if (!this.props.events.count()) {
       return null;
     }
 
     return (
-      <Table responsive stripped hover>
-        <thead>
-          <tr>
-            <th>Created</th>
-            <th>Component</th>
-            <th>Event</th>
-            <th>Creator</th>
-          </tr>
-        </thead>
-        <tbody>{this.props.events.map(this.renderRow)}</tbody>
-      </Table>
+      <div>
+        {this.renderEventDetailModal()}
+
+        <Table responsive stripped hover>
+          <thead>
+            <tr>
+              <th>Created</th>
+              <th>Component</th>
+              <th>Event</th>
+              <th>Creator</th>
+            </tr>
+          </thead>
+          <tbody>{this.props.events.map(this.renderRow).toArray()}</tbody>
+        </Table>
+      </div>
     );
   },
 
@@ -38,7 +49,7 @@ export default React.createClass({
     const component = this.getComponent(event.get('component'));
 
     return (
-      <tr>
+      <tr key={event.get('id')} onClick={() => this.eventDetail(event)} className="kbc-cursor-pointer">
         <td>{format(event.get('created'))}</td>
         <td>
           <span>
@@ -52,6 +63,26 @@ export default React.createClass({
         <td>{event.getIn(['token', 'name'])}</td>
       </tr>
     );
+  },
+
+  renderEventDetailModal() {
+    if (!this.state.eventDetail) {
+      return null;
+    }
+
+    return <EventDetailModal event={this.state.eventDetail} onHide={this.resetEvent} />;
+  },
+
+  eventDetail(event) {
+    this.setState({
+      eventDetail: event
+    });
+  },
+
+  resetEvent() {
+    this.setState({
+      eventDetail: null
+    });
   },
 
   getComponent(componentId) {

--- a/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { Table, Button, Modal } from 'react-bootstrap';
 import { ExternalLink, Tree } from '@keboola/indigo-ui';
 import { format } from '../../../../utils/date';
-import FileSize from '../../../../react/common/FileSize';
+import FileLink from '../../../sapi-events/react/FileLink';
 
 export default React.createClass({
   propTypes: {
@@ -70,7 +70,14 @@ export default React.createClass({
       return null;
     }
 
-    return <div className="well message">{message}</div>;
+    const classMap = {
+      error: 'alert alert-danger',
+      warn: 'alert alert-warning',
+      success: 'alert alert-success',
+      info: 'well'
+    };
+
+    return <div className={classMap[this.props.event.get('type')] || 'well'}>{message}</div>;
   },
 
   renderDeprecatedAuthorization() {
@@ -109,11 +116,13 @@ export default React.createClass({
       <div>
         <h3>Attachments</h3>
         <ul>
-          {attachments.map(attachment => (
-            <li>
-              {attachment.get('uploadType')} <FileSize size={attachment.get('sizeBytes')} />
-            </li>
-          ))}
+          {attachments
+            .map((attachment, index) => (
+              <li key={index}>
+                <FileLink file={attachment} />
+              </li>
+            ))
+            .toArray()}
         </ul>
       </div>
     );

--- a/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
@@ -1,0 +1,140 @@
+import React, { PropTypes } from 'react';
+import { Table, Button, Modal } from 'react-bootstrap';
+import { ExternalLink, Tree } from '@keboola/indigo-ui';
+import { format } from '../../../../utils/date';
+import FileSize from '../../../../react/common/FileSize';
+
+export default React.createClass({
+  propTypes: {
+    event: PropTypes.object.isRequired,
+    onHide: PropTypes.func.isRequired
+  },
+
+  render() {
+    return (
+      <Modal show={true} onHide={this.props.onHide} enforceFocus={false}>
+        <Modal.Header closeButton>
+          <Modal.Title>Event detail</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {this.renderMessage()}
+          {this.renderDeprecatedAuthorization()}
+          {this.renderDescription()}
+          {this.renderDetail()}
+          {this.renderAttachments()}
+          {this.renderTreeData('Params', 'params')}
+          {this.renderTreeData('Performance', 'performance')}
+          {this.renderTreeData('Results', 'results')}
+          {this.renderTreeData('Context', 'context')}
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.props.onHide}>Close</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  },
+
+  renderDetail() {
+    return (
+      <Table>
+        <tbody>
+          <tr>
+            <td>ID</td>
+            <td>{this.props.event.get('id')}</td>
+          </tr>
+          <tr>
+            <td>Created</td>
+            <td>{format(this.props.event.get('created'))}</td>
+          </tr>
+          <tr>
+            <td>Component</td>
+            <td>{this.props.event.get('component')}</td>
+          </tr>
+          <tr>
+            <td>Configuration ID</td>
+            <td>{this.props.event.get('configurationId') || 'N/A'}</td>
+          </tr>
+          <tr>
+            <td>Run ID</td>
+            <td>{this.props.event.get('runId') || 'N/A'}</td>
+          </tr>
+        </tbody>
+      </Table>
+    );
+  },
+
+  renderMessage() {
+    const message = this.props.event.get('message');
+
+    if (!message) {
+      return null;
+    }
+
+    return <div className="well message">{message}</div>;
+  },
+
+  renderDeprecatedAuthorization() {
+    if (!this.isDeprecatedAuthorization()) {
+      return null;
+    }
+
+    return (
+      <p className="well error">
+        Used authorization method is deprecated and will be disabled soon.
+        <br />
+        Please move your tokens from query string parameters to "X-StorageApi-Token" http header. See more in{' '}
+        <ExternalLink href="http://docs.keboola.apiary.io/">API documentation</ExternalLink>
+      </p>
+    );
+  },
+
+  renderDescription() {
+    const description = this.props.event.get('description');
+
+    if (!description) {
+      return null;
+    }
+
+    return <p className="well">{description}</p>;
+  },
+
+  renderAttachments() {
+    const attachments = this.props.event.get('attachments');
+
+    if (!attachments || !attachments.count()) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h3>Attachments</h3>
+        <ul>
+          {attachments.map(attachment => (
+            <li>
+              {attachment.get('uploadType')} <FileSize size={attachment.get('sizeBytes')} />
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  },
+
+  renderTreeData(header, param) {
+    const data = this.props.event.get(param);
+
+    if (!data || !data.count()) {
+      return null;
+    }
+
+    return (
+      <div>
+        <h3>{header}</h3>
+        <Tree data={data} />
+      </div>
+    );
+  },
+
+  isDeprecatedAuthorization() {
+    return this.props.event.getIn(['context', 'authorization']) === 'deprecated';
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/EventDetailModal.jsx
@@ -1,5 +1,5 @@
 import React, { PropTypes } from 'react';
-import { Table, Button, Modal } from 'react-bootstrap';
+import { Table, Button, Modal, Alert } from 'react-bootstrap';
 import { ExternalLink, Tree } from '@keboola/indigo-ui';
 import { format } from '../../../../utils/date';
 import FileLink from '../../../sapi-events/react/FileLink';
@@ -70,14 +70,10 @@ export default React.createClass({
       return null;
     }
 
-    const classMap = {
-      error: 'alert alert-danger',
-      warn: 'alert alert-warning',
-      success: 'alert alert-success',
-      info: 'well'
-    };
+    const type = this.props.event.get('type');
+    const validType = ['success', 'warning', 'danger', 'info'].includes(type);
 
-    return <div className={classMap[this.props.event.get('type')] || 'well'}>{message}</div>;
+    return <Alert bsStyle={validType ? type : 'info'}>{message}</Alert>;
   },
 
   renderDeprecatedAuthorization() {
@@ -86,12 +82,14 @@ export default React.createClass({
     }
 
     return (
-      <p className="well error">
-        Used authorization method is deprecated and will be disabled soon.
-        <br />
-        Please move your tokens from query string parameters to "X-StorageApi-Token" http header. See more in{' '}
-        <ExternalLink href="http://docs.keboola.apiary.io/">API documentation</ExternalLink>
-      </p>
+      <Alert bsStyle="danger">
+        <p>
+          Used authorization method is deprecated and will be disabled soon.
+          <br />
+          Please move your tokens from query string parameters to "X-StorageApi-Token" http header. See more in{' '}
+          <ExternalLink href="http://docs.keboola.apiary.io/">API documentation</ExternalLink>
+        </p>
+      </Alert>
     );
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/Bucket.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/Bucket.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Col } from 'react-bootstrap';
+import Buckets from '../../components/Buckets';
+import BucketDetail from './BucketDetail';
+
+export default React.createClass({
+  render() {
+    return (
+      <div className="container-fluid">
+        <Col sm={3}>
+          <Buckets />
+        </Col>
+        <Col sm={9} className="kbc-main-content">
+          <BucketDetail />
+        </Col>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
+import RoutesStore from '../../../../../stores/RoutesStore';
+import BucketsStore from '../../../../components/stores/StorageBucketsStore';
+
+export default React.createClass({
+  mixins: [createStoreMixin(BucketsStore)],
+
+  getStateFromStores() {
+    const bucketId = RoutesStore.getCurrentRouteParam('bucketId');
+
+    return {
+      bucket: BucketsStore.getAll().find(item => item.get('id') === bucketId)
+    };
+  },
+
+  render() {
+    if (!this.state.bucket) {
+      return (
+        <div className="kbc-inner-padding">
+          <p>Bucket not found</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="kbc-inner-padding">
+        <h2>Bucket {this.state.bucket.get('id')}</h2>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tabs, Tab } from 'react-bootstrap';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
@@ -26,6 +27,21 @@ export default React.createClass({
     return (
       <div className="kbc-inner-padding">
         <h2>Bucket {this.state.bucket.get('id')}</h2>
+
+        <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
+          <Tab eventKey={1} title="Overview">
+            Overview
+          </Tab>
+          <Tab eventKey={2} title="Description">
+            Description
+          </Tab>
+          <Tab eventKey={3} title="Tables">
+            Tables
+          </Tab>
+          <Tab eventKey={4} title="Events">
+            Events
+          </Tab>
+        </Tabs>
       </div>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -15,6 +15,12 @@ export default React.createClass({
     };
   },
 
+  getInitialState() {
+    return {
+      activeTab: 'overview'
+    };
+  },
+
   render() {
     if (!this.state.bucket) {
       return (
@@ -30,21 +36,34 @@ export default React.createClass({
           <h2>Bucket {this.state.bucket.get('id')}</h2>
         </div>
 
-        <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
-          <Tab eventKey={1} title="Overview">
+        <Tabs
+          activeKey={this.state.activeTab}
+          onSelect={this.handleSelectTab}
+          animation={false}
+          id="bucket-detail-tabs"
+        >
+          <Tab eventKey="overview" title="Overview">
             Overview
           </Tab>
-          <Tab eventKey={2} title="Description">
+          <Tab eventKey="description" title="Description">
             Description
           </Tab>
-          <Tab eventKey={3} title="Tables">
+          <Tab eventKey="tables" title="Tables">
             Tables
           </Tab>
-          <Tab eventKey={4} title="Events">
+          <Tab eventKey="events" title="Events">
             Events
           </Tab>
         </Tabs>
       </div>
     );
+  },
+
+  handleSelectTab(tab) {
+    if (['overview', 'description', 'tables', 'events'].includes(tab)) {
+      this.setState({
+        activeTab: tab
+      });
+    }
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -25,8 +25,10 @@ export default React.createClass({
     }
 
     return (
-      <div className="kbc-inner-padding">
-        <h2>Bucket {this.state.bucket.get('id')}</h2>
+      <div>
+        <div className="kbc-inner-padding">
+          <h2>Bucket {this.state.bucket.get('id')}</h2>
+        </div>
 
         <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
           <Tab eventKey={1} title="Overview">

--- a/src/scripts/modules/storage-explorer/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Index/Index.jsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Col } from 'react-bootstrap';
-import Buckets from '../components/Buckets';
-import Events from '../components/Events';
+import Buckets from '../../components/Buckets';
+import Events from '../../components/Events';
 
 export default React.createClass({
   render() {
     return (
       <div className="container-fluid">
-        <Col sm={3} className="kbc-main-sidebar">
+        <Col sm={3}>
           <Buckets />
         </Col>
         <Col sm={9} className="kbc-main-content">

--- a/src/scripts/modules/storage-explorer/react/pages/Table/Table.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/Table.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Col } from 'react-bootstrap';
+import Buckets from '../../components/Buckets';
+import TableDetail from './TableDetail';
+
+export default React.createClass({
+  render() {
+    return (
+      <div className="container-fluid">
+        <Col sm={3}>
+          <Buckets />
+        </Col>
+        <Col sm={9} className="kbc-main-content">
+          <TableDetail />
+        </Col>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Tabs, Tab } from 'react-bootstrap';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
@@ -29,6 +30,30 @@ export default React.createClass({
     return (
       <div className="kbc-inner-padding">
         <h2>Table {this.state.table.get('name')}</h2>
+
+        <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
+          <Tab eventKey={1} title="Overview">
+            Overview
+          </Tab>
+          <Tab eventKey={2} title="Description">
+            Description
+          </Tab>
+          <Tab eventKey={3} title="Events">
+            Events
+          </Tab>
+          <Tab eventKey={3} title="Data sample">
+            Data sample
+          </Tab>
+          <Tab eventKey={3} title="Snapshot and Restore">
+            Snapshot and Restore
+          </Tab>
+          <Tab eventKey={3} title="Graph">
+            Graph
+          </Tab>
+          <Tab eventKey={3} title="Actions">
+            Actions
+          </Tab>
+        </Tabs>
       </div>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Tabs, Tab } from 'react-bootstrap';
+import { Tab, Nav, NavItem, NavDropdown, MenuItem } from 'react-bootstrap';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
@@ -18,6 +18,12 @@ export default React.createClass({
     };
   },
 
+  getInitialState() {
+    return {
+      activeTab: 'overview'
+    };
+  },
+
   render() {
     if (!this.state.table) {
       return (
@@ -33,30 +39,69 @@ export default React.createClass({
           <h2>Table {this.state.table.get('name')}</h2>
         </div>
 
-        <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
-          <Tab eventKey={1} title="Overview">
-            Overview
-          </Tab>
-          <Tab eventKey={2} title="Description">
-            Description
-          </Tab>
-          <Tab eventKey={3} title="Events">
-            Events
-          </Tab>
-          <Tab eventKey={4} title="Data sample">
-            Data sample
-          </Tab>
-          <Tab eventKey={5} title="Snapshot and Restore">
-            Snapshot and Restore
-          </Tab>
-          <Tab eventKey={6} title="Graph">
-            Graph
-          </Tab>
-          <Tab eventKey={7} title="Actions">
-            Actions
-          </Tab>
-        </Tabs>
+        <Tab.Container
+          activeKey={this.state.activeTab}
+          onSelect={this.handleSelectTab}
+          id="bucket-tabs"
+          generateChildId={this.generateTabId}
+        >
+          <div>
+            <Nav bsStyle="tabs">
+              <NavItem eventKey="overview">Overview</NavItem>
+              <NavItem eventKey="description">Description</NavItem>
+              <NavItem eventKey="events">Events</NavItem>
+              <NavItem eventKey="data-sample">Data sample</NavItem>
+              <NavItem eventKey="snapshot-and-restore">Snapshot and Restore</NavItem>
+              <NavItem eventKey="graph">Graph</NavItem>
+              <NavDropdown title="Actions">
+                <MenuItem eventKey="export" onSelect={this.handleDropdownAction}>
+                  Export
+                </MenuItem>
+                <MenuItem eventKey="load" onSelect={this.handleDropdownAction}>
+                  Load
+                </MenuItem>
+                <MenuItem eventKey="restore" onSelect={this.handleDropdownAction}>
+                  Time Travel Restore
+                </MenuItem>
+                <MenuItem eventKey="snapshot" onSelect={this.handleDropdownAction}>
+                  Create snapshot
+                </MenuItem>
+                <MenuItem divider />
+                <MenuItem eventKey="truncate" onSelect={this.handleDropdownAction}>
+                  Truncate table
+                </MenuItem>
+                <MenuItem eventKey="delete" onSelect={this.handleDropdownAction}>
+                  Delete table
+                </MenuItem>
+              </NavDropdown>
+            </Nav>
+            <Tab.Content animation={false}>
+              <Tab.Pane eventKey="overview">Overview</Tab.Pane>
+              <Tab.Pane eventKey="description">Description</Tab.Pane>
+              <Tab.Pane eventKey="events">Events</Tab.Pane>
+              <Tab.Pane eventKey="data-sample">Data sample</Tab.Pane>
+              <Tab.Pane eventKey="snapshot-and-restore">Snapshot and Restore</Tab.Pane>
+              <Tab.Pane eventKey="graph">Graph</Tab.Pane>
+            </Tab.Content>
+          </div>
+        </Tab.Container>
       </div>
     );
+  },
+
+  handleSelectTab(tab) {
+    if (['overview', 'description', 'events', 'data-sample', 'snapshot-and-restore', 'graph'].includes(tab)) {
+      this.setState({
+        activeTab: tab
+      });
+    }
+  },
+
+  handleDropdownAction(key) {
+    alert('action ' + key);
+  },
+
+  generateTabId(eventKey, type) {
+    return `${eventKey}-${type}`;
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
+import RoutesStore from '../../../../../stores/RoutesStore';
+import TablesStore from '../../../../components/stores/StorageTablesStore';
+
+export default React.createClass({
+  mixins: [createStoreMixin(TablesStore)],
+
+  getStateFromStores() {
+    const bucketId = RoutesStore.getCurrentRouteParam('bucketId');
+    const tableName = RoutesStore.getCurrentRouteParam('tableName');
+
+    return {
+      table: TablesStore.getAll().find(item => {
+        return item.getIn(['bucket', 'id']) === bucketId && item.get('name') === tableName;
+      })
+    };
+  },
+
+  render() {
+    if (!this.state.table) {
+      return (
+        <div className="kbc-inner-padding">
+          <p>Table not found</p>
+        </div>
+      );
+    }
+
+    return (
+      <div className="kbc-inner-padding">
+        <h2>Table {this.state.table.get('name')}</h2>
+      </div>
+    );
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -41,16 +41,16 @@ export default React.createClass({
           <Tab eventKey={3} title="Events">
             Events
           </Tab>
-          <Tab eventKey={3} title="Data sample">
+          <Tab eventKey={4} title="Data sample">
             Data sample
           </Tab>
-          <Tab eventKey={3} title="Snapshot and Restore">
+          <Tab eventKey={5} title="Snapshot and Restore">
             Snapshot and Restore
           </Tab>
-          <Tab eventKey={3} title="Graph">
+          <Tab eventKey={6} title="Graph">
             Graph
           </Tab>
-          <Tab eventKey={3} title="Actions">
+          <Tab eventKey={7} title="Actions">
             Actions
           </Tab>
         </Tabs>

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -28,8 +28,10 @@ export default React.createClass({
     }
 
     return (
-      <div className="kbc-inner-padding">
-        <h2>Table {this.state.table.get('name')}</h2>
+      <div>
+        <div className="kbc-inner-padding">
+          <h2>Table {this.state.table.get('name')}</h2>
+        </div>
 
         <Tabs defaultActiveKey={1} animation={false} id="bucket-detail-tabs">
           <Tab eventKey={1} title="Overview">

--- a/src/scripts/react/layout/SidebarNavigation.jsx
+++ b/src/scripts/react/layout/SidebarNavigation.jsx
@@ -48,6 +48,14 @@ const _pages = [
   }
 ];
 
+if (process.env.NODE_ENV === 'development') {
+  _pages.push({
+    id: 'storage-explorer',
+    title: 'Storage Explorer',
+    icon: 'kbc-icon-storage'
+  });
+}
+
 const SidebarNavigation = React.createClass({
   mixins: [State],
 

--- a/src/scripts/routes.js
+++ b/src/scripts/routes.js
@@ -10,6 +10,7 @@ import {extractors, writers, applications} from './modules/components/Routes';
 import orchestrationRoutes  from './modules/orchestrations/Routes';
 import transformationRoutes from './modules/transformations/Routes';
 import jobRoutes from './modules/jobs/Routes';
+import storageExplorerRouter from './modules/storage-explorer/Routes';
 import trashRoutes from './modules/trash/routes';
 import tables from './modules/table-browser/routes';
 
@@ -30,6 +31,7 @@ export default {
     jobRoutes,
     billingRoutes,
     transformationRoutes,
+    storageExplorerRouter,
     tables,
     trashRoutes,
     tokensRoutes,


### PR DESCRIPTION
Related #2402

Posílám teda INIT, aby se dalo mrknout zda jdu správným směrem. 

Co jsem přidal:
- routy na index, detail bucketu a detail tabulky
- na indexu jsem napojil eventy - klik otevře podobný modal jako v originále
- klik na detail název bucketu otevře menu kde jsou ty tabulky - po kliku se načte stránka detailu tabulky
- napojení na drobečkovku kde se dá překliknout na detail bucketu - původně bylo v nadpisu tabulky, ale v KBC se to asi spíše řeší přes tu drobečkovku
- ten sidebar i eventy mají napojený SearchBar
- ten sidebar se "resetuje" po překliku komponent, tak to případně budu muset ukládat, zatím neřešeno

