### PR TITLE
Fix unknown basetype mapping

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -235,7 +235,10 @@ export default React.createClass({
 
   buildDatatypes(columns, datatypes = Map()) {
     return columns.reduce((memo, column) => {
-      return memo.set(column, datatypes.get(column, this.getDefaultDatatype(column)));
+      if (!datatypes.get(column)) {
+        return memo.set(column, this.getDefaultDatatype(column));
+      }
+      return memo.set(column, datatypes.get(column));
     }, Map());
   },
 

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.js
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.js
@@ -21,15 +21,14 @@ const getMetadataDataTypes = (columnMetadata) => {
     const matchedDataType = SnowflakeDataTypesMapping.find((mappedDatatype) => {
       return mappedDatatype.get('basetype') === baseType.get('value');
     });
+    if (!matchedDataType) {
+      return null;
+    }
 
-    const dataTypeName = matchedDataType ? matchedDataType.get('name') : null;
-    let length = null;
-
-    if (matchedDataType) {
-      length = matchedDataType.get('size') ? dataTypeLength.get('value', null) : null;
-      if (matchedDataType.has('maxLength') && length > matchedDataType.get('maxLength')) {
-        length = matchedDataType.get('maxLength');
-      }
+    const dataTypeName = matchedDataType.get('name');
+    let length = matchedDataType.get('size') ? dataTypeLength.get('value', null) : null;
+    if (matchedDataType.has('maxLength') && length > matchedDataType.get('maxLength')) {
+      length = matchedDataType.get('maxLength');
     }
     return fromJS({
       column: colname,

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.test.js
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.test.js
@@ -60,7 +60,7 @@ describe('getMetadataDataType', function() {
     }));
   });
 
-  it('should work with nonexistent KBC.datatype.basetype', function() {
+  it('should return null for nonexistent KBC.datatype.basetype', function() {
     assert.deepStrictEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
@@ -72,12 +72,7 @@ describe('getMetadataDataType', function() {
         }
       ]
     })), fromJS({
-      Price: {
-        column: 'Price',
-        type: null,
-        length: null,
-        convertEmptyValuesToNull: false
-      }
+      Price: null
     }));
   });
 


### PR DESCRIPTION
Fixes #2508 

Proposed changes:

- unknown base type will return `null`  (identical to case w/o base type)
- properly handle `null` data type