### PR TITLE
fix (OAuth): custom authorization

### DIFF
--- a/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
+++ b/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
@@ -218,6 +218,7 @@ export default React.createClass({
   renderInstant() {
     return (
       <InstantAuthorizationFields
+        enabled={this.state.activeTab === 'instant'}
         authorizedFor={this.state.instant.authorizedFor}
         componentId={this.props.componentId}
         onChangeFn={this.setInstantState}

--- a/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
+++ b/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
@@ -218,7 +218,7 @@ export default React.createClass({
   renderInstant() {
     return (
       <InstantAuthorizationFields
-        enabled={this.state.activeTab === 'instant'}
+        disabled={this.state.activeTab !== 'instant'}
         authorizedFor={this.state.instant.authorizedFor}
         componentId={this.props.componentId}
         onChangeFn={this.setInstantState}

--- a/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
+++ b/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
@@ -6,7 +6,8 @@ export default React.createClass({
     authorizedFor: PropTypes.string,
     componentId: PropTypes.string.isRequired,
     onChangeFn: PropTypes.func,
-    infoText: PropTypes.string
+    infoText: PropTypes.string,
+    disabled: PropTypes.bool
   },
 
   render() {
@@ -27,6 +28,7 @@ export default React.createClass({
               defaultValue={this.props.authorizedFor}
               onChange={(e) => this.props.onChangeFn('authorizedFor', e.target.value)}
               autoFocus={true}
+              disabled={this.props.disabled}
             />
             <p className="help-block">
               Describe this authorization, e.g. by the account name.

--- a/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
+++ b/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
@@ -7,7 +7,7 @@ export default React.createClass({
     componentId: PropTypes.string.isRequired,
     onChangeFn: PropTypes.func,
     infoText: PropTypes.string,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool.isRequired
   },
 
   render() {


### PR DESCRIPTION
Instant authorization field `authorizedFor` is now disabled when its tab is not active.

Fixes https://github.com/keboola/kbc-ui/issues/2524

Proposed changes:
- field `authorizedFor` is disabled, when active tab is not `instant`
