### PR TITLE
Storage Explorer - Table - Data sample

### DIFF
--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -1,4 +1,5 @@
 import StorageActionCreators from '../components/StorageActionCreators';
+import StorageApi from '../components/StorageApi';
 import RoutesStore from '../../stores/RoutesStore';
 import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 
@@ -47,6 +48,21 @@ const addTableColumn = (tableId, params) => {
     .catch(errorNotification);
 };
 
+const dataPreview = (tableId, params) => {
+  return StorageApi
+    .tableDataPreview(tableId, { limit: 20, ...params })
+    .catch(error => {
+      if (!error.response && !error.response.body) {
+        throw new Error(JSON.stringify(error));
+      }
+
+      if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
+        return 'Data sample cannot be displayed. Too many columns.';
+      }
+
+      return error.response.body.message;
+    });
+};
 
 export {
   deleteBucket,
@@ -54,5 +70,6 @@ export {
   createTablePrimaryKey,
   removeTablePrimaryKey,
   deleteTableColumn,
-  addTableColumn
+  addTableColumn,
+  dataPreview
 };

--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -52,7 +52,7 @@ const dataPreview = (tableId, params) => {
   return StorageApi
     .tableDataPreview(tableId, { limit: 20, ...params })
     .catch(error => {
-      if (!error.response && !error.response.body) {
+      if (!error.response || !error.response.body) {
         throw new Error(JSON.stringify(error));
       }
 

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -28,7 +28,7 @@ export default React.createClass({
   render() {
     return (
       <div>
-        {this.renderSearchForm()}
+        {(this.state.data.count() > 1 || this.state.filtered) && this.renderSearchForm()}
         {this.renderTable()}
       </div>
     );

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -162,7 +162,7 @@ export default React.createClass({
   fetchDataPreview(params = {}) {
     this.setState({ loading: true });
 
-    return dataPreview(this.props.table.get('id'), params)
+    dataPreview(this.props.table.get('id'), params)
       .then(csv => {
         this.setState({ data: fromJS(csv) });
       })

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -1,0 +1,203 @@
+import React, { PropTypes } from 'react';
+import { Map, fromJS } from 'immutable';
+import { Alert, Form, FormGroup, FormControl, Col, ButtonGroup, Button, Table } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import Select from 'react-select';
+import StorageApi from '../../../components/StorageApi';
+
+export default React.createClass({
+  propTypes: {
+    table: PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    return {
+      data: Map(),
+      error: null,
+      loading: false,
+      filtered: false,
+      filterColumn: '',
+      filterValue: ''
+    };
+  },
+
+  componentDidMount() {
+    this.fetchDataPreview();
+  },
+
+  render() {
+    return (
+      <div>
+        {this.renderSearchForm()}
+        {this.renderTable()}
+      </div>
+    );
+  },
+
+  renderSearchForm() {
+    return (
+      <div className="kbc-inner-padding">
+        <Form onSubmit={this.handleSearch} horizontal>
+          <FormGroup>
+            <Col sm={4}>
+              <Select
+                clearable={false}
+                disabled={false}
+                placeholder="Filter by column"
+                value={this.state.filterColumn}
+                onChange={this.handleSearchColumn}
+                options={this.tableColumns()}
+              />
+            </Col>
+            <Col sm={4}>
+              <FormControl
+                type="text"
+                placeholder="Value"
+                value={this.state.filterValue}
+                onChange={this.handleSearchValue}
+              />
+            </Col>
+            <Col sm={4}>
+              <ButtonGroup>
+                <Button bsStyle="success" type="submit" disabled={!this.state.filterColumn || !this.state.filterValue}>
+                  Search
+                </Button>
+                <Button onClick={this.resetSearchForm} disabled={!this.state.filtered}>
+                  Reset
+                </Button>
+              </ButtonGroup>
+            </Col>
+          </FormGroup>
+        </Form>
+      </div>
+    );
+  },
+
+  renderTable() {
+    if (this.state.loading) {
+      return (
+        <div className="kbc-inner-padding">
+          <p>
+            Loading data.. <Loader />
+          </p>
+        </div>
+      );
+    }
+
+    if (this.state.data.count() < 2) {
+      return (
+        <div className="kbc-inner-padding">
+          <p>{this.state.filtered ? 'No data found.' : 'Table is empty.'}</p>
+        </div>
+      );
+    }
+
+    if (this.state.error) {
+      return (
+        <div className="kbc-inner-padding">
+          <Alert bsStyle="danger">{this.state.error}</Alert>
+        </div>
+      );
+    }
+
+    return (
+      <Table responsive striped hover>
+        <thead>
+          <tr>
+            {this.state.data.first().map((header, index) => (
+              <th key={index}>
+                <strong>{header}</strong>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {this.state.data.shift().map((row, index) => (
+            <tr key={index}>
+              {row.map((item, itemIndex) => (
+                <td key={`${index}-${itemIndex}`}>{item}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    );
+  },
+
+  handleSearchColumn(column) {
+    this.setState({
+      filterColumn: column.value
+    });
+  },
+
+  handleSearchValue(event) {
+    this.setState({
+      filterValue: event.target.value
+    });
+  },
+
+  handleSearch(event) {
+    event.preventDefault();
+
+    const params = {
+      whereColumn: this.state.filterColumn,
+      'whereValues[]': [this.state.filterValue]
+    };
+
+    return this.fetchDataPreview(params).finally(() => {
+      this.setState({ filtered: true });
+    });
+  },
+
+  resetSearchForm() {
+    if (this.state.filtered) {
+      this.fetchDataPreview();
+    }
+
+    this.setState({
+      filtered: false,
+      filterColumn: '',
+      filterValue: ''
+    });
+  },
+
+  tableColumns() {
+    return this.props.table
+      .get('columns')
+      .map(column => ({
+        label: column,
+        value: column
+      }))
+      .toArray();
+  },
+
+  fetchDataPreview(params = {}) {
+    this.setState({ loading: true });
+    return StorageApi.tableDataPreview(this.props.table.get('id'), { limit: 20, ...params })
+      .then(csv => {
+        this.setState({
+          loading: false,
+          data: fromJS(csv)
+        });
+      })
+      .catch(error => {
+        let errorMessage = null;
+
+        if (error.response && error.response.body) {
+          if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
+            errorMessage = 'Data sample cannot be displayed. Too many columns.';
+          } else {
+            errorMessage = error.response.body.message;
+          }
+        } else {
+          throw new Error(JSON.stringify(error));
+        }
+
+        this.setState({
+          loading: false,
+          dataPreview: Map(),
+          error: errorMessage
+        });
+      });
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -100,10 +100,10 @@ export default React.createClass({
           </tr>
         </thead>
         <tbody>
-          {this.state.data.shift().map((row, index) => (
-            <tr key={index}>
-              {row.map((item, itemIndex) => (
-                <td key={`${index}-${itemIndex}`}>{item}</td>
+          {this.state.data.shift().map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {row.map((column, columnIndex) => (
+                <td key={`${rowIndex}-${columnIndex}`}>{column}</td>
               ))}
             </tr>
           ))}

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -132,7 +132,7 @@ export default React.createClass({
       'whereValues[]': [this.state.filterValue]
     };
 
-    this.fetchDataPreview(params).than(() => {
+    this.fetchDataPreview(params).then(() => {
       this.setState({ filtered: true });
     });
   },
@@ -162,7 +162,7 @@ export default React.createClass({
   fetchDataPreview(params = {}) {
     this.setState({ loading: true });
 
-    dataPreview(this.props.table.get('id'), params)
+    return dataPreview(this.props.table.get('id'), params)
       .then(csv => {
         this.setState({ data: fromJS(csv) });
       })

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -36,68 +36,56 @@ export default React.createClass({
 
   renderSearchForm() {
     return (
-      <div className="kbc-inner-padding">
-        <Form onSubmit={this.handleSearch} horizontal>
-          <FormGroup>
-            <Col sm={4}>
-              <Select
-                clearable={false}
-                disabled={false}
-                placeholder="Filter by column"
-                value={this.state.filterColumn}
-                onChange={this.handleSearchColumn}
-                options={this.tableColumns()}
-              />
-            </Col>
-            <Col sm={4}>
-              <FormControl
-                type="text"
-                placeholder="Value"
-                value={this.state.filterValue}
-                onChange={this.handleSearchValue}
-              />
-            </Col>
-            <Col sm={4}>
-              <ButtonGroup>
-                <Button bsStyle="success" type="submit" disabled={!this.state.filterColumn || !this.state.filterValue}>
-                  Search
-                </Button>
-                <Button onClick={this.resetSearchForm} disabled={!this.state.filtered}>
-                  Reset
-                </Button>
-              </ButtonGroup>
-            </Col>
-          </FormGroup>
-        </Form>
-      </div>
+      <Form onSubmit={this.handleSearch} horizontal>
+        <FormGroup>
+          <Col sm={4}>
+            <Select
+              clearable={false}
+              disabled={false}
+              placeholder="Filter by column"
+              value={this.state.filterColumn}
+              onChange={this.handleSearchColumn}
+              options={this.tableColumns()}
+            />
+          </Col>
+          <Col sm={4}>
+            <FormControl
+              type="text"
+              placeholder="Value"
+              value={this.state.filterValue}
+              onChange={this.handleSearchValue}
+            />
+          </Col>
+          <Col sm={4}>
+            <ButtonGroup>
+              <Button className="btn btn-link" onClick={this.resetSearchForm} disabled={!this.state.filtered}>
+                Reset
+              </Button>
+              <Button bsStyle="success" type="submit" disabled={!this.state.filterColumn || !this.state.filterValue}>
+                Search
+              </Button>
+            </ButtonGroup>
+          </Col>
+        </FormGroup>
+      </Form>
     );
   },
 
   renderTable() {
     if (this.state.loading) {
       return (
-        <div className="kbc-inner-padding">
-          <p>
-            Loading data.. <Loader />
-          </p>
-        </div>
+        <p>
+          Loading data.. <Loader />
+        </p>
       );
     }
 
     if (this.state.data.count() < 2) {
-      return (
-        <div className="kbc-inner-padding">
-          <p>{this.state.filtered ? 'No data found.' : 'Table is empty.'}</p>
-        </div>
-      );
+      return <p>{this.state.filtered ? 'No data found.' : 'Table is empty.'}</p>;
     }
 
     if (this.state.error) {
-      return (
-        <div className="kbc-inner-padding">
-          <Alert bsStyle="danger">{this.state.error}</Alert>
-        </div>
-      );
+      return <Alert bsStyle="danger">{this.state.error}</Alert>;
     }
 
     return (
@@ -144,7 +132,7 @@ export default React.createClass({
       'whereValues[]': [this.state.filterValue]
     };
 
-    return this.fetchDataPreview(params).finally(() => {
+    this.fetchDataPreview(params).finally(() => {
       this.setState({ filtered: true });
     });
   },

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -6,6 +6,7 @@ import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
+import DataSample from '../../components/DataSample';
 
 import TableOverview from './TableOverview';
 import TableColumn from './TableColumn';
@@ -109,7 +110,9 @@ export default React.createClass({
                 />
               </Tab.Pane>
               <Tab.Pane eventKey="events">Events</Tab.Pane>
-              <Tab.Pane eventKey="data-sample">Data sample</Tab.Pane>
+              <Tab.Pane eventKey="data-sample">
+                <DataSample table={this.state.table} />
+              </Tab.Pane>
               <Tab.Pane eventKey="snapshot-and-restore">Snapshot and Restore</Tab.Pane>
               <Tab.Pane eventKey="graph">Graph</Tab.Pane>
             </Tab.Content>


### PR DESCRIPTION
Related #2402 

Koukal jsem že data sample na pár místech je, ale nějakou přímo komponentu jsme neviděl. Spíš každá slouží na tom svém místě. Jestli jsem nějakou nepřehlédnul.

V originálním storage-api-console bylo u "Data Sample" ještě nějaký editor. Ale pouze pokud je true `tableDataEditing` které nikde nevidím. Takže to je možná vždy false. Něco "starého" jakože. Takže to jsem nepřenášel.

Ještě jsem koukal, že když pošlu v "params" do api pole, při hledání mám posílat "whereValues". Ale i když posílám whereValues = ["item"] tak mi api hlásí že neposílám pole. A musel jsem ručně ten parametr upravit na "whereValues[]". Je to OK nebo na to je nějaký helper nebo jsme to dělal blbě? :)

Catch blok při tom načítání Preview jsem vzal z jiného místa. Jak se tam získává ta message případně vyhazuje Error. Tak snad ok.
