### PR TITLE
fix parse transformation old data types format

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -244,8 +244,9 @@ export default React.createClass({
 
   getDatatypes() {
     return this.getDefaultDatatypes().map((defaultType) => {
-      const existingTypeFilter = this.props.value.get('datatypes', Map()).filter((existingType) => {
-        return existingType.get('column') === defaultType.get('column');
+      const existingTypeFilter = this.props.value.get('datatypes', Map()).filter((existingType, columnName) => {
+        const column = Map.isMap(existingType) ? existingType.get('column') : columnName;
+        return column === defaultType.get('column');
       });
       if (existingTypeFilter.count() > 0) {
         return existingTypeFilter.get(defaultType.get('column'));

--- a/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
@@ -30,19 +30,16 @@ export default React.createClass({
   },
 
   renderColumn(column) {
-    let columnDataType = this.props.datatypes.find((type, columnName) => {
+    const columnDataType = this.props.datatypes.find((type, columnName) => {
       const computedName = typeof type === 'string' ? columnName : type.get('column');
       return computedName === column;
     });
-    const isOldFormat = typeof columnDataType === 'string';
-    if (isOldFormat) {
-      columnDataType = parseDataType(columnDataType, column);
-    }
+    const parsedColumnDataType = parseDataType(columnDataType, column);
     return (
       <DatatypeFormRow
         key={column}
         columnName={column}
-        datatype={columnDataType}
+        datatype={parsedColumnDataType}
         datatypesMap={this.props.datatypesMap}
         onChange={this.handleDatatypeChange}
         disabled={this.props.disabled}

--- a/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Table, HelpBlock, Checkbox} from 'react-bootstrap';
 import DatatypeFormRow from './DatatypeFormRow';
+import parseDataType from '../../../../utils/parseDataType';
 
 export default React.createClass({
   propTypes: {
@@ -29,13 +30,19 @@ export default React.createClass({
   },
 
   renderColumn(column) {
-    const columnObject = this.props.datatypes.filter((type) => {
-      return type.get('column') === column;
+    let columnDataType = this.props.datatypes.find((type, columnName) => {
+      const computedName = typeof type === 'string' ? columnName : type.get('column');
+      return computedName === column;
     });
+    const isOldFormat = typeof columnDataType === 'string';
+    if (isOldFormat) {
+      columnDataType = parseDataType(columnDataType, column);
+    }
     return (
       <DatatypeFormRow
         key={column}
-        datatype={columnObject.get(column)}
+        columnName={column}
+        datatype={columnDataType}
         datatypesMap={this.props.datatypesMap}
         onChange={this.handleDatatypeChange}
         disabled={this.props.disabled}
@@ -76,9 +83,7 @@ export default React.createClass({
           </tr>
         </thead>
         <tbody>
-          {this.props.columns.map((column) => {
-            return this.renderColumn(column);
-          })}
+          {this.props.columns.map(this.renderColumn)}
         </tbody>
       </Table>
     );

--- a/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/input/DatatypeForm.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Table, HelpBlock, Checkbox} from 'react-bootstrap';
 import DatatypeFormRow from './DatatypeFormRow';
-import parseDataType from '../../../../utils/parseDataType';
+import {parseDataTypeFromString, isDataTypeAsString} from '../../../../utils/parseDataType';
 
 export default React.createClass({
   propTypes: {
@@ -30,16 +30,18 @@ export default React.createClass({
   },
 
   renderColumn(column) {
-    const columnDataType = this.props.datatypes.find((type, columnName) => {
+    let columnDataType = this.props.datatypes.find((type, columnName) => {
       const computedName = typeof type === 'string' ? columnName : type.get('column');
       return computedName === column;
     });
-    const parsedColumnDataType = parseDataType(columnDataType, column);
+    if (isDataTypeAsString(columnDataType)) {
+      columnDataType = parseDataTypeFromString(columnDataType, column);
+    }
     return (
       <DatatypeFormRow
         key={column}
         columnName={column}
-        datatype={parsedColumnDataType}
+        datatype={columnDataType}
         datatypesMap={this.props.datatypesMap}
         onChange={this.handleDatatypeChange}
         disabled={this.props.disabled}

--- a/src/scripts/modules/transformations/react/components/mapping/input/DatatypeFormRow.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/input/DatatypeFormRow.jsx
@@ -5,6 +5,7 @@ import Select from 'react-select';
 export default React.createClass({
 
   propTypes: {
+    columnName: React.PropTypes.string.isRequired,
     datatype: React.PropTypes.object.isRequired,
     datatypesMap: React.PropTypes.object.isRequired,
     disabled: React.PropTypes.bool.isRequired,
@@ -88,11 +89,11 @@ export default React.createClass({
     return (
       <tr onMouseEnter={this.setHoveredTrue} onMouseLeave={this.setHoveredFalse} >
         <td>
-          <strong>{this.props.datatype.get('column')}</strong>
+          <strong>{this.props.columnName}</strong>
         </td>
         <td>
           <Select
-            name={this.props.datatype.get('column') + '_datatype'}
+            name={this.props.columnName + '_datatype'}
             value={this.props.datatype.get('type')}
             options={this.getTypeOptions()}
             onChange={this.handleTypeChange}
@@ -104,7 +105,7 @@ export default React.createClass({
         <td>
           {this.lengthEnabled() && (
             <FormControl
-              name={this.props.datatype.get('column') + '_length'}
+              name={this.props.columnName + '_length'}
               type="text"
               size={15}
               value={this.props.datatype.get('length')}
@@ -116,7 +117,7 @@ export default React.createClass({
         </td>
         <td>
           <Checkbox
-            name={this.props.datatype.get('column') + '_nullable'}
+            name={this.props.columnName + '_nullable'}
             checked={this.props.datatype.get('convertEmptyValuesToNull')}
             onChange={this.handleNullableChange}
           >

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -24,6 +24,7 @@ import TransformationEmptyInputImage from '../../components/TransformationEmptyI
 import TransformationEmptyOutputImage from '../../components/TransformationEmptyOutputImage';
 import ConfigurationRowEditField from '../../../../components/react/components/ConfigurationRowEditField';
 import contactSupport from '../../../../../utils/contactSupport';
+import parseDataType from '../../../utils/parseDataType';
 
 import {
   getInputMappingValue,
@@ -99,7 +100,11 @@ export default React.createClass({
     if (this._isOpenRefineTransformation()) {
       return getInputMappingValue(this.openRefine.inputMappingDefinitions, value);
     }
-    return value;
+    return value.map(inputMapping =>
+      inputMapping.update('datatypes', dataTypes =>
+        dataTypes.map(parseDataType)
+      )
+    );
   },
 
   _getOutputMappingValue() {

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -24,7 +24,6 @@ import TransformationEmptyInputImage from '../../components/TransformationEmptyI
 import TransformationEmptyOutputImage from '../../components/TransformationEmptyOutputImage';
 import ConfigurationRowEditField from '../../../../components/react/components/ConfigurationRowEditField';
 import contactSupport from '../../../../../utils/contactSupport';
-import parseDataType from '../../../utils/parseDataType';
 
 import {
   getInputMappingValue,
@@ -100,11 +99,7 @@ export default React.createClass({
     if (this._isOpenRefineTransformation()) {
       return getInputMappingValue(this.openRefine.inputMappingDefinitions, value);
     }
-    return value.map(inputMapping =>
-      inputMapping.update('datatypes', dataTypes =>
-        dataTypes.map(parseDataType)
-      )
-    );
+    return value;
   },
 
   _getOutputMappingValue() {

--- a/src/scripts/modules/transformations/utils/parseDataType.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.js
@@ -1,11 +1,10 @@
 import {Map} from 'immutable';
 
-export default function(dataTypeDefinition, columnName) {
-  if (typeof dataTypeDefinition !== 'string') {
-    return dataTypeDefinition;
-  }
+export function isDataTypeAsString(dataTypeDefinition) {
+  return typeof dataTypeDefinition === 'string';
+}
 
-  // dataTypeDefinition is string so we parse it to object
+export function parseDataTypeFromString(dataTypeDefinition, columnName) {
   const parts = dataTypeDefinition.trim().split(' ');
   const type = parts[0];
   let typeLength = parts.length > 1 ? parts[1] : '';

--- a/src/scripts/modules/transformations/utils/parseDataType.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.js
@@ -5,15 +5,12 @@ export function isDataTypeAsString(dataTypeDefinition) {
 }
 
 export function parseDataTypeFromString(dataTypeDefinition, columnName) {
-  const parts = dataTypeDefinition.trim().split(' ');
+  const parts = dataTypeDefinition.trim().split('(');
   const type = parts[0];
-  let typeLength = parts.length > 1 ? parts[1] : '';
-  if (typeLength.startsWith('(') && typeLength.endsWith(')')) {
-    typeLength = typeLength.slice(1, typeLength.length - 1);
-  }
+  const typeLength = parts.length > 1 ? parts[1].slice(0, parts[1].length - 1) : '';
   return Map({
     column: columnName,
-    type: type,
+    type: type.trim(),
     length: typeLength
   });
 }

--- a/src/scripts/modules/transformations/utils/parseDataType.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.js
@@ -7,7 +7,7 @@ export function isDataTypeAsString(dataTypeDefinition) {
 export function parseDataTypeFromString(dataTypeDefinition, columnName) {
   const parts = dataTypeDefinition.trim().split('(');
   const type = parts[0];
-  const typeLength = parts.length > 1 ? parts[1].slice(0, parts[1].length - 1) : '';
+  const typeLength = parts.length > 1 ? parts[1].slice(0, parts[1].length - 1) : null;
   return Map({
     column: columnName,
     type: type.trim(),

--- a/src/scripts/modules/transformations/utils/parseDataType.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.js
@@ -1,0 +1,20 @@
+import {Map} from 'immutable';
+
+export default function(dataTypeDefinition, columnName) {
+  if (typeof dataTypeDefinition !== 'string') {
+    return dataTypeDefinition;
+  }
+
+  // dataTypeDefinition is string so we parse it to object
+  const parts = dataTypeDefinition.trim().split(' ');
+  const type = parts[0];
+  let typeLength = parts.length > 1 ? parts[1] : '';
+  if (typeLength.startsWith('(') && typeLength.endsWith(')')) {
+    typeLength = typeLength.slice(1, typeLength.length - 1);
+  }
+  return Map({
+    column: columnName,
+    type: type,
+    length: typeLength
+  });
+}

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -1,6 +1,5 @@
-import {parseDataTypeFromString} from './parseDataTypeFromString';
+import {parseDataTypeFromString} from './parseDataType';
 import assert from 'assert';
-import {Map} from 'immutable';
 
 describe('parseDataTypeFromString()', () => {
   it('should parse empty string', () => {

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -1,0 +1,61 @@
+import parseDataType from './parseDataType';
+import assert from 'assert';
+import {Map} from 'immutable';
+
+describe('parseDataType()', () => {
+  it('should parse empty string', () => {
+    const test = parseDataType('', 'columnName').toJS();
+    const expected = {
+      column: 'columnName',
+      type: '',
+      length: ''
+    };
+    assert.deepEqual(test, expected);
+  });
+
+  it('should return input if is Immutable.Map', () => {
+    const testMap1 = Map({});
+    const testMap2 = Map({type: 'VARCHAR'});
+    const testMap3 = Map({type: 'NUMBER'});
+    assert.deepEqual(testMap1.toJS(), parseDataType(testMap1, 'foo').toJS());
+    assert.deepEqual(testMap2.toJS(), parseDataType(testMap2, 'foo').toJS());
+    assert.deepEqual(testMap3.toJS(), parseDataType(testMap3, 'foo').toJS());
+  });
+
+  it('should parse string defined data types', () => {
+    assert.deepEqual({
+      type: 'VARCHAR',
+      length: '',
+      column: 'name'
+    }, parseDataType('VARCHAR', 'name').toJS());
+
+    assert.deepEqual({
+      type: 'NUMBER',
+      length: '',
+      column: 'name'
+    }, parseDataType('NUMBER', 'name').toJS());
+
+    assert.deepEqual({
+      type: 'DATE',
+      length: '',
+      column: 'name'
+    }, parseDataType('DATE', 'name').toJS());
+
+  });
+
+  it('should parse string defined data types with length', () => {
+    assert.deepEqual({
+      type: 'VARCHAR',
+      length: '255',
+      column: 'name'
+    }, parseDataType('VARCHAR (255)', 'name').toJS());
+
+    assert.deepEqual({
+      type: 'NUMBER',
+      length: '12,2',
+      column: 'name'
+    }, parseDataType('NUMBER (12,2)', 'name').toJS());
+
+  })
+
+});

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -40,9 +40,7 @@ describe('parseDataType()', () => {
       length: '',
       column: 'name'
     }, parseDataType('DATE', 'name').toJS());
-
   });
-
   it('should parse string defined data types with length', () => {
     assert.deepEqual({
       type: 'VARCHAR',
@@ -55,7 +53,5 @@ describe('parseDataType()', () => {
       length: '12,2',
       column: 'name'
     }, parseDataType('NUMBER (12,2)', 'name').toJS());
-
-  })
-
+  });
 });

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -1,10 +1,10 @@
-import parseDataType from './parseDataType';
+import {parseDataTypeFromString} from './parseDataTypeFromString';
 import assert from 'assert';
 import {Map} from 'immutable';
 
-describe('parseDataType()', () => {
+describe('parseDataTypeFromString()', () => {
   it('should parse empty string', () => {
-    const test = parseDataType('', 'columnName').toJS();
+    const test = parseDataTypeFromString('', 'columnName').toJS();
     const expected = {
       column: 'columnName',
       type: '',
@@ -13,63 +13,54 @@ describe('parseDataType()', () => {
     assert.deepEqual(test, expected);
   });
 
-  it('should return input if is Immutable.Map', () => {
-    const testMap1 = Map({});
-    const testMap2 = Map({type: 'VARCHAR'});
-    const testMap3 = Map({type: 'NUMBER'});
-    assert.deepEqual(testMap1.toJS(), parseDataType(testMap1, 'foo').toJS());
-    assert.deepEqual(testMap2.toJS(), parseDataType(testMap2, 'foo').toJS());
-    assert.deepEqual(testMap3.toJS(), parseDataType(testMap3, 'foo').toJS());
-  });
-
   it('should parse string defined data types', () => {
     assert.deepEqual({
       type: 'VARCHAR',
       length: '',
       column: 'name'
-    }, parseDataType('VARCHAR', 'name').toJS());
+    }, parseDataTypeFromString('VARCHAR', 'name').toJS());
 
     assert.deepEqual({
       type: 'NUMBER',
       length: '',
       column: 'name'
-    }, parseDataType('NUMBER', 'name').toJS());
+    }, parseDataTypeFromString('NUMBER', 'name').toJS());
 
     assert.deepEqual({
       type: 'DATE',
       length: '',
       column: 'name'
-    }, parseDataType('DATE', 'name').toJS());
+    }, parseDataTypeFromString('DATE', 'name').toJS());
 
     assert.deepEqual({
       type: 'BIGINT UNSIGNED',
       length: '',
       column: 'name'
-    }, parseDataType('BIGINT UNSIGNED', 'name').toJS());
+    }, parseDataTypeFromString('BIGINT UNSIGNED', 'name').toJS());
   });
   it('should parse string defined data types with length', () => {
     assert.deepEqual({
       type: 'VARCHAR',
       length: '255',
       column: 'name'
-    }, parseDataType('VARCHAR (255)', 'name').toJS());
+    }, parseDataTypeFromString('VARCHAR (255)', 'name').toJS());
 
     assert.deepEqual({
       type: 'VARCHAR',
       length: '255',
       column: 'name'
-    }, parseDataType('VARCHAR(255)', 'name').toJS());
+    }, parseDataTypeFromString('VARCHAR(255)', 'name').toJS());
 
     assert.deepEqual({
       type: 'NUMBER',
       length: '12,2',
       column: 'name'
-    }, parseDataType('NUMBER (12,2)', 'name').toJS());
+    }, parseDataTypeFromString('NUMBER (12,2)', 'name').toJS());
 
     assert.deepEqual({
       type: 'NUMBER',
       length: '12,2',
       column: 'name'
-    }, parseDataType('NUMBER(12,2)', 'name').toJS());
+    }, parseDataTypeFromString('NUMBER(12,2)', 'name').toJS());
   });
 });

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -7,7 +7,7 @@ describe('parseDataTypeFromString()', () => {
     const expected = {
       column: 'columnName',
       type: '',
-      length: ''
+      length: null
     };
     assert.deepEqual(test, expected);
   });
@@ -15,25 +15,25 @@ describe('parseDataTypeFromString()', () => {
   it('should parse string defined data types', () => {
     assert.deepEqual({
       type: 'VARCHAR',
-      length: '',
+      length: null,
       column: 'name'
     }, parseDataTypeFromString('VARCHAR', 'name').toJS());
 
     assert.deepEqual({
       type: 'NUMBER',
-      length: '',
+      length: null,
       column: 'name'
     }, parseDataTypeFromString('NUMBER', 'name').toJS());
 
     assert.deepEqual({
       type: 'DATE',
-      length: '',
+      length: null,
       column: 'name'
     }, parseDataTypeFromString('DATE', 'name').toJS());
 
     assert.deepEqual({
       type: 'BIGINT UNSIGNED',
-      length: '',
+      length: null,
       column: 'name'
     }, parseDataTypeFromString('BIGINT UNSIGNED', 'name').toJS());
   });

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -40,6 +40,12 @@ describe('parseDataType()', () => {
       length: '',
       column: 'name'
     }, parseDataType('DATE', 'name').toJS());
+
+    assert.deepEqual({
+      type: 'BIGINT UNSIGNED',
+      length: '',
+      column: 'name'
+    }, parseDataType('BIGINT UNSIGNED', 'name').toJS());
   });
   it('should parse string defined data types with length', () => {
     assert.deepEqual({
@@ -49,9 +55,21 @@ describe('parseDataType()', () => {
     }, parseDataType('VARCHAR (255)', 'name').toJS());
 
     assert.deepEqual({
+      type: 'VARCHAR',
+      length: '255',
+      column: 'name'
+    }, parseDataType('VARCHAR(255)', 'name').toJS());
+
+    assert.deepEqual({
       type: 'NUMBER',
       length: '12,2',
       column: 'name'
     }, parseDataType('NUMBER (12,2)', 'name').toJS());
+
+    assert.deepEqual({
+      type: 'NUMBER',
+      length: '12,2',
+      column: 'name'
+    }, parseDataType('NUMBER(12,2)', 'name').toJS());
   });
 });


### PR DESCRIPTION
Fixes #2555 

Proposed changes:
Datovy typy sa pred tou "velkou" zmenou ukladali jednoducho ako stringy:
```
  "datatypes": {
    "column1": "NUMBER",
    "column2": "NUMBER"
  }
```
teraz sa ukladaju ako objekty:
```
  "datatypes": {
    "column1": { column: "column1", type: "NUMBER"},
    "column2": { column: "column2", type: "NUMBER"}
  }
```

Tato uprava zavadza podporu pre stary format, tj ui input mappingu sa pri starych datovych typoch nerozbije. 

Zaroven kazda zmena data type nejake column sa uz ulozi do noveho formatu:
![image](https://user-images.githubusercontent.com/1412120/50092005-347dc980-020d-11e9-9e73-94bafe4275c4.png)
