### PR TITLE
fix writers columnseditor

### DIFF
--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -71,7 +71,8 @@ export default React.createClass({
     return (
       <Element
         showAdvanced={this.state.showAdvanced}
-        onChangeShowAdvanced={(newValue) => this.setState({showAdvanced: newValue})} />
+        onChangeShowAdvanced={(newValue) => this.setState({showAdvanced: newValue})}
+      />
     );
   },
 
@@ -79,7 +80,7 @@ export default React.createClass({
     let headers = this.props.value.columnsMappings.map(mapping => mapping.title);
     return (
       <div>
-        { !this.props.value.tableExist &&
+        {!this.props.value.tableExist && (
           <div className="alert alert-warning">
             <h3>Table Missing</h3>
             <div className="help-block">
@@ -88,12 +89,11 @@ export default React.createClass({
               </span>
             </div>
           </div>
-        }
-        { this.props.value.columns.length > 0 &&
+        )}
+        {this.props.value.columns.length > 0 && (
           <div>
             <h3>Columns</h3>
             <div className="storage-table-columns-editor-wrapper">
-
               <Table striped className="storage-table-columns-editor">
                 <thead>
                   <tr>
@@ -106,7 +106,7 @@ export default React.createClass({
               </Table>
             </div>
           </div>
-        }
+        )}
       </div>
     );
   },

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import {Alert, Table} from 'react-bootstrap';
+import {Table} from 'react-bootstrap';
 import storageApi from '../../../components/StorageApi';
 import {fromJS} from 'immutable';
 import ColumnDataPreview from './ColumnDataPreview';
@@ -80,10 +80,14 @@ export default React.createClass({
     return (
       <div>
         { !this.props.value.tableExist &&
-          <Alert bsStyle="warning">
-            <strong>Table Missing</strong>
-            <div> Table <code>{this.props.value.tableId}</code> used in this configuration is missing in Storage. Running this configuration will fail. </div>
-          </Alert>
+          <div className="alert alert-warning">
+            <h3>Table Missing</h3>
+            <div className="help-block">
+              <span>
+                Table <code>{this.props.value.tableId}</code> used in this configuration is missing in Storage. Running this configuration will fail.
+              </span>
+            </div>
+          </div>
         }
         { this.props.value.columns.length > 0 &&
           <div>

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -9,6 +9,7 @@ require('./StorageTableColumnsEditor.less');
 export default React.createClass({
   propTypes: {
     value: PropTypes.shape({
+      tableExist: PropTypes.bool,
       matchColumnKey: PropTypes.string,
       tableId: PropTypes.string,
       columns: PropTypes.any,
@@ -79,16 +80,22 @@ export default React.createClass({
       <div>
         <h3>Columns</h3>
         <div className="storage-table-columns-editor-wrapper">
-          <Table striped className="storage-table-columns-editor">
-            <thead>
-              <tr>
-                <th className="col-md-2">Column Name</th>
-                {headers.map((title, index) => <th key={index}>{typeof title === 'string' ? title : this.renderHeaderCell(title)}</th>)}
-                <th className="col-md-1">Preview</th>
-              </tr>
-            </thead>
-            {this.renderBody()}
-          </Table>
+          {this.props.value.tableExist ?
+            <Table striped className="storage-table-columns-editor">
+              <thead>
+                <tr>
+                  <th className="col-md-2">Column Name</th>
+                  {headers.map((title, index) => <th key={index}>{typeof title === 'string' ? title : this.renderHeaderCell(title)}</th>)}
+                  <th className="col-md-1">Preview</th>
+                </tr>
+              </thead>
+              {this.renderBody()}
+            </Table>
+            :
+            <div className="component-empty-state text-center">
+              <p> Table <code>{this.props.value.tableId}</code> does not exist </p>
+            </div>
+          }
         </div>
       </div>
     );

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -78,25 +78,29 @@ export default React.createClass({
     let headers = this.props.value.columnsMappings.map(mapping => mapping.title);
     return (
       <div>
-        <h3>Columns</h3>
-        <div className="storage-table-columns-editor-wrapper">
-          {this.props.value.tableExist ?
-            <Table striped className="storage-table-columns-editor">
-              <thead>
-                <tr>
-                  <th className="col-md-2">Column Name</th>
-                  {headers.map((title, index) => <th key={index}>{typeof title === 'string' ? title : this.renderHeaderCell(title)}</th>)}
-                  <th className="col-md-1">Preview</th>
-                </tr>
-              </thead>
-              {this.renderBody()}
-            </Table>
-            :
-            <div className="component-empty-state text-center">
-              <p> Table <code>{this.props.value.tableId}</code> does not exist </p>
+        { !this.props.value.tableExist &&
+          <div className="component-empty-state text-center">
+            <p> Table <code>{this.props.value.tableId}</code> does not exist </p>
+          </div>
+        }
+        { this.props.value.columns.length > 0 &&
+          <div>
+            <h3>Columns</h3>
+            <div className="storage-table-columns-editor-wrapper">
+
+              <Table striped className="storage-table-columns-editor">
+                <thead>
+                  <tr>
+                    <th className="col-md-2">Column Name</th>
+                    {headers.map((title, index) => <th key={index}>{typeof title === 'string' ? title : this.renderHeaderCell(title)}</th>)}
+                    <th className="col-md-1">Preview</th>
+                  </tr>
+                </thead>
+                {this.renderBody()}
+              </Table>
             </div>
-          }
-        </div>
+          </div>
+        }
       </div>
     );
   },

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -1,10 +1,11 @@
 import React, {PropTypes} from 'react';
-import {Table} from 'react-bootstrap';
+import {Alert, Table} from 'react-bootstrap';
 import storageApi from '../../../components/StorageApi';
 import {fromJS} from 'immutable';
 import ColumnDataPreview from './ColumnDataPreview';
 import classnames from 'classnames';
 require('./StorageTableColumnsEditor.less');
+
 
 export default React.createClass({
   propTypes: {
@@ -79,9 +80,10 @@ export default React.createClass({
     return (
       <div>
         { !this.props.value.tableExist &&
-          <div className="component-empty-state text-center">
-            <p> Table <code>{this.props.value.tableId}</code> does not exist </p>
-          </div>
+          <Alert bsStyle="warning">
+            <strong>Table Missing</strong>
+            <div> Table <code>{this.props.value.tableId}</code> used in this configuration is missing in Storage. Running this configuration will fail. </div>
+          </Alert>
         }
         { this.props.value.columns.length > 0 &&
           <div>

--- a/src/scripts/modules/configurations/react/pages/Row.jsx
+++ b/src/scripts/modules/configurations/react/pages/Row.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
     if (parseTableIdFn) {
       const tableId = parseTableIdFn(rowConfiguration);
       const table = TablesStore.getAll().get(tableId);
-      context = context.set('table', table);
+      context = context.set('table', table || Immutable.Map({id: tableId}));
     }
     const parseBySectionsFn = sections.makeParseFn(
       settings.getIn(['row', 'sections']),

--- a/src/scripts/modules/configurations/react/pages/Row.jsx
+++ b/src/scripts/modules/configurations/react/pages/Row.jsx
@@ -50,7 +50,7 @@ export default React.createClass({
     if (parseTableIdFn) {
       const tableId = parseTableIdFn(rowConfiguration);
       const table = TablesStore.getAll().get(tableId);
-      context = context.set('table', table || Immutable.Map({id: tableId}));
+      context = context.set('table', table).set('tableId', tableId);
     }
     const parseBySectionsFn = sections.makeParseFn(
       settings.getIn(['row', 'sections']),

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -2,22 +2,152 @@
 
 exports[`columns editor section test nonexisting table render 1`] = `
 <div>
-  <h3>
-    Columns
-  </h3>
   <div
-    class="storage-table-columns-editor-wrapper"
+    class="component-empty-state text-center"
   >
+    <p>
+       Table 
+      <code>
+        in.some.table
+      </code>
+       does not exist 
+    </p>
+  </div>
+  <div>
+    <h3>
+      Columns
+    </h3>
     <div
-      class="component-empty-state text-center"
+      class="storage-table-columns-editor-wrapper"
     >
-      <p>
-         Table 
-        <code>
-          in.some.table
-        </code>
-         does not exist 
-      </p>
+      <table
+        class="storage-table-columns-editor table table-striped"
+      >
+        <thead>
+          <tr>
+            <th
+              class="col-md-2"
+            >
+              Column Name
+            </th>
+            <th>
+              Column Setup
+            </th>
+            <th
+              class="col-md-1"
+            >
+              Preview
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class=""
+          >
+            <td
+              class="column-name"
+            >
+              age
+            </td>
+            <td>
+              <span>
+                <div>
+                  age
+                </div>
+                <div>
+                  number
+                </div>
+                <div />
+                <div>
+                  3
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr
+            class=""
+          >
+            <td
+              class="column-name"
+            >
+              person
+            </td>
+            <td>
+              <span>
+                <div>
+                  person
+                </div>
+                <div>
+                  varchar
+                </div>
+                <div />
+                <div>
+                  3
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr
+            class=""
+          >
+            <td
+              class="column-name"
+            >
+              deletedColumn
+            </td>
+            <td>
+              <span>
+                <div>
+                  deletedColumn
+                </div>
+                <div>
+                  varchar
+                </div>
+                <div />
+                <div>
+                  3
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </div>
@@ -25,183 +155,185 @@ exports[`columns editor section test nonexisting table render 1`] = `
 
 exports[`columns editor section test render 1`] = `
 <div>
-  <h3>
-    Columns
-  </h3>
-  <div
-    class="storage-table-columns-editor-wrapper"
-  >
-    <table
-      class="storage-table-columns-editor table table-striped"
+  <div>
+    <h3>
+      Columns
+    </h3>
+    <div
+      class="storage-table-columns-editor-wrapper"
     >
-      <thead>
-        <tr>
-          <th
-            class="col-md-2"
-          >
-            Column Name
-          </th>
-          <th>
-            Column Setup
-          </th>
-          <th
-            class="col-md-1"
-          >
-            Preview
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
-          >
-            age
-          </td>
-          <td>
-            <span>
-              <div>
-                age
-              </div>
-              <div>
-                number
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                4
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
+      <table
+        class="storage-table-columns-editor table table-striped"
+      >
+        <thead>
+          <tr>
+            <th
+              class="col-md-2"
             >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
-          >
-            person
-          </td>
-          <td>
-            <span>
-              <div>
-                person
-              </div>
-              <div>
-                varchar
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                4
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
+              Column Name
+            </th>
+            <th>
+              Column Setup
+            </th>
+            <th
+              class="col-md-1"
             >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-        <tr
-          class="danger"
-        >
-          <td
-            class="column-name"
+              Preview
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            class=""
           >
-            otherColumn
-          </td>
-          <td>
-            <span>
-              <div>
-                otherColumn
-              </div>
-              <div>
-                ignore
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                4
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
+            <td
+              class="column-name"
             >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
+              age
+            </td>
+            <td>
+              <span>
+                <div>
+                  age
+                </div>
+                <div>
+                  number
+                </div>
+                <div>
+                  in.some.table
+                </div>
+                <div>
+                  4
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr
+            class=""
           >
-            deletedColumn
-          </td>
-          <td>
-            <span>
-              <div>
-                deletedColumn
-              </div>
-              <div>
-                varchar
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                4
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
+            <td
+              class="column-name"
             >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              person
+            </td>
+            <td>
+              <span>
+                <div>
+                  person
+                </div>
+                <div>
+                  varchar
+                </div>
+                <div>
+                  in.some.table
+                </div>
+                <div>
+                  4
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr
+            class="danger"
+          >
+            <td
+              class="column-name"
+            >
+              otherColumn
+            </td>
+            <td>
+              <span>
+                <div>
+                  otherColumn
+                </div>
+                <div>
+                  ignore
+                </div>
+                <div>
+                  in.some.table
+                </div>
+                <div>
+                  4
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+          <tr
+            class=""
+          >
+            <td
+              class="column-name"
+            >
+              deletedColumn
+            </td>
+            <td>
+              <span>
+                <div>
+                  deletedColumn
+                </div>
+                <div>
+                  varchar
+                </div>
+                <div>
+                  in.some.table
+                </div>
+                <div>
+                  4
+                </div>
+                <span>
+                   ignore column
+                </span>
+              </span>
+            </td>
+            <td>
+              <button
+                class="btn btn-link"
+              >
+                <span
+                  class="fa fa-eye"
+                />
+              </button>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
 `;

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -8,140 +8,17 @@ exports[`columns editor section test nonexisting table render 1`] = `
   <div
     class="storage-table-columns-editor-wrapper"
   >
-    <table
-      class="storage-table-columns-editor table table-striped"
+    <div
+      class="component-empty-state text-center"
     >
-      <thead>
-        <tr>
-          <th
-            class="col-md-2"
-          >
-            Column Name
-          </th>
-          <th>
-            Column Setup
-          </th>
-          <th
-            class="col-md-1"
-          >
-            Preview
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
-          >
-            age
-          </td>
-          <td>
-            <span>
-              <div>
-                age
-              </div>
-              <div>
-                number
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                3
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
-            >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
-          >
-            person
-          </td>
-          <td>
-            <span>
-              <div>
-                person
-              </div>
-              <div>
-                varchar
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                3
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
-            >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-        <tr
-          class=""
-        >
-          <td
-            class="column-name"
-          >
-            deletedColumn
-          </td>
-          <td>
-            <span>
-              <div>
-                deletedColumn
-              </div>
-              <div>
-                varchar
-              </div>
-              <div>
-                in.some.table
-              </div>
-              <div>
-                3
-              </div>
-              <span>
-                 ignore column
-              </span>
-            </span>
-          </td>
-          <td>
-            <button
-              class="btn btn-link"
-            >
-              <span
-                class="fa fa-eye"
-              />
-            </button>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+      <p>
+         Table 
+        <code>
+          in.some.table
+        </code>
+         does not exist 
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -4,17 +4,20 @@ exports[`columns editor section test nonexisting table render 1`] = `
 <div>
   <div
     class="alert alert-warning"
-    role="alert"
   >
-    <strong>
+    <h3>
       Table Missing
-    </strong>
-    <div>
-       Table 
-      <code>
-        in.some.table
-      </code>
-       used in this configuration is missing in Storage. Running this configuration will fail. 
+    </h3>
+    <div
+      class="help-block"
+    >
+      <span>
+        Table 
+        <code>
+          in.some.table
+        </code>
+         used in this configuration is missing in Storage. Running this configuration will fail.
+      </span>
     </div>
   </div>
   <div>

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -1,5 +1,151 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`columns editor section test nonexisting table render 1`] = `
+<div>
+  <h3>
+    Columns
+  </h3>
+  <div
+    class="storage-table-columns-editor-wrapper"
+  >
+    <table
+      class="storage-table-columns-editor table table-striped"
+    >
+      <thead>
+        <tr>
+          <th
+            class="col-md-2"
+          >
+            Column Name
+          </th>
+          <th>
+            Column Setup
+          </th>
+          <th
+            class="col-md-1"
+          >
+            Preview
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          class=""
+        >
+          <td
+            class="column-name"
+          >
+            age
+          </td>
+          <td>
+            <span>
+              <div>
+                age
+              </div>
+              <div>
+                number
+              </div>
+              <div>
+                in.some.table
+              </div>
+              <div>
+                3
+              </div>
+              <span>
+                 ignore column
+              </span>
+            </span>
+          </td>
+          <td>
+            <button
+              class="btn btn-link"
+            >
+              <span
+                class="fa fa-eye"
+              />
+            </button>
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class="column-name"
+          >
+            person
+          </td>
+          <td>
+            <span>
+              <div>
+                person
+              </div>
+              <div>
+                varchar
+              </div>
+              <div>
+                in.some.table
+              </div>
+              <div>
+                3
+              </div>
+              <span>
+                 ignore column
+              </span>
+            </span>
+          </td>
+          <td>
+            <button
+              class="btn btn-link"
+            >
+              <span
+                class="fa fa-eye"
+              />
+            </button>
+          </td>
+        </tr>
+        <tr
+          class=""
+        >
+          <td
+            class="column-name"
+          >
+            deletedColumn
+          </td>
+          <td>
+            <span>
+              <div>
+                deletedColumn
+              </div>
+              <div>
+                varchar
+              </div>
+              <div>
+                in.some.table
+              </div>
+              <div>
+                3
+              </div>
+              <span>
+                 ignore column
+              </span>
+            </span>
+          </td>
+          <td>
+            <button
+              class="btn btn-link"
+            >
+              <span
+                class="fa fa-eye"
+              />
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
 exports[`columns editor section test render 1`] = `
 <div>
   <h3>

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -3,15 +3,19 @@
 exports[`columns editor section test nonexisting table render 1`] = `
 <div>
   <div
-    class="component-empty-state text-center"
+    class="alert alert-warning"
+    role="alert"
   >
-    <p>
+    <strong>
+      Table Missing
+    </strong>
+    <div>
        Table 
       <code>
         in.some.table
       </code>
-       does not exist 
-    </p>
+       used in this configuration is missing in Storage. Running this configuration will fail. 
+    </div>
   </div>
   <div>
     <h3>

--- a/src/scripts/modules/configurations/utils/createColumnsEditorSection.js
+++ b/src/scripts/modules/configurations/utils/createColumnsEditorSection.js
@@ -40,8 +40,9 @@ export default (params) => {
     onLoad(configuration, sectionContext) {
       const configColumns = onLoadColumns(configuration);
       const storageTable = sectionContext.get('table');
-      const tableId = storageTable.get('id');
-      const storageTableColumns = storageTable.get('columns') || List();
+      const tableExist = !!storageTable;
+      const tableId = sectionContext.get('tableId');
+      const storageTableColumns = tableExist ? storageTable.get('columns') : List();
       const deletedColumns = configColumns
         .map(configColumn => configColumn.get(matchColumnKey))
         .filter(configColumnName =>
@@ -57,6 +58,7 @@ export default (params) => {
       const columnContext = prepareColumnContext(sectionContext, columnsList);
 
       return fromJS({
+        tableExist,
         columns: columnsList,
         tableId: tableId,
         columnsMappings,

--- a/src/scripts/modules/configurations/utils/createColumnsEditorSection.js
+++ b/src/scripts/modules/configurations/utils/createColumnsEditorSection.js
@@ -1,4 +1,4 @@
-import {fromJS} from 'immutable';
+import {fromJS, List} from 'immutable';
 import StorageTableColumnsEditor from '../react/components/StorageTableColumnsEditor';
 
 export default (params) => {
@@ -41,7 +41,7 @@ export default (params) => {
       const configColumns = onLoadColumns(configuration);
       const storageTable = sectionContext.get('table');
       const tableId = storageTable.get('id');
-      const storageTableColumns = storageTable.get('columns');
+      const storageTableColumns = storageTable.get('columns') || List();
       const deletedColumns = configColumns
         .map(configColumn => configColumn.get(matchColumnKey))
         .filter(configColumnName =>

--- a/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
+++ b/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
@@ -52,6 +52,7 @@ const configuration = fromJS({
 });
 
 const sectionContext = fromJS({
+  tableId: 'in.some.table',
   table: {
     id: 'in.some.table',
     columns: ['age', 'person', 'otherColumn']
@@ -108,6 +109,7 @@ describe('columns editor section', () => {
             type: 'varchar'
           }
         ],
+        tableExist: true,
         tableId: 'in.some.table',
         columnsMappings: editorSectionDefinition.columnsMappings,
         context: {
@@ -161,9 +163,8 @@ describe('columns editor section', () => {
   it('test nonexisting table render', () => {
     const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
     const nonExistingTableContext =  fromJS({
-      table: {
-        id: 'in.some.table'
-      }
+      table: null,
+      tableId: 'in.some.table'
     });
     const localState = editorSection.onLoad(configuration, nonExistingTableContext).toJS();
     const EditorComponent = editorSection.render;

--- a/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
+++ b/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
@@ -158,6 +158,22 @@ describe('columns editor section', () => {
       }
     );
   });
+  it('test nonexisting table render', () => {
+    const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
+    const nonExistingTableContext =  fromJS({
+      table: {
+        id: 'in.some.table'
+      }
+    });
+    const localState = editorSection.onLoad(configuration, nonExistingTableContext).toJS();
+    const EditorComponent = editorSection.render;
+    renderSnapshot(
+      <EditorComponent
+        value={localState}
+        onChange={() => null}
+        disabled={false}/>
+    );
+  });
   it('test render', () => {
     const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
     const localState = editorSection.onLoad(configuration, sectionContext).toJS();

--- a/src/scripts/modules/gooddata-writer-v3/adapters/columnsEditorAdapter.js
+++ b/src/scripts/modules/gooddata-writer-v3/adapters/columnsEditorAdapter.js
@@ -1,5 +1,5 @@
 import makeColumnDefinition from '../helpers/makeColumnDefinition';
-import { Map, fromJS } from 'immutable';
+import { Map, fromJS, List } from 'immutable';
 import getInitialShowAdvanced from '../helpers/getInitialShowAdvanced';
 import PreferencesHeader from '../react/components/PreferencesHeader';
 import PreferencesColumn from '../react/components/PreferencesColumn';
@@ -41,7 +41,7 @@ export default function(configProvisioning, tablesProvisioning, storageTable) {
   const { getEditingTable, setEditingTable, tables } = tablesProvisioning;
   const editing = getEditingTable(tableId);
 
-  const storageTableColumns = storageTable.get('columns');
+  const storageTableColumns = storageTable.get('columns', List());
   const configuredColumns = editing.tableParameters.get('columns', Map());
   const allColumnsList = prepareAllTableColumns(configuredColumns, storageTableColumns);
 

--- a/src/scripts/modules/gooddata-writer-v3/adapters/columnsEditorAdapter.js
+++ b/src/scripts/modules/gooddata-writer-v3/adapters/columnsEditorAdapter.js
@@ -35,13 +35,12 @@ function prepareAllTableColumns(configuredColumns, storageTableColumns) {
   return allColumnsList;
 }
 
-export default function(configProvisioning, tablesProvisioning, storageTable) {
-  const tableId = storageTable.get('id');
+export default function(configProvisioning, tablesProvisioning, storageTable, tableId) {
   const { isSaving, parameters } = configProvisioning;
   const { getEditingTable, setEditingTable, tables } = tablesProvisioning;
   const editing = getEditingTable(tableId);
-
-  const storageTableColumns = storageTable.get('columns', List());
+  const tableExist = !!storageTable;
+  const storageTableColumns = tableExist ? storageTable.get('columns', List()) : List();
   const configuredColumns = editing.tableParameters.get('columns', Map());
   const allColumnsList = prepareAllTableColumns(configuredColumns, storageTableColumns);
 
@@ -60,6 +59,7 @@ export default function(configProvisioning, tablesProvisioning, storageTable) {
   const context = prepareColumnContext(parameters, tables, tableId, allColumnsList);
 
   const value = Map({
+    tableExist,
     columns: allColumnsList,
     tableId,
     columnsMappings: [

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import {Map} from 'immutable';
 
 // stores
 import RoutesStore from '../../../../../stores/RoutesStore';
@@ -43,13 +42,13 @@ export default React.createClass({
     const table = tables.get(tableId);
     const configProvisioning = makeConfigProvisioning(configurationId);
     const {isSaving, isPendingFn} = configProvisioning;
-    const storageTable = TablesStore.getAll().get(tableId) || Map({id: tableId});
+    const storageTable = TablesStore.getAll().get(tableId);
     const isPendingToggleExport = isPendingFn([tableId, 'activate']);
     const loadOnly = tableLoadSettingsAdapter(configProvisioning).value.loadOnly;
 
     // section props adapters
     const titleSectionProps = titleAdapter(configProvisioning, tablesProvisioning, tableId);
-    const columnsEditorSectionProps = columnsEditorAdapter(configProvisioning, tablesProvisioning, storageTable);
+    const columnsEditorSectionProps = columnsEditorAdapter(configProvisioning, tablesProvisioning, storageTable, tableId);
 
     const loadTypeSectionProps = loadTypeAdater(configProvisioning, tablesProvisioning, tableId);
 

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import {Map} from 'immutable';
 
 // stores
 import RoutesStore from '../../../../../stores/RoutesStore';
@@ -42,7 +43,7 @@ export default React.createClass({
     const table = tables.get(tableId);
     const configProvisioning = makeConfigProvisioning(configurationId);
     const {isSaving, isPendingFn} = configProvisioning;
-    const storageTable = TablesStore.getAll().get(tableId);
+    const storageTable = TablesStore.getAll().get(tableId) || Map({id: tableId});
     const isPendingToggleExport = isPendingFn([tableId, 'activate']);
     const loadOnly = tableLoadSettingsAdapter(configProvisioning).value.loadOnly;
 
@@ -57,7 +58,6 @@ export default React.createClass({
       columnsEditorSectionProps,
       loadTypeSectionProps,
       isPendingToggleExport,
-      storageTable,
       deleteTable,
       toggleTableExport,
       isSaving: isSaving && !isPendingToggleExport,


### PR DESCRIPTION
Fixes #2543 
Uprava sa obecne tyka config rows writerov ktore pouzivaju `columnsEditorSection` a rovnako aj GoodData writer v3 kde je to tiez.
Ak bola tabulka nakonfigurovana ale nasledne zmazana tak to pri vstupe na stranku detailu row-u padalo. Upravil som to tak ze sa v pripade neexistujucej tabulky sekce nainicializuje s `{id: <tableId>}` objektom. Zaroven to nenarusuje zbytok stranky detailu tabulky(napr nevyhodnoti isParsable == false). To ze tabulka neexistuje sa da zistit z linku na table preview ktory je na tej strajke. Neviem ci to je ono, ale viac sa mi v tom vrtat nechce.


