### PR TITLE
Unused form classnames

### DIFF
--- a/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
@@ -260,7 +260,6 @@ the source file data will be loaded to - you can create a new table or use an ex
                       value={this.props.value.get('delete_where_operator')}
                       disabled={this.props.disabled}
                       onChange={this._handleChangeDeleteWhereOperator}
-                      groupClassName="no-bottom-margin"
                     >
                       <option value={whereOperatorConstants.EQ_VALUE}>{whereOperatorConstants.EQ_LABEL}</option>
                       <option value={whereOperatorConstants.NOT_EQ_VALUE}>

--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
@@ -280,18 +280,16 @@ export default React.createClass({
               />
             </Col>
             <Col sm={2}>
-              <FormGroup className="no-bottom-margin">
-                <FormControl
-                  componentClass="select"
-                  name="deleteWhereOperator"
-                  value={this.props.value.get('deleteWhereOperator')}
-                  disabled={this.props.disabled}
-                  onChange={this._handleChangeDeleteWhereOperator}
-                >
-                  <option value={whereOperatorConstants.EQ_VALUE}>{whereOperatorConstants.EQ_LABEL}</option>
-                  <option value={whereOperatorConstants.NOT_EQ_VALUE}>{whereOperatorConstants.NOT_EQ_LABEL}</option>
-                </FormControl>
-              </FormGroup>
+              <FormControl
+                componentClass="select"
+                name="deleteWhereOperator"
+                value={this.props.value.get('deleteWhereOperator')}
+                disabled={this.props.disabled}
+                onChange={this._handleChangeDeleteWhereOperator}
+              >
+                <option value={whereOperatorConstants.EQ_VALUE}>{whereOperatorConstants.EQ_LABEL}</option>
+                <option value={whereOperatorConstants.NOT_EQ_VALUE}>{whereOperatorConstants.NOT_EQ_LABEL}</option>
+              </FormControl>
             </Col>
             <Col sm={4}>
               <Select


### PR DESCRIPTION
v TableOutputMappingEditor.jsx - komponenta 'Input' ani nemala props 'groupClassName' 
v OutputMappingRowEditor.jsx - tam to nemelo zadny vliv - ani tam nemel co delat 'FormGroup'

nepouzivane styly: https://github.com/keboola/indigo-ui/pull/335