### PR TITLE
use matchByWords for transformations and orchestrations lists

### DIFF
--- a/src/scripts/modules/orchestrations/stores/OrchestrationsStore.js
+++ b/src/scripts/modules/orchestrations/stores/OrchestrationsStore.js
@@ -1,7 +1,7 @@
 import Dispatcher from '../../../Dispatcher';
 import { Map, List, fromJS } from 'immutable';
 import { ActionTypes } from '../Constants';
-import fuzzy from 'fuzzy';
+import matchByWords from '../../../utils/matchByWords';
 import StoreUtils from '../../../utils/StoreUtils';
 
 let _store = Map({
@@ -128,7 +128,7 @@ const OrchestrationStore = StoreUtils.createStore({
     const filter = this.getFilter();
     return this.getAll().filter(orchestration => {
       if (filter) {
-        return fuzzy.match(filter, orchestration.get('name'));
+        return matchByWords(orchestration.get('name').toLowerCase(), filter.toLowerCase());
       } else {
         return true;
       }

--- a/src/scripts/modules/transformations/react/pages/transformations-index/TransformationsIndex.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformations-index/TransformationsIndex.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Immutable from 'immutable';
-import fuzzy from 'fuzzy';
+import matchByWords from '../../../../../utils/matchByWords';
 
 import TransformationBucketRow from './TransformationBucketRow';
 import TransformationsList from './TransformationsList';
@@ -105,13 +105,13 @@ export default React.createClass({
   _getFilteredBuckets() {
     let filtered = this.state.buckets;
     if (this.state.filter && this.state.filter !== '') {
-      const { filter } = this.state;
+      const filter = this.state.filter.toLowerCase();
       const component = this;
       filtered = this.state.buckets.filter(
         bucket =>
-          fuzzy.match(filter, bucket.get('name', '').toString()) ||
-          fuzzy.match(filter, bucket.get('id', '').toString()) ||
-          fuzzy.match(filter, bucket.get('description', '').toString()) ||
+          matchByWords(bucket.get('name', '').toLowerCase(), filter) ||
+          matchByWords(bucket.get('id', ''), filter) ||
+          matchByWords(bucket.get('description', '').toLowerCase(), filter) ||
           component._getFilteredTransformations(bucket.get('id')).count()
       );
     }
@@ -122,15 +122,15 @@ export default React.createClass({
   _getFilteredTransformations(bucketId) {
     let filtered = this.state.transformationsInBuckets.getIn([bucketId], Immutable.Map());
     if (this.state.filter && this.state.filter !== '') {
-      const { filter } = this.state;
+      const filter = this.state.filter.toLowerCase();
       filtered = this.state.transformationsInBuckets
         .getIn([bucketId], Immutable.Map())
         .filter(
           transformation =>
-            fuzzy.match(filter, transformation.get('name', '').toString()) ||
-            fuzzy.match(filter, transformation.get('description', '').toString()) ||
-            fuzzy.match(filter, transformation.get('fullId', '').toString()) ||
-            fuzzy.match(filter, transformation.get('id', '').toString())
+            matchByWords(transformation.get('name', '').toLowerCase(), filter) ||
+            matchByWords(transformation.get('description', '').toLowerCase(), filter) ||
+            matchByWords(transformation.get('fullId', '').toString(), filter) ||
+            matchByWords(transformation.get('id', ''), filter)
         );
     }
 

--- a/src/scripts/modules/transformations/react/pages/transformations-index/TransformationsIndex.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformations-index/TransformationsIndex.jsx
@@ -106,17 +106,20 @@ export default React.createClass({
     let filtered = this.state.buckets;
     if (this.state.filter && this.state.filter !== '') {
       const filter = this.state.filter.toLowerCase();
-      const component = this;
       filtered = this.state.buckets.filter(
         bucket =>
           matchByWords(bucket.get('name', '').toLowerCase(), filter) ||
           matchByWords(bucket.get('id', ''), filter) ||
           matchByWords(bucket.get('description', '').toLowerCase(), filter) ||
-          component._getFilteredTransformations(bucket.get('id')).count()
+          this._getFilteredTransformations(bucket.get('id')).count()
       );
     }
 
     return filtered.sortBy(bucket => bucket.get('name').toLowerCase());
+  },
+
+  getTransformationDescription(bucketId, transformationId) {
+    return TransformationsStore.getTransformationDescription(bucketId, transformationId) || '';
   },
 
   _getFilteredTransformations(bucketId) {
@@ -128,7 +131,7 @@ export default React.createClass({
         .filter(
           transformation =>
             matchByWords(transformation.get('name', '').toLowerCase(), filter) ||
-            matchByWords(transformation.get('description', '').toLowerCase(), filter) ||
+            matchByWords(this.getTransformationDescription(bucketId, transformation.get('id')).toLowerCase(), filter) ||
             matchByWords(transformation.get('fullId', '').toString(), filter) ||
             matchByWords(transformation.get('id', ''), filter)
         );


### PR DESCRIPTION
Fixes #2519 
related to #2517 

Proposed changes:
- pouzitie `matchByWords` namiesto `fuzzy.match` pri filtrovani zoznamu transformaci a orchestraci.

este som u transformaci dal prec `.toString()` okrem `transformation.get('fullId')` - tam som nikdy nenasiel ziadne data tak som nato radsej nesahal.
