### PR TITLE
Storage Explorer - Events table - truncate long messages

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -1,15 +1,16 @@
 import React, { PropTypes } from 'react';
-import PureRendererMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import ComponentsStore from '../../../components/stores/ComponentsStore';
 import { Table } from 'react-bootstrap';
 import { NewLineToBr } from '@keboola/indigo-ui';
+import { truncate } from 'underscore.string';
 import { format } from '../../../../utils/date';
 import ComponentName from '../../../../react/common/ComponentName';
 import ComponentIcon from '../../../../react/common/ComponentIcon';
 import EventDetailModal from '../modals/EventDetailModal';
 
 export default React.createClass({
-  mixins: [PureRendererMixin],
+  mixins: [ImmutableRenderMixin],
 
   propTypes: {
     events: PropTypes.object.isRequired
@@ -58,7 +59,7 @@ export default React.createClass({
           </span>
         </td>
         <td>
-          <NewLineToBr text={event.get('message')} />
+          <NewLineToBr text={truncate(event.get('message'), 60)} />
         </td>
         <td>{event.getIn(['token', 'name'])}</td>
       </tr>

--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -2,7 +2,6 @@ import React, { PropTypes } from 'react';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import ComponentsStore from '../../../components/stores/ComponentsStore';
 import { Table } from 'react-bootstrap';
-import { NewLineToBr } from '@keboola/indigo-ui';
 import { truncate } from 'underscore.string';
 import { format } from '../../../../utils/date';
 import ComponentName from '../../../../react/common/ComponentName';
@@ -58,9 +57,7 @@ export default React.createClass({
             <ComponentName component={component} showType={true} capitalize={true} />
           </span>
         </td>
-        <td>
-          <NewLineToBr text={truncate(event.get('message'), 60)} />
-        </td>
+        <td>{truncate(event.get('message'), 60)}</td>
         <td>{event.getIn(['token', 'name'])}</td>
       </tr>
     );


### PR DESCRIPTION
Related #2402 

Některé message byly několika řádkové a "rozbilo" to "hezkou" tabulku.
Plus používám ImmutableRenderMixin když props chodí immutable object.