### PR TITLE
Show component's deprecation date on overview

### DIFF
--- a/src/scripts/modules/home/react/DeprecatedComponents.jsx
+++ b/src/scripts/modules/home/react/DeprecatedComponents.jsx
@@ -1,9 +1,11 @@
 import React, {PropTypes} from 'react';
+import Immutable from 'immutable';
+import moment from 'moment';
+import { AlertBlock } from '@keboola/indigo-ui';
+
 import StringUtils from '../../../utils/string';
 import ComponentDetailLink from '../../../react/common/ComponentDetailLink';
 import ComponentName from '../../../react/common/ComponentName';
-import Immutable from 'immutable';
-import {AlertBlock} from '@keboola/indigo-ui';
 
 export default React.createClass({
   propTypes: {
@@ -42,6 +44,11 @@ export default React.createClass({
                           componentId={component.get('id')}
                         >
                           <ComponentName component={component} />
+                          {component.get('expiredOn') && (
+                            <span>
+                              {' '}(Deprecated in {moment(component.get('expiredOn')).format('MMM YYYY')})
+                            </span>
+                          )}
                         </ComponentDetailLink>
                       </li>
                     );


### PR DESCRIPTION
Fixes #2058

Proposed changes:

- show "deprecated in ..." from component's `expiredOn` param in overview

![screenshot_2018-12-10_09-58-03](https://user-images.githubusercontent.com/419849/49721564-cf513380-fc62-11e8-8d01-12f556d0cdbb.png)
