### PR TITLE
Add query hint for pgsql-ex about inline comments

### DIFF
--- a/src/scripts/modules/ex-db-generic/templates/helpAndHints.js
+++ b/src/scripts/modules/ex-db-generic/templates/helpAndHints.js
@@ -15,7 +15,8 @@ const queryEditorHelp = {
   'keboola.ex-db-mssql': <div>From Oct 1, 2018, DATETIME fields will be exported with milliseconds.<br/>
     If you'd like to export without milliseconds please cast your column as <code>CONVERT(DATETIME2(0), my_column)</code><br/>
     See the <ExternalLink href="https://help.keboola.com/extractors/database/sqldb/#ms-sql-server-advanced-mode">documentation</ExternalLink>
-    &nbsp;for further help.</div>
+    &nbsp;for further help.</div>,
+  'keboola.ex-db-pgsql': 'Please use only block comments "/* */". The \copy command will fail on "--" inline comments'
 };
 
 export function getQueryEditorHelpText(componentId) {

--- a/src/scripts/modules/ex-db-generic/templates/helpAndHints.js
+++ b/src/scripts/modules/ex-db-generic/templates/helpAndHints.js
@@ -16,7 +16,7 @@ const queryEditorHelp = {
     If you'd like to export without milliseconds please cast your column as <code>CONVERT(DATETIME2(0), my_column)</code><br/>
     See the <ExternalLink href="https://help.keboola.com/extractors/database/sqldb/#ms-sql-server-advanced-mode">documentation</ExternalLink>
     &nbsp;for further help.</div>,
-  'keboola.ex-db-pgsql': 'Please use only block comments "/* */". The \copy command will fail on "--" inline comments'
+  'keboola.ex-db-pgsql': <span>Please use only block comments <code>/* */</code>. The copy command will fail on <code>--</code> inline comments</span>
 };
 
 export function getQueryEditorHelpText(componentId) {


### PR DESCRIPTION
Proposed changes:

- Add query hint for pgsql extractor that inline comments break the \copy command
