### PR TITLE
Storage Explorer - do not use alert in code

### DIFF
--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -97,8 +97,19 @@ export default React.createClass({
     }
   },
 
-  handleDropdownAction(key) {
-    alert('action ' + key);
+  handleDropdownAction(action) {
+    switch (action) {
+      case 'export':
+      case 'load':
+      case 'restore':
+      case 'snapshot':
+      case 'truncate':
+      case 'delete':
+        return null;
+
+      default:
+        return null;
+    }
   },
 
   generateTabId(eventKey, type) {


### PR DESCRIPTION
Příprava na řešení akcí. 
Vymazání alertu z kódu. Hází to warningy do konzole, tak bude lepší to mít takto připravené.