### PR TITLE
clone table support in transformation input mapping

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -298,7 +298,7 @@ export default React.createClass({
             </Col>
           </FormGroup>
           {!isCloneTable &&
-           <span>
+           <div>
              <FormGroup>
                <Col sm={2} componentClass={ControlLabel}>Columns</Col>
                <Col sm={10}>
@@ -371,7 +371,7 @@ export default React.createClass({
                disabled={this.props.disabled || !this.props.value.get('source')}
                onChange={this._handleChangeDataTypes}
              />
-           </span>
+           </div>
           }
         </PanelWithDetails>
       </Form>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -77,6 +77,16 @@ export default React.createClass({
     return this.props.onChange(value);
   },
 
+  canCloneTable() {
+    const table = this.getSelectedTable();
+    const isSnowflake = table.getIn(['bucket', 'backend']) === 'snowflake';
+    const isAliased = table.get('isAlias', false);
+    const isFiltered = table.get('aliasFilter', Map()).count() > 0;
+    const isSynced = table.get('aliasColumnsAutoSync', false);
+    const isAliasClonable = isAliased ? isSynced && !isFiltered : true;
+    return isSnowflake && isAliasClonable;
+  },
+
   handleChangeLoadType(newValue) {
     const newMapping = this.props.value.set('loadType', newValue);
     return this.props.onChange(newMapping);
@@ -287,7 +297,7 @@ export default React.createClass({
                 onChange={this.handleChangeLoadType}
                 options={[
                   {label: 'Copy Table', value: 'copy'},
-                  {label: 'Clone Table', value: 'clone'}
+                  {label: 'Clone Table', value: 'clone', disabled: !this.canCloneTable()}
                 ]}
               />
               <HelpBlock>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -281,6 +281,7 @@ export default React.createClass({
             <Col sm={10}>
               <Select
                 name="loadType"
+                searchable={false}
                 value={this.props.value.get('loadType', 'copy')}
                 disabled={this.props.disabled || !this.props.value.get('source')}
                 placeholder="Default input mapping"

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -52,13 +52,14 @@ export default React.createClass({
     // use only table name from the table identifier
     const destination = value ? value.substr(value.lastIndexOf('.') + 1) : '';
     const mutatedValue = this.props.value.withMutations((mapping) => {
-      let mutation = mapping.set('source', value);
-      mutation = mutation.set('destination', destination);
-      mutation = mutation.set('datatypes', this.getInitialDatatypes(value));
-      mutation = mutation.set('whereColumn', '');
-      mutation = mutation.set('whereValues', List());
-      mutation = mutation.set('whereOperator', 'eq');
-      return mutation.set('columns', List());
+      mapping.set('source', value);
+      mapping.set('destination', destination);
+      mapping.set('datatypes', this.getInitialDatatypes(value));
+      mapping.set('whereColumn', '');
+      mapping.set('loadType', 'copy');
+      mapping.set('whereValues', List());
+      mapping.set('whereOperator', 'eq');
+      mapping.set('columns', List());
     });
     return this.props.onChange(mutatedValue);
   },

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -88,7 +88,14 @@ export default React.createClass({
   },
 
   handleChangeLoadType(newValue) {
-    const newMapping = this.props.value.set('loadType', newValue);
+    const newMapping = this.props.value.withMutations(mapping => {
+      mapping.set('loadType', newValue);
+      mapping.set('whereColumn', '');
+      mapping.set('whereValues', List());
+      mapping.set('whereOperator', 'eq');
+      mapping.set('columns', List());
+      mapping.set('datatypes', Map());
+    });
     return this.props.onChange(newMapping);
   },
 
@@ -235,6 +242,7 @@ export default React.createClass({
   },
 
   render() {
+    const isCloneTable = this.props.value.get('loadType') === 'clone';
     return (
       <Form horizontal>
         <FormGroup>
@@ -269,23 +277,6 @@ export default React.createClass({
         />
         <PanelWithDetails defaultExpanded={this.props.initialShowDetails}>
           <FormGroup>
-            <Col sm={2} componentClass={ControlLabel}>Columns</Col>
-            <Col sm={10}>
-              <Select
-                multi={true}
-                name="columns"
-                value={this.props.value.get('columns', List()).toJS()}
-                disabled={this.props.disabled || !this.props.value.get('source')}
-                placeholder="All columns will be imported"
-                onChange={this._handleChangeColumns}
-                options={this._getColumnsOptions()}
-              />
-              <HelpBlock>
-                Import only specified columns
-              </HelpBlock>
-            </Col>
-          </FormGroup>
-          <FormGroup>
             <Col sm={2} componentClass={ControlLabel}>Load Type</Col>
             <Col sm={10}>
               <Select
@@ -305,62 +296,82 @@ export default React.createClass({
               </HelpBlock>
             </Col>
           </FormGroup>
-
-          <FormGroup>
-            <Col sm={2} componentClass={ControlLabel}>Changed in last</Col>
-            <Col sm={10}>
-              <ChangedSinceInput
-                value={this.getChangedSinceValue()}
-                disabled={this.props.disabled}
-                onChange={this._handleChangeChangedSince}
-              />
-            </Col>
-          </FormGroup>
-          <FormGroup>
-            <Col sm={2} componentClass={ControlLabel}>Data filter</Col>
-            <Col sm={4}>
-              <Select
-                name="whereColumn"
-                value={this.props.value.get('whereColumn')}
-                disabled={this.props.disabled || !this.props.value.get('source')}
-                placeholder="Select column"
-                onChange={this._handleChangeWhereColumn}
-                options={this._getColumnsOptions()}
-              />
-            </Col>
-            <Col sm={2}>
-              <Input
-                type="select"
-                name="whereOperator"
-                value={this.props.value.get('whereOperator')}
-                disabled={this.props.disabled}
-                onChange={this._handleChangeWhereOperator}
-              >
-                <option value={whereOperatorConstants.EQ_VALUE}>{whereOperatorConstants.EQ_LABEL}</option>
-                <option value={whereOperatorConstants.NOT_EQ_VALUE}>{whereOperatorConstants.NOT_EQ_LABEL}</option>
-              </Input>
-            </Col>
-            <Col sm={4}>
-              <Select
-                name="whereValues"
-                value={this.props.value.get('whereValues')}
-                multi={true}
-                disabled={this.props.disabled}
-                allowCreate={true}
-                placeholder="Add a value..."
-                emptyStrings={true}
-                onChange={this._handleChangeWhereValues}
-              />
-            </Col>
-          </FormGroup>
-          <ControlLabel>Data types</ControlLabel>
-          <DatatypeForm
-            datatypes={this.getDatatypes()}
-            columns={this._getFilteredColumns()}
-            datatypesMap={SnowflakeDataTypesMapping}
-            disabled={this.props.disabled || !this.props.value.get('source')}
-            onChange={this._handleChangeDataTypes}
-          />
+          {!isCloneTable &&
+           <span>
+             <FormGroup>
+               <Col sm={2} componentClass={ControlLabel}>Columns</Col>
+               <Col sm={10}>
+                 <Select
+                   multi={true}
+                   name="columns"
+                   value={this.props.value.get('columns', List()).toJS()}
+                   disabled={this.props.disabled || !this.props.value.get('source')}
+                   placeholder="All columns will be imported"
+                   onChange={this._handleChangeColumns}
+                   options={this._getColumnsOptions()}
+                 />
+                 <HelpBlock>
+                   Import only specified columns
+                 </HelpBlock>
+               </Col>
+             </FormGroup>
+             <FormGroup>
+               <Col sm={2} componentClass={ControlLabel}>Changed in last</Col>
+               <Col sm={10}>
+                 <ChangedSinceInput
+                   value={this.getChangedSinceValue()}
+                   disabled={this.props.disabled}
+                   onChange={this._handleChangeChangedSince}
+                 />
+               </Col>
+             </FormGroup>
+             <FormGroup>
+               <Col sm={2} componentClass={ControlLabel}>Data filter</Col>
+               <Col sm={4}>
+                 <Select
+                   name="whereColumn"
+                   value={this.props.value.get('whereColumn')}
+                   disabled={this.props.disabled || !this.props.value.get('source')}
+                   placeholder="Select column"
+                   onChange={this._handleChangeWhereColumn}
+                   options={this._getColumnsOptions()}
+                 />
+               </Col>
+               <Col sm={2}>
+                 <Input
+                   type="select"
+                   name="whereOperator"
+                   value={this.props.value.get('whereOperator')}
+                   disabled={this.props.disabled}
+                   onChange={this._handleChangeWhereOperator}
+                 >
+                   <option value={whereOperatorConstants.EQ_VALUE}>{whereOperatorConstants.EQ_LABEL}</option>
+                   <option value={whereOperatorConstants.NOT_EQ_VALUE}>{whereOperatorConstants.NOT_EQ_LABEL}</option>
+                 </Input>
+               </Col>
+               <Col sm={4}>
+                 <Select
+                   name="whereValues"
+                   value={this.props.value.get('whereValues')}
+                   multi={true}
+                   disabled={this.props.disabled}
+                   allowCreate={true}
+                   placeholder="Add a value..."
+                   emptyStrings={true}
+                   onChange={this._handleChangeWhereValues}
+                 />
+               </Col>
+             </FormGroup>
+             <ControlLabel>Data types</ControlLabel>
+             <DatatypeForm
+               datatypes={this.getDatatypes()}
+               columns={this._getFilteredColumns()}
+               datatypesMap={SnowflakeDataTypesMapping}
+               disabled={this.props.disabled || !this.props.value.get('source')}
+               onChange={this._handleChangeDataTypes}
+             />
+           </span>
+          }
         </PanelWithDetails>
       </Form>
     );

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -78,7 +78,7 @@ export default React.createClass({
   },
 
   canCloneTable() {
-    const table = this.getSelectedTable();
+    const table = this.getSelectedTable() || Map();
     const isSnowflake = table.getIn(['bucket', 'backend']) === 'snowflake';
     const isAliased = table.get('isAlias', false);
     const isFiltered = table.get('aliasFilter', Map()).count() > 0;

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -77,6 +77,11 @@ export default React.createClass({
     return this.props.onChange(value);
   },
 
+  handleChangeLoadType(newValue) {
+    const newMapping = this.props.value.set('loadType', newValue);
+    return this.props.onChange(newMapping);
+  },
+
   _handleChangeColumns(newValue) {
     const mutatedValue = this.props.value.withMutations((mapping) => {
       let mutation = mapping.set('columns', newValue);
@@ -270,6 +275,27 @@ export default React.createClass({
               </HelpBlock>
             </Col>
           </FormGroup>
+          <FormGroup>
+            <Col sm={2} componentClass={ControlLabel}>Load Type</Col>
+            <Col sm={10}>
+              <Select
+                name="loadType"
+                value={this.props.value.get('loadType', 'copy')}
+                disabled={this.props.disabled || !this.props.value.get('source')}
+                placeholder="Default input mapping"
+                clearable={false}
+                onChange={this.handleChangeLoadType}
+                options={[
+                  {label: 'Copy Table', value: 'copy'},
+                  {label: 'Clone Table', value: 'clone'}
+                ]}
+              />
+              <HelpBlock>
+                Type of table load from Storage into a Workspace. <code>Clone</code> load type can be aplied only on snowflake tables without any filtering parameters.
+              </HelpBlock>
+            </Col>
+          </FormGroup>
+
           <FormGroup>
             <Col sm={2} componentClass={ControlLabel}>Changed in last</Col>
             <Col sm={10}>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -56,7 +56,7 @@ export default React.createClass({
       mapping.set('destination', destination);
       mapping.set('datatypes', this.getInitialDatatypes(value));
       mapping.set('whereColumn', '');
-      mapping.set('loadType', 'copy');
+      mapping.delete('loadType');
       mapping.set('whereValues', List());
       mapping.set('whereOperator', 'eq');
       mapping.set('columns', List());
@@ -89,7 +89,11 @@ export default React.createClass({
 
   handleChangeLoadType(newValue) {
     const newMapping = this.props.value.withMutations(mapping => {
-      mapping.set('loadType', newValue);
+      if (newValue && newValue !== '') {
+        mapping.set('loadType', newValue);
+      } else {
+        mapping.delete('loadType');
+      }
       mapping.set('whereColumn', '');
       mapping.set('whereValues', List());
       mapping.set('whereOperator', 'eq');
@@ -282,13 +286,13 @@ export default React.createClass({
               <Select
                 name="loadType"
                 searchable={false}
-                value={this.props.value.get('loadType', 'copy')}
+                value={this.props.value.get('loadType', '')}
                 disabled={this.props.disabled || !this.props.value.get('source')}
-                placeholder="Default input mapping"
+                placeholder="Copy Table (default)"
                 clearable={false}
                 onChange={this.handleChangeLoadType}
                 options={[
-                  {label: 'Copy Table (default)', value: 'copy'},
+                  {label: 'Copy Table (default)', value: ''},
                   {label: 'Clone Table', value: 'clone', disabled: !this.canCloneTable()}
                 ]}
               />

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -293,7 +293,7 @@ export default React.createClass({
                 ]}
               />
               <HelpBlock>
-                Type of table load from Storage into a Workspace. <code>Clone</code> load type can be aplied only on snowflake tables without any filtering parameters.
+                Type of table load from Storage into a Workspace. <code>Clone</code> load type can be applied only on Snowflake tables without any filtering parameters.
               </HelpBlock>
             </Col>
           </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -288,7 +288,7 @@ export default React.createClass({
                 clearable={false}
                 onChange={this.handleChangeLoadType}
                 options={[
-                  {label: 'Copy Table', value: 'copy'},
+                  {label: 'Copy Table (default)', value: 'copy'},
                   {label: 'Clone Table', value: 'clone', disabled: !this.canCloneTable()}
                 ]}
               />

--- a/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
+++ b/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
@@ -64,7 +64,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         componentClass={[Function]}
         sm={2}
       >
-        Columns
+        Load Type
       </Col>
       <Col
         bsClass="col"
@@ -73,67 +73,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
       >
         <Select
           allowCreate={false}
-          delimiter=","
-          disabled={true}
-          emptyStrings={false}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="columns"
-          onChange={[Function]}
-          options={Array []}
-          placeholder="All columns will be imported"
-          trimMultiCreatedValues={false}
-          value={Array []}
-          valueKey="value"
-        />
-        <HelpBlock
-          bsClass="help-block"
-        >
-          Import only specified columns
-        </HelpBlock>
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Changed in last
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={10}
-      >
-        <ChangedSinceInput
-          disabled={false}
-          onChange={[Function]}
-          value={null}
-        />
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Data filter
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={false}
+          clearable={false}
           delimiter=","
           disabled={true}
           emptyStrings={false}
@@ -141,124 +81,243 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
           labelKey="label"
           matchProp="any"
           multi={false}
-          name="whereColumn"
+          name="loadType"
           onChange={[Function]}
-          options={Array []}
-          placeholder="Select column"
+          options={
+            Array [
+              Object {
+                "label": "Copy Table (default)",
+                "value": "",
+              },
+              Object {
+                "disabled": true,
+                "label": "Clone Table",
+                "value": "clone",
+              },
+            ]
+          }
+          placeholder="Copy Table (default)"
+          searchable={false}
           trimMultiCreatedValues={false}
           value=""
           valueKey="value"
         />
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={2}
-      >
-        <Input
-          disabled={false}
-          name="whereOperator"
-          onChange={[Function]}
-          type="select"
+        <HelpBlock
+          bsClass="help-block"
         >
-          <option
-            value="eq"
-          >
-            in
-          </option>
-          <option
-            value="ne"
-          >
-            not in
-          </option>
-        </Input>
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={true}
-          delimiter=","
-          disabled={false}
-          emptyStrings={true}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="whereValues"
-          onChange={[Function]}
-          placeholder="Add a value..."
-          trimMultiCreatedValues={false}
-          value=""
-          valueKey="value"
-        />
+          Type of table load from Storage into a Workspace. 
+          <code>
+            Clone
+          </code>
+           load type can be applied only on Snowflake tables without any filtering parameters.
+        </HelpBlock>
       </Col>
     </FormGroup>
-    <ControlLabel
-      bsClass="control-label"
-      srOnly={false}
-    >
-      Data types
-    </ControlLabel>
-    <DatatypeForm
-      columns={Immutable.List []}
-      datatypes={Immutable.Map {}}
-      datatypesMap={
-        Immutable.Map {
-          "VARIANT": Immutable.Map {
-            "name": "VARIANT",
-            "size": false,
-          },
-          "TIMESTAMP_LTZ": Immutable.Map {
-            "name": "TIMESTAMP_LTZ",
-            "size": false,
-          },
-          "NUMBER": Immutable.Map {
-            "name": "NUMBER",
-            "basetype": "NUMERIC",
-            "size": true,
-          },
-          "TIMESTAMP_NTZ": Immutable.Map {
-            "name": "TIMESTAMP_NTZ",
-            "size": false,
-          },
-          "DATE": Immutable.Map {
-            "name": "DATE",
-            "basetype": "DATE",
-            "size": false,
-          },
-          "TIMESTAMP_TZ": Immutable.Map {
-            "name": "TIMESTAMP_TZ",
-            "size": false,
-          },
-          "TIMESTAMP": Immutable.Map {
-            "name": "TIMESTAMP",
-            "basetype": "TIMESTAMP",
-            "size": false,
-          },
-          "FLOAT": Immutable.Map {
-            "name": "FLOAT",
-            "basetype": "FLOAT",
-            "size": false,
-          },
-          "VARCHAR": Immutable.Map {
-            "name": "VARCHAR",
-            "basetype": "STRING",
-            "size": true,
-            "maxLength": 16777216,
-          },
-          "INTEGER": Immutable.Map {
-            "name": "INTEGER",
-            "basetype": "INTEGER",
-            "size": false,
-          },
+    <div>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Columns
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={true}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="columns"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="All columns will be imported"
+            trimMultiCreatedValues={false}
+            value={Array []}
+            valueKey="value"
+          />
+          <HelpBlock
+            bsClass="help-block"
+          >
+            Import only specified columns
+          </HelpBlock>
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Changed in last
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <ChangedSinceInput
+            disabled={false}
+            onChange={[Function]}
+            value={null}
+          />
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Data filter
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={true}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={false}
+            name="whereColumn"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="Select column"
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={2}
+        >
+          <Input
+            disabled={false}
+            name="whereOperator"
+            onChange={[Function]}
+            type="select"
+          >
+            <option
+              value="eq"
+            >
+              in
+            </option>
+            <option
+              value="ne"
+            >
+              not in
+            </option>
+          </Input>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={true}
+            delimiter=","
+            disabled={false}
+            emptyStrings={true}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="whereValues"
+            onChange={[Function]}
+            placeholder="Add a value..."
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+      </FormGroup>
+      <ControlLabel
+        bsClass="control-label"
+        srOnly={false}
+      >
+        Data types
+      </ControlLabel>
+      <DatatypeForm
+        columns={Immutable.List []}
+        datatypes={Immutable.Map {}}
+        datatypesMap={
+          Immutable.Map {
+            "VARIANT": Immutable.Map {
+              "name": "VARIANT",
+              "size": false,
+            },
+            "TIMESTAMP_LTZ": Immutable.Map {
+              "name": "TIMESTAMP_LTZ",
+              "size": false,
+            },
+            "NUMBER": Immutable.Map {
+              "name": "NUMBER",
+              "basetype": "NUMERIC",
+              "size": true,
+            },
+            "TIMESTAMP_NTZ": Immutable.Map {
+              "name": "TIMESTAMP_NTZ",
+              "size": false,
+            },
+            "DATE": Immutable.Map {
+              "name": "DATE",
+              "basetype": "DATE",
+              "size": false,
+            },
+            "TIMESTAMP_TZ": Immutable.Map {
+              "name": "TIMESTAMP_TZ",
+              "size": false,
+            },
+            "TIMESTAMP": Immutable.Map {
+              "name": "TIMESTAMP",
+              "basetype": "TIMESTAMP",
+              "size": false,
+            },
+            "FLOAT": Immutable.Map {
+              "name": "FLOAT",
+              "basetype": "FLOAT",
+              "size": false,
+            },
+            "VARCHAR": Immutable.Map {
+              "name": "VARCHAR",
+              "basetype": "STRING",
+              "size": true,
+              "maxLength": 16777216,
+            },
+            "INTEGER": Immutable.Map {
+              "name": "INTEGER",
+              "basetype": "INTEGER",
+              "size": false,
+            },
+          }
         }
-      }
-      disabled={true}
-      onChange={[Function]}
-    />
+        disabled={true}
+        onChange={[Function]}
+      />
+    </div>
   </PanelWithDetails>
 </Form>
 `;
@@ -328,7 +387,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
         componentClass={[Function]}
         sm={2}
       >
-        Columns
+        Load Type
       </Col>
       <Col
         bsClass="col"
@@ -337,67 +396,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
       >
         <Select
           allowCreate={false}
-          delimiter=","
-          disabled={false}
-          emptyStrings={false}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="columns"
-          onChange={[Function]}
-          options={Array []}
-          placeholder="All columns will be imported"
-          trimMultiCreatedValues={false}
-          value={Array []}
-          valueKey="value"
-        />
-        <HelpBlock
-          bsClass="help-block"
-        >
-          Import only specified columns
-        </HelpBlock>
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Changed in last
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={10}
-      >
-        <ChangedSinceInput
-          disabled={false}
-          onChange={[Function]}
-          value={null}
-        />
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Data filter
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={false}
+          clearable={false}
           delimiter=","
           disabled={false}
           emptyStrings={false}
@@ -405,124 +404,243 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
           labelKey="label"
           matchProp="any"
           multi={false}
-          name="whereColumn"
+          name="loadType"
           onChange={[Function]}
-          options={Array []}
-          placeholder="Select column"
+          options={
+            Array [
+              Object {
+                "label": "Copy Table (default)",
+                "value": "",
+              },
+              Object {
+                "disabled": true,
+                "label": "Clone Table",
+                "value": "clone",
+              },
+            ]
+          }
+          placeholder="Copy Table (default)"
+          searchable={false}
           trimMultiCreatedValues={false}
           value=""
           valueKey="value"
         />
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={2}
-      >
-        <Input
-          disabled={false}
-          name="whereOperator"
-          onChange={[Function]}
-          type="select"
+        <HelpBlock
+          bsClass="help-block"
         >
-          <option
-            value="eq"
-          >
-            in
-          </option>
-          <option
-            value="ne"
-          >
-            not in
-          </option>
-        </Input>
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={true}
-          delimiter=","
-          disabled={false}
-          emptyStrings={true}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="whereValues"
-          onChange={[Function]}
-          placeholder="Add a value..."
-          trimMultiCreatedValues={false}
-          value=""
-          valueKey="value"
-        />
+          Type of table load from Storage into a Workspace. 
+          <code>
+            Clone
+          </code>
+           load type can be applied only on Snowflake tables without any filtering parameters.
+        </HelpBlock>
       </Col>
     </FormGroup>
-    <ControlLabel
-      bsClass="control-label"
-      srOnly={false}
-    >
-      Data types
-    </ControlLabel>
-    <DatatypeForm
-      columns={Immutable.List []}
-      datatypes={Immutable.Map {}}
-      datatypesMap={
-        Immutable.Map {
-          "VARIANT": Immutable.Map {
-            "name": "VARIANT",
-            "size": false,
-          },
-          "TIMESTAMP_LTZ": Immutable.Map {
-            "name": "TIMESTAMP_LTZ",
-            "size": false,
-          },
-          "NUMBER": Immutable.Map {
-            "name": "NUMBER",
-            "basetype": "NUMERIC",
-            "size": true,
-          },
-          "TIMESTAMP_NTZ": Immutable.Map {
-            "name": "TIMESTAMP_NTZ",
-            "size": false,
-          },
-          "DATE": Immutable.Map {
-            "name": "DATE",
-            "basetype": "DATE",
-            "size": false,
-          },
-          "TIMESTAMP_TZ": Immutable.Map {
-            "name": "TIMESTAMP_TZ",
-            "size": false,
-          },
-          "TIMESTAMP": Immutable.Map {
-            "name": "TIMESTAMP",
-            "basetype": "TIMESTAMP",
-            "size": false,
-          },
-          "FLOAT": Immutable.Map {
-            "name": "FLOAT",
-            "basetype": "FLOAT",
-            "size": false,
-          },
-          "VARCHAR": Immutable.Map {
-            "name": "VARCHAR",
-            "basetype": "STRING",
-            "size": true,
-            "maxLength": 16777216,
-          },
-          "INTEGER": Immutable.Map {
-            "name": "INTEGER",
-            "basetype": "INTEGER",
-            "size": false,
-          },
+    <div>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Columns
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="columns"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="All columns will be imported"
+            trimMultiCreatedValues={false}
+            value={Array []}
+            valueKey="value"
+          />
+          <HelpBlock
+            bsClass="help-block"
+          >
+            Import only specified columns
+          </HelpBlock>
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Changed in last
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <ChangedSinceInput
+            disabled={false}
+            onChange={[Function]}
+            value={null}
+          />
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Data filter
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={false}
+            name="whereColumn"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="Select column"
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={2}
+        >
+          <Input
+            disabled={false}
+            name="whereOperator"
+            onChange={[Function]}
+            type="select"
+          >
+            <option
+              value="eq"
+            >
+              in
+            </option>
+            <option
+              value="ne"
+            >
+              not in
+            </option>
+          </Input>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={true}
+            delimiter=","
+            disabled={false}
+            emptyStrings={true}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="whereValues"
+            onChange={[Function]}
+            placeholder="Add a value..."
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+      </FormGroup>
+      <ControlLabel
+        bsClass="control-label"
+        srOnly={false}
+      >
+        Data types
+      </ControlLabel>
+      <DatatypeForm
+        columns={Immutable.List []}
+        datatypes={Immutable.Map {}}
+        datatypesMap={
+          Immutable.Map {
+            "VARIANT": Immutable.Map {
+              "name": "VARIANT",
+              "size": false,
+            },
+            "TIMESTAMP_LTZ": Immutable.Map {
+              "name": "TIMESTAMP_LTZ",
+              "size": false,
+            },
+            "NUMBER": Immutable.Map {
+              "name": "NUMBER",
+              "basetype": "NUMERIC",
+              "size": true,
+            },
+            "TIMESTAMP_NTZ": Immutable.Map {
+              "name": "TIMESTAMP_NTZ",
+              "size": false,
+            },
+            "DATE": Immutable.Map {
+              "name": "DATE",
+              "basetype": "DATE",
+              "size": false,
+            },
+            "TIMESTAMP_TZ": Immutable.Map {
+              "name": "TIMESTAMP_TZ",
+              "size": false,
+            },
+            "TIMESTAMP": Immutable.Map {
+              "name": "TIMESTAMP",
+              "basetype": "TIMESTAMP",
+              "size": false,
+            },
+            "FLOAT": Immutable.Map {
+              "name": "FLOAT",
+              "basetype": "FLOAT",
+              "size": false,
+            },
+            "VARCHAR": Immutable.Map {
+              "name": "VARCHAR",
+              "basetype": "STRING",
+              "size": true,
+              "maxLength": 16777216,
+            },
+            "INTEGER": Immutable.Map {
+              "name": "INTEGER",
+              "basetype": "INTEGER",
+              "size": false,
+            },
+          }
         }
-      }
-      disabled={false}
-      onChange={[Function]}
-    />
+        disabled={false}
+        onChange={[Function]}
+      />
+    </div>
   </PanelWithDetails>
 </Form>
 `;
@@ -592,7 +710,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         componentClass={[Function]}
         sm={2}
       >
-        Columns
+        Load Type
       </Col>
       <Col
         bsClass="col"
@@ -601,67 +719,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
       >
         <Select
           allowCreate={false}
-          delimiter=","
-          disabled={false}
-          emptyStrings={false}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="columns"
-          onChange={[Function]}
-          options={Array []}
-          placeholder="All columns will be imported"
-          trimMultiCreatedValues={false}
-          value={Array []}
-          valueKey="value"
-        />
-        <HelpBlock
-          bsClass="help-block"
-        >
-          Import only specified columns
-        </HelpBlock>
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Changed in last
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={10}
-      >
-        <ChangedSinceInput
-          disabled={false}
-          onChange={[Function]}
-          value={null}
-        />
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Data filter
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={false}
+          clearable={false}
           delimiter=","
           disabled={false}
           emptyStrings={false}
@@ -669,125 +727,244 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
           labelKey="label"
           matchProp="any"
           multi={false}
-          name="whereColumn"
+          name="loadType"
           onChange={[Function]}
-          options={Array []}
-          placeholder="Select column"
+          options={
+            Array [
+              Object {
+                "label": "Copy Table (default)",
+                "value": "",
+              },
+              Object {
+                "disabled": true,
+                "label": "Clone Table",
+                "value": "clone",
+              },
+            ]
+          }
+          placeholder="Copy Table (default)"
+          searchable={false}
           trimMultiCreatedValues={false}
           value=""
           valueKey="value"
         />
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={2}
-      >
-        <Input
-          disabled={false}
-          name="whereOperator"
-          onChange={[Function]}
-          type="select"
-          value="eq"
+        <HelpBlock
+          bsClass="help-block"
         >
-          <option
-            value="eq"
-          >
-            in
-          </option>
-          <option
-            value="ne"
-          >
-            not in
-          </option>
-        </Input>
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={true}
-          delimiter=","
-          disabled={false}
-          emptyStrings={true}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="whereValues"
-          onChange={[Function]}
-          placeholder="Add a value..."
-          trimMultiCreatedValues={false}
-          value={Immutable.List []}
-          valueKey="value"
-        />
+          Type of table load from Storage into a Workspace. 
+          <code>
+            Clone
+          </code>
+           load type can be applied only on Snowflake tables without any filtering parameters.
+        </HelpBlock>
       </Col>
     </FormGroup>
-    <ControlLabel
-      bsClass="control-label"
-      srOnly={false}
-    >
-      Data types
-    </ControlLabel>
-    <DatatypeForm
-      columns={Immutable.List []}
-      datatypes={Immutable.Map {}}
-      datatypesMap={
-        Immutable.Map {
-          "VARIANT": Immutable.Map {
-            "name": "VARIANT",
-            "size": false,
-          },
-          "TIMESTAMP_LTZ": Immutable.Map {
-            "name": "TIMESTAMP_LTZ",
-            "size": false,
-          },
-          "NUMBER": Immutable.Map {
-            "name": "NUMBER",
-            "basetype": "NUMERIC",
-            "size": true,
-          },
-          "TIMESTAMP_NTZ": Immutable.Map {
-            "name": "TIMESTAMP_NTZ",
-            "size": false,
-          },
-          "DATE": Immutable.Map {
-            "name": "DATE",
-            "basetype": "DATE",
-            "size": false,
-          },
-          "TIMESTAMP_TZ": Immutable.Map {
-            "name": "TIMESTAMP_TZ",
-            "size": false,
-          },
-          "TIMESTAMP": Immutable.Map {
-            "name": "TIMESTAMP",
-            "basetype": "TIMESTAMP",
-            "size": false,
-          },
-          "FLOAT": Immutable.Map {
-            "name": "FLOAT",
-            "basetype": "FLOAT",
-            "size": false,
-          },
-          "VARCHAR": Immutable.Map {
-            "name": "VARCHAR",
-            "basetype": "STRING",
-            "size": true,
-            "maxLength": 16777216,
-          },
-          "INTEGER": Immutable.Map {
-            "name": "INTEGER",
-            "basetype": "INTEGER",
-            "size": false,
-          },
+    <div>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Columns
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="columns"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="All columns will be imported"
+            trimMultiCreatedValues={false}
+            value={Array []}
+            valueKey="value"
+          />
+          <HelpBlock
+            bsClass="help-block"
+          >
+            Import only specified columns
+          </HelpBlock>
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Changed in last
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <ChangedSinceInput
+            disabled={false}
+            onChange={[Function]}
+            value={null}
+          />
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Data filter
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={false}
+            name="whereColumn"
+            onChange={[Function]}
+            options={Array []}
+            placeholder="Select column"
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={2}
+        >
+          <Input
+            disabled={false}
+            name="whereOperator"
+            onChange={[Function]}
+            type="select"
+            value="eq"
+          >
+            <option
+              value="eq"
+            >
+              in
+            </option>
+            <option
+              value="ne"
+            >
+              not in
+            </option>
+          </Input>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={true}
+            delimiter=","
+            disabled={false}
+            emptyStrings={true}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="whereValues"
+            onChange={[Function]}
+            placeholder="Add a value..."
+            trimMultiCreatedValues={false}
+            value={Immutable.List []}
+            valueKey="value"
+          />
+        </Col>
+      </FormGroup>
+      <ControlLabel
+        bsClass="control-label"
+        srOnly={false}
+      >
+        Data types
+      </ControlLabel>
+      <DatatypeForm
+        columns={Immutable.List []}
+        datatypes={Immutable.Map {}}
+        datatypesMap={
+          Immutable.Map {
+            "VARIANT": Immutable.Map {
+              "name": "VARIANT",
+              "size": false,
+            },
+            "TIMESTAMP_LTZ": Immutable.Map {
+              "name": "TIMESTAMP_LTZ",
+              "size": false,
+            },
+            "NUMBER": Immutable.Map {
+              "name": "NUMBER",
+              "basetype": "NUMERIC",
+              "size": true,
+            },
+            "TIMESTAMP_NTZ": Immutable.Map {
+              "name": "TIMESTAMP_NTZ",
+              "size": false,
+            },
+            "DATE": Immutable.Map {
+              "name": "DATE",
+              "basetype": "DATE",
+              "size": false,
+            },
+            "TIMESTAMP_TZ": Immutable.Map {
+              "name": "TIMESTAMP_TZ",
+              "size": false,
+            },
+            "TIMESTAMP": Immutable.Map {
+              "name": "TIMESTAMP",
+              "basetype": "TIMESTAMP",
+              "size": false,
+            },
+            "FLOAT": Immutable.Map {
+              "name": "FLOAT",
+              "basetype": "FLOAT",
+              "size": false,
+            },
+            "VARCHAR": Immutable.Map {
+              "name": "VARCHAR",
+              "basetype": "STRING",
+              "size": true,
+              "maxLength": 16777216,
+            },
+            "INTEGER": Immutable.Map {
+              "name": "INTEGER",
+              "basetype": "INTEGER",
+              "size": false,
+            },
+          }
         }
-      }
-      disabled={false}
-      onChange={[Function]}
-    />
+        disabled={false}
+        onChange={[Function]}
+      />
+    </div>
   </PanelWithDetails>
 </Form>
 `;
@@ -857,7 +1034,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         componentClass={[Function]}
         sm={2}
       >
-        Columns
+        Load Type
       </Col>
       <Col
         bsClass="col"
@@ -866,86 +1043,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
       >
         <Select
           allowCreate={false}
-          delimiter=","
-          disabled={false}
-          emptyStrings={false}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="columns"
-          onChange={[Function]}
-          options={
-            Array [
-              Object {
-                "label": "ProductID",
-                "value": "ProductID",
-              },
-              Object {
-                "label": "ProductName",
-                "value": "ProductName",
-              },
-              Object {
-                "label": "Price",
-                "value": "Price",
-              },
-              Object {
-                "label": "ProductDescription",
-                "value": "ProductDescription",
-              },
-            ]
-          }
-          placeholder="All columns will be imported"
-          trimMultiCreatedValues={false}
-          value={Array []}
-          valueKey="value"
-        />
-        <HelpBlock
-          bsClass="help-block"
-        >
-          Import only specified columns
-        </HelpBlock>
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Changed in last
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={10}
-      >
-        <ChangedSinceInput
-          disabled={false}
-          onChange={[Function]}
-          value={null}
-        />
-      </Col>
-    </FormGroup>
-    <FormGroup
-      bsClass="form-group"
-    >
-      <Col
-        bsClass="col"
-        componentClass={[Function]}
-        sm={2}
-      >
-        Data filter
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={false}
+          clearable={false}
           delimiter=","
           disabled={false}
           emptyStrings={false}
@@ -953,178 +1051,316 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
           labelKey="label"
           matchProp="any"
           multi={false}
-          name="whereColumn"
+          name="loadType"
           onChange={[Function]}
           options={
             Array [
               Object {
-                "label": "ProductID",
-                "value": "ProductID",
+                "label": "Copy Table (default)",
+                "value": "",
               },
               Object {
-                "label": "ProductName",
-                "value": "ProductName",
-              },
-              Object {
-                "label": "Price",
-                "value": "Price",
-              },
-              Object {
-                "label": "ProductDescription",
-                "value": "ProductDescription",
+                "disabled": true,
+                "label": "Clone Table",
+                "value": "clone",
               },
             ]
           }
-          placeholder="Select column"
+          placeholder="Copy Table (default)"
+          searchable={false}
           trimMultiCreatedValues={false}
           value=""
           valueKey="value"
         />
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={2}
-      >
-        <Input
-          disabled={false}
-          name="whereOperator"
-          onChange={[Function]}
-          type="select"
-          value="eq"
+        <HelpBlock
+          bsClass="help-block"
         >
-          <option
-            value="eq"
-          >
-            in
-          </option>
-          <option
-            value="ne"
-          >
-            not in
-          </option>
-        </Input>
-      </Col>
-      <Col
-        bsClass="col"
-        componentClass="div"
-        sm={4}
-      >
-        <Select
-          allowCreate={true}
-          delimiter=","
-          disabled={false}
-          emptyStrings={true}
-          ignoreCase={true}
-          labelKey="label"
-          matchProp="any"
-          multi={true}
-          name="whereValues"
-          onChange={[Function]}
-          placeholder="Add a value..."
-          trimMultiCreatedValues={false}
-          value={Immutable.List []}
-          valueKey="value"
-        />
+          Type of table load from Storage into a Workspace. 
+          <code>
+            Clone
+          </code>
+           load type can be applied only on Snowflake tables without any filtering parameters.
+        </HelpBlock>
       </Col>
     </FormGroup>
-    <ControlLabel
-      bsClass="control-label"
-      srOnly={false}
-    >
-      Data types
-    </ControlLabel>
-    <DatatypeForm
-      columns={
-        Immutable.List [
-          "ProductID",
-          "ProductName",
-          "Price",
-          "ProductDescription",
-        ]
-      }
-      datatypes={
-        Immutable.Map {
-          "ProductID": Immutable.Map {
-            "column": "ProductID",
-            "type": "VARCHAR",
-            "length": null,
-            "convertEmptyValuesToNull": false,
-          },
-          "ProductName": Immutable.Map {
-            "column": "ProductName",
-            "type": "VARCHAR",
-            "length": null,
-            "convertEmptyValuesToNull": false,
-          },
-          "Price": Immutable.Map {
-            "column": "Price",
-            "type": "VARCHAR",
-            "length": null,
-            "convertEmptyValuesToNull": false,
-          },
-          "ProductDescription": Immutable.Map {
-            "column": "ProductDescription",
-            "type": "VARCHAR",
-            "length": null,
-            "convertEmptyValuesToNull": false,
-          },
+    <div>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Columns
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="columns"
+            onChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "label": "ProductID",
+                  "value": "ProductID",
+                },
+                Object {
+                  "label": "ProductName",
+                  "value": "ProductName",
+                },
+                Object {
+                  "label": "Price",
+                  "value": "Price",
+                },
+                Object {
+                  "label": "ProductDescription",
+                  "value": "ProductDescription",
+                },
+              ]
+            }
+            placeholder="All columns will be imported"
+            trimMultiCreatedValues={false}
+            value={Array []}
+            valueKey="value"
+          />
+          <HelpBlock
+            bsClass="help-block"
+          >
+            Import only specified columns
+          </HelpBlock>
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Changed in last
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={10}
+        >
+          <ChangedSinceInput
+            disabled={false}
+            onChange={[Function]}
+            value={null}
+          />
+        </Col>
+      </FormGroup>
+      <FormGroup
+        bsClass="form-group"
+      >
+        <Col
+          bsClass="col"
+          componentClass={[Function]}
+          sm={2}
+        >
+          Data filter
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={false}
+            delimiter=","
+            disabled={false}
+            emptyStrings={false}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={false}
+            name="whereColumn"
+            onChange={[Function]}
+            options={
+              Array [
+                Object {
+                  "label": "ProductID",
+                  "value": "ProductID",
+                },
+                Object {
+                  "label": "ProductName",
+                  "value": "ProductName",
+                },
+                Object {
+                  "label": "Price",
+                  "value": "Price",
+                },
+                Object {
+                  "label": "ProductDescription",
+                  "value": "ProductDescription",
+                },
+              ]
+            }
+            placeholder="Select column"
+            trimMultiCreatedValues={false}
+            value=""
+            valueKey="value"
+          />
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={2}
+        >
+          <Input
+            disabled={false}
+            name="whereOperator"
+            onChange={[Function]}
+            type="select"
+            value="eq"
+          >
+            <option
+              value="eq"
+            >
+              in
+            </option>
+            <option
+              value="ne"
+            >
+              not in
+            </option>
+          </Input>
+        </Col>
+        <Col
+          bsClass="col"
+          componentClass="div"
+          sm={4}
+        >
+          <Select
+            allowCreate={true}
+            delimiter=","
+            disabled={false}
+            emptyStrings={true}
+            ignoreCase={true}
+            labelKey="label"
+            matchProp="any"
+            multi={true}
+            name="whereValues"
+            onChange={[Function]}
+            placeholder="Add a value..."
+            trimMultiCreatedValues={false}
+            value={Immutable.List []}
+            valueKey="value"
+          />
+        </Col>
+      </FormGroup>
+      <ControlLabel
+        bsClass="control-label"
+        srOnly={false}
+      >
+        Data types
+      </ControlLabel>
+      <DatatypeForm
+        columns={
+          Immutable.List [
+            "ProductID",
+            "ProductName",
+            "Price",
+            "ProductDescription",
+          ]
         }
-      }
-      datatypesMap={
-        Immutable.Map {
-          "VARIANT": Immutable.Map {
-            "name": "VARIANT",
-            "size": false,
-          },
-          "TIMESTAMP_LTZ": Immutable.Map {
-            "name": "TIMESTAMP_LTZ",
-            "size": false,
-          },
-          "NUMBER": Immutable.Map {
-            "name": "NUMBER",
-            "basetype": "NUMERIC",
-            "size": true,
-          },
-          "TIMESTAMP_NTZ": Immutable.Map {
-            "name": "TIMESTAMP_NTZ",
-            "size": false,
-          },
-          "DATE": Immutable.Map {
-            "name": "DATE",
-            "basetype": "DATE",
-            "size": false,
-          },
-          "TIMESTAMP_TZ": Immutable.Map {
-            "name": "TIMESTAMP_TZ",
-            "size": false,
-          },
-          "TIMESTAMP": Immutable.Map {
-            "name": "TIMESTAMP",
-            "basetype": "TIMESTAMP",
-            "size": false,
-          },
-          "FLOAT": Immutable.Map {
-            "name": "FLOAT",
-            "basetype": "FLOAT",
-            "size": false,
-          },
-          "VARCHAR": Immutable.Map {
-            "name": "VARCHAR",
-            "basetype": "STRING",
-            "size": true,
-            "maxLength": 16777216,
-          },
-          "INTEGER": Immutable.Map {
-            "name": "INTEGER",
-            "basetype": "INTEGER",
-            "size": false,
-          },
+        datatypes={
+          Immutable.Map {
+            "ProductID": Immutable.Map {
+              "column": "ProductID",
+              "type": "VARCHAR",
+              "length": null,
+              "convertEmptyValuesToNull": false,
+            },
+            "ProductName": Immutable.Map {
+              "column": "ProductName",
+              "type": "VARCHAR",
+              "length": null,
+              "convertEmptyValuesToNull": false,
+            },
+            "Price": Immutable.Map {
+              "column": "Price",
+              "type": "VARCHAR",
+              "length": null,
+              "convertEmptyValuesToNull": false,
+            },
+            "ProductDescription": Immutable.Map {
+              "column": "ProductDescription",
+              "type": "VARCHAR",
+              "length": null,
+              "convertEmptyValuesToNull": false,
+            },
+          }
         }
-      }
-      disabled={false}
-      onChange={[Function]}
-    />
+        datatypesMap={
+          Immutable.Map {
+            "VARIANT": Immutable.Map {
+              "name": "VARIANT",
+              "size": false,
+            },
+            "TIMESTAMP_LTZ": Immutable.Map {
+              "name": "TIMESTAMP_LTZ",
+              "size": false,
+            },
+            "NUMBER": Immutable.Map {
+              "name": "NUMBER",
+              "basetype": "NUMERIC",
+              "size": true,
+            },
+            "TIMESTAMP_NTZ": Immutable.Map {
+              "name": "TIMESTAMP_NTZ",
+              "size": false,
+            },
+            "DATE": Immutable.Map {
+              "name": "DATE",
+              "basetype": "DATE",
+              "size": false,
+            },
+            "TIMESTAMP_TZ": Immutable.Map {
+              "name": "TIMESTAMP_TZ",
+              "size": false,
+            },
+            "TIMESTAMP": Immutable.Map {
+              "name": "TIMESTAMP",
+              "basetype": "TIMESTAMP",
+              "size": false,
+            },
+            "FLOAT": Immutable.Map {
+              "name": "FLOAT",
+              "basetype": "FLOAT",
+              "size": false,
+            },
+            "VARCHAR": Immutable.Map {
+              "name": "VARCHAR",
+              "basetype": "STRING",
+              "size": true,
+              "maxLength": 16777216,
+            },
+            "INTEGER": Immutable.Map {
+              "name": "INTEGER",
+              "basetype": "INTEGER",
+              "size": false,
+            },
+          }
+        }
+        disabled={false}
+        onChange={[Function]}
+      />
+    </div>
   </PanelWithDetails>
 </Form>
 `;


### PR DESCRIPTION
Fixes #2430

Proposed changes:
- uprava input mapping snowflake editoru(modal dialog) tak aby podporoval `Load Type`
- onChange load type selectu vzdy vyresetuje niektore polozky input mapping(whereValues,whereColumn, whereOperator, columns, dataTypes), niesom si ale isty ci to je potreba

![image](https://user-images.githubusercontent.com/1412120/49535859-7598e400-f8c5-11e8-8988-1a6df37aa9f1.png)


![image](https://user-images.githubusercontent.com/1412120/49535905-95300c80-f8c5-11e8-8ca3-6b93a1bb4f15.png)

![image](https://user-images.githubusercontent.com/1412120/49535932-a842dc80-f8c5-11e8-9cc1-52db39bfe92a.png)


