### PR TITLE
ex-ga: remove misleading warning of authorized profiles

### DIFF
--- a/src/scripts/modules/ex-google-analytics-v4/react/Index/ProfilesManagerModal.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/Index/ProfilesManagerModal.jsx
@@ -66,7 +66,6 @@ export default React.createClass({
   renderProfilesSelector() {
     return (
       <ProfilesPicker
-        authorizedEmail={this.props.authorizedEmail}
         localStateProfiles={this.getLocalProfiles()}
         localStatePickerData={this.getLocalStatePickerData()}
         updateLocalStateProfiles={this.updateLocalStateProfiles}

--- a/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
+++ b/src/scripts/modules/google-utils/react/ProfilesPicker.jsx
@@ -2,12 +2,11 @@ import React, {PropTypes} from 'react';
 import {fromJS} from 'immutable';
 import ProfilesLoader from './ProfilesLoader';
 import EmptyState from '../../components/react/components/ComponentEmptyState';
-import { Panel, Alert, ListGroup, ListGroupItem } from 'react-bootstrap';
+import { Panel, ListGroup, ListGroupItem } from 'react-bootstrap';
 
 export default React.createClass({
 
   propTypes: {
-    authorizedEmail: PropTypes.string,
     localStateProfiles: PropTypes.object.isRequired,
     localStatePickerData: PropTypes.object.isRequired,
     updateLocalStateProfiles: PropTypes.func.isRequired,
@@ -33,7 +32,6 @@ export default React.createClass({
         {profiles ?
           <span>
             <h3>Select Profiles of {email} </h3>
-            {this.renderWarning(email)}
             {this.renderLoadedProfiles(profiles)}
           </span>
           :
@@ -46,21 +44,6 @@ export default React.createClass({
         }
       </div>
     );
-  },
-
-
-  renderWarning(profilesEmail) {
-    const {authorizedEmail} = this.props;
-    if (authorizedEmail && profilesEmail && profilesEmail !== authorizedEmail) {
-      return (
-        <Alert bsStyle="warning">
-          <strong>Warning:</strong>
-          Selected account {profilesEmail} does not match account authorized for data extraction <strong>{authorizedEmail}</strong>.
-        </Alert>
-      );
-    } else {
-      return null;
-    }
   },
 
   renderLoadedProfiles(profiles) {


### PR DESCRIPTION
Tyka sa upravy Google Analytics ex - cast vyber profilov. Tam sa porovnava autorizovany email ktory zoberie z auth credentials z `authorizedFor` property s emailom ktory bol autorizovany docasne pre vyber profilov. Ak sa nerovnaju tak vypise warning pretoze `authorizedFor` vacsinou obsahuje popis autorizace nez jej email(napr padak).
Uprava spociva v odstraneni warningu teda aby sa uz nikdy nezorbrazoval.
viac infa v debate: https://keboola.slack.com/archives/C11NVEAV9/p1544368685003200