### PR TITLE
Remove unsued lib react-addons-clone-with-props

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "prettycron": "~0.10.0",
     "rc-switch": "^1.3.3",
     "react": "^0.14.9",
-    "react-addons-clone-with-props": "~0.14.8",
     "react-addons-css-transition-group": "~0.14.8",
     "react-addons-pure-render-mixin": "~0.14.8",
     "react-addons-test-utils": "~0.14.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6643,10 +6643,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-addons-clone-with-props@~0.14.8:
-  version "0.14.8"
-  resolved "https://registry.yarnpkg.com/react-addons-clone-with-props/-/react-addons-clone-with-props-0.14.8.tgz#3d481b9a9d146cf2671562e3627ad7e4c0f6b2e2"
-
 react-addons-css-transition-group@~0.14.8:
   version "0.14.8"
   resolved "https://registry.yarnpkg.com/react-addons-css-transition-group/-/react-addons-css-transition-group-0.14.8.tgz#c7a2279e71095e743c43a3a4583a1e4f1a2dd61d"


### PR DESCRIPTION
Koukal jsem že se to tam hodilo při upgradu Reactu (na 0.14). V coffee se to asi používalo na pár místech ale pak se přešlo asi na React.cloneElement a teď už to nikde v ./src nenacházím.