### PR TITLE
remove unused classname drag

### DIFF
--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTableRow.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
   render() {
     return (
       <tr style={{ backgroundColor: this.props.color }}>
-        <td className="kb-orchestrator-task-drasg">
+        <td>
           <Tooltip tooltip="Select task to move between phases">
             <input
               type="checkbox"


### PR DESCRIPTION
dalsi mala cistka stylu. V classe bylo typo a element nebyl ostylovany. se spravne pojmenovanou classou to nevypadalo dobre.

odebrani stylu: https://github.com/keboola/indigo-ui/pull/334