### PR TITLE
Fake storage component for events list

### DIFF
--- a/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
+++ b/src/scripts/modules/sapi-events/react/EventsTableRow.jsx
@@ -60,7 +60,9 @@ export default React.createClass({
 
   getComponent() {
     const componentId = this.props.event.get('component');
-    const component = ComponentsStore.getComponent(componentId);
+    const component = componentId === 'storage'
+      ? ComponentsStore.getComponent('keboola.storage')
+      : ComponentsStore.getComponent(componentId);
 
     if (!component) {
       return ComponentsStore.unknownComponent(componentId);


### PR DESCRIPTION
Fixes #2308 

Proposed changes:

- use `keboola.storage` component for showing component in events list
