### PR TITLE
Return Map() for initial metadata if table no longer exists

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -221,6 +221,9 @@ export default React.createClass({
 
   getInitialDatatypes(sourceTable) {
     const selectedTable = this.props.tables.find(table => table.get('id') === sourceTable);
+    if (!selectedTable) {
+      return Map();
+    }
 
     if (MetadataStore.tableHasMetadataDatatypes(sourceTable)) {
       const datatypes = getMetadataDataTypes(MetadataStore.getTableColumnsMetadata(sourceTable));


### PR DESCRIPTION
Fixes #2475 

Proposed changes:

- no table, no metadata, sorryjako

Dialo sa to ked som klikol na neexist. tabulku, ktora je v IM.
