### PR TITLE
gooddata writer: fix orphaned tables render

### DIFF
--- a/src/scripts/modules/gooddata-writer/react/pages/index/TableRow.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/TableRow.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
     if (!this.props.table.getIn(['data', 'export'])) {
       titleClass = 'td text-muted';
     }
-    const Elem = this.props.isDeleted ? React.DOM.div : Link;
+    const Elem = this.props.isDeleted ? 'div' : Link;
     return (
       <Elem
         className="tr"


### PR DESCRIPTION
Fixes #2454 

ak config obsahuje uz zmazanu tabulku tak by sa spravne mal zobrazit `Nonexisting tables` panel.
![image](https://user-images.githubusercontent.com/1412120/49378201-4b4ff680-f70c-11e8-8d64-3797f1f9393c.png)

Toto PR fixuje jeho zobrazenie - teraz to pada na chybe rendru ktora zrejme vznikla pri prevode z coffee->jsx.

