### PR TITLE
Revert confirm buttons hotfix

### DIFF
--- a/src/scripts/modules/tokens/react/pages/New/New.jsx
+++ b/src/scripts/modules/tokens/react/pages/New/New.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
             ) : (
               <div className="form form-horizontal">
                 <FormGroup>
-                  <Col sm={12}>
+                  <Col sm={12} className="text-right">
                     <ConfirmButtons
                       saveButtonType="submit"
                       isSaving={this.state.isSaving}
@@ -53,7 +53,6 @@ export default React.createClass({
                       onSave={this.handleSave}
                       saveLabel="Create"
                       showCancel={false}
-                      className="pull-right"
                     />
                   </Col>
                 </FormGroup>

--- a/src/scripts/react/common/EditButtons.jsx
+++ b/src/scripts/react/common/EditButtons.jsx
@@ -39,7 +39,6 @@ export default React.createClass({
           saveLabel={this.props.saveLabel}
           onCancel={this.props.onCancel}
           onSave={this.props.onSave}
-          className="pull-right"
         />
       );
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -684,8 +684,8 @@
     to-fast-properties "^2.0.0"
 
 "@keboola/indigo-ui@^7.0.0":
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/@keboola/indigo-ui/-/indigo-ui-7.1.0.tgz#1f71d852fe03e501a9497f7de14621684834d535"
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/@keboola/indigo-ui/-/indigo-ui-7.1.4.tgz#5de6c100eeb48b0c16e07790f47a47cb88126e51"
   dependencies:
     bootstrap "^3.3.7"
     classnames "^2.1.0"


### PR DESCRIPTION
Related to #2404 
Related to #2347 

Proposed changes:

- Revert hotifx with `pull-right` (`text-right` is enough)
