### PR TITLE
Show full datetime on configuration versions list

### DIFF
--- a/src/scripts/modules/components/react/components/VersionRow.jsx
+++ b/src/scripts/modules/components/react/components/VersionRow.jsx
@@ -94,6 +94,7 @@ export default React.createClass({
         <td>
           <CreatedWithIcon
             createdTime={this.props.version.get('created')}
+            relative={false}
           />
         </td>
         <td>

--- a/src/scripts/react/common/CreatedWithIcon.jsx
+++ b/src/scripts/react/common/CreatedWithIcon.jsx
@@ -3,18 +3,29 @@ import moment from 'moment';
 import date from '../../utils/date';
 
 export default React.createClass({
-  displayName: 'CreatedWithIcon',
-
   propTypes: {
-    createdTime: React.PropTypes.string
+    createdTime: React.PropTypes.string.isRequired,
+    relative: React.PropTypes.bool
   },
 
-  render: function() {
+  getDefaultProps() {
+    return {
+      relative: true
+    };
+  },
+
+  render() {
+    if (this.props.relative) {
+      return (
+        <span title={date.format(this.props.createdTime)}>
+          <i className="fa fa-fw fa-calendar" /> {moment(this.props.createdTime).fromNow()}
+        </span>
+      );
+    }
+
     return (
-      <span title={date.format(this.props.createdTime)}>
-        <i className="fa fa-fw fa-calendar" />
-        {' '}
-        {moment(this.props.createdTime).fromNow()}
+      <span title={moment(this.props.createdTime).fromNow()}>
+        <i className="fa fa-fw fa-calendar" /> {date.format(this.props.createdTime)}
       </span>
     );
   }


### PR DESCRIPTION
Fixes #2431

Upravil jsem tu komponentu `CreatedWithIcon` aby se dalo nastavit zda preferuji relativní čas nebo "klasický". A v těch verzích jsem teda aktivoval klasický. Jak je to na celou šířku, tak by se tam dalo napsat asi obojí, ale myslím, že i takto to je dobré.
