### PR TITLE
Replace "word-break" inline style with new classes

### DIFF
--- a/src/scripts/modules/components/react/components/TablesByBucketsPanel.jsx
+++ b/src/scripts/modules/components/react/components/TablesByBucketsPanel.jsx
@@ -131,7 +131,7 @@ export default React.createClass({
               {header}
             </div>
           )}
-          <div className="tbody" style={{ wordBreak: 'break-word' }}>
+          <div className="tbody kbc-break-all kbc-break-word">
             {childs}
           </div>
         </div>

--- a/src/scripts/modules/components/react/components/generic/FileInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileInputMappingHeader.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{'wordBreak': 'break-word'}}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             <span className="td col-xs-3">

--- a/src/scripts/modules/components/react/components/generic/FileOutputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileOutputMappingHeader.jsx
@@ -20,7 +20,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{ 'word-break': 'break-word' }}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             <span className="td col-xs-4">

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
@@ -29,7 +29,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{ 'word-break': 'break-word' }}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             {this.props.definition.has('label')

--- a/src/scripts/modules/components/react/components/generic/TableOutputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMappingHeader.jsx
@@ -29,7 +29,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{ 'word-break': 'break-word' }}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             {this.props.definition.get('label')

--- a/src/scripts/modules/ex-facebook/react/Index/QueriesTable.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/QueriesTable.jsx
@@ -29,7 +29,7 @@ export default React.createClass({
 
   render() {
     return (
-      <Table className="table table-striped" style={{wordBreak: 'break-word'}}>
+      <Table striped className="kbc-break-all kbc-break-word">
         <thead className="thead">
           <tr className="tr">
             <th className="th">

--- a/src/scripts/modules/ex-google-analytics-v4/react/Index/QueriesTable.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/Index/QueriesTable.jsx
@@ -52,7 +52,7 @@ export default React.createClass({
             </div>
           </div>
         </div>
-        <div className="tbody" style={{'wordBreak': 'break-word'}}>
+        <div className="tbody kbc-break-all kbc-break-word">
           {this.props.queries.map((q) => this.renderQueryRow(q))}
         </div>
       </div>

--- a/src/scripts/modules/ex-google-drive/react/Index/SheetsTable.jsx
+++ b/src/scripts/modules/ex-google-drive/react/Index/SheetsTable.jsx
@@ -51,7 +51,7 @@ export default React.createClass({
             </div>
           </div>
         </div>
-        <div className="tbody" style={{'wordBreak': 'break-word'}}>
+        <div className="tbody kbc-break-all kbc-break-word">
           {this.props.sheets.map((q) => this.renderSheetRow(q))}
         </div>
       </div>

--- a/src/scripts/modules/gooddata-writer/react/components/TableLoadType.jsx
+++ b/src/scripts/modules/gooddata-writer/react/components/TableLoadType.jsx
@@ -266,7 +266,7 @@ export default React.createClass({
       );
     }
     return (
-      <span style={{ 'padding-left': 0 }} className="col-sm-4">
+      <span style={{ 'paddingLeft': 0 }} className="col-sm-4">
         <select
           className="form-control"
           disabled={!enabled}

--- a/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
@@ -28,7 +28,9 @@ export default React.createClass({
         <td>
           <span className="label label-info">{this.props.task.get('action')}</span>
         </td>
-        <td style={{ wordBreak: 'break-word' }}>{this._renderConfiguration()}</td>
+        <td className="kbc-break-all kbc-break-word">
+          {this._renderConfiguration()}
+        </td>
         <td>
           <input
             type="checkbox"

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
@@ -33,7 +33,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{ wordBreak: 'break-word' }}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             {this.props.definition.has('label')

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
@@ -33,7 +33,7 @@ export default React.createClass({
 
   render() {
     return (
-      <span className="table" style={{ wordBreak: 'break-word' }}>
+      <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
           <span className="tr">
             {this.props.definition.has('label')


### PR DESCRIPTION
Fixes #1354 .. ještě koukám na toto staré issue #480, to je asi už úplně neaktuální že?

Použití nových tříd `kbc-break-all kbc-break-word`. První je fallback pokud druhá nejde použít. Což platí asi pro Firefox třeba. Je možné že to někde může "breakovat" víc než je potřeba, ale asi lepší než aby třeba tlačítka byly mimo obrazovku. Pro Chrome a všechny co podporují `word-break` by se tímto nemělo nic změnit. 