### PR TITLE
always save new dimension with includeTime property

### DIFF
--- a/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
@@ -171,7 +171,7 @@ export default React.createClass({
   handleCreate(e) {
     e.preventDefault();
     e.stopPropagation();
-    const newDimension = {...this.state.newDimension};
+    const newDimension = {...this.state.newDimension, includeTime: !!this.state.newDimension.includeTime};
     const name = this.state.newDimension.name;
     delete newDimension.name;
     const dimensionsToSave = {...this.props.value.dimensions, [name]: newDimension};


### PR DESCRIPTION
Tyka sa noveho GoodData Writeru - ak sa vytvori dimenze bez `includeTime`(true/false) tak sa ta property neulozi do konfigu vobec a po jeho pusteni to spadne na nevalidnom konfigu 
`The child node "includeTime" at path "root.parameters.dimensions.created" must be configured.`

Tato uprava zarucuje ze sa vzdy ulozi property includeTime aj ked sa prvykrat nezasrktne(na false).
![image](https://user-images.githubusercontent.com/1412120/49736822-721da800-fc8b-11e8-8e28-eaa615edc020.png)

