### PR TITLE
Use Alert component

### DIFF
--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Promise from 'bluebird';
 import _ from 'underscore';
-import {Modal, Table, Tabs, Tab, Row, Col, Button} from 'react-bootstrap';
+import {Modal, Alert, Table, Tabs, Tab, Row, Col, Button} from 'react-bootstrap';
 import {AlertBlock} from '@keboola/indigo-ui';
 import {Check, Loader, RefreshIcon} from '@keboola/indigo-ui';
 import {fromJS, List, Map} from 'immutable';
@@ -166,9 +166,9 @@ export default React.createClass({
     const body = !this.state.loadingStatus ? (
       <span>
         {this.state.error ?
-          <p className="alert alert-danger">
-           Error Loading status: {this.state.error}
-          </p>
+          <Alert bsStyle="danger">
+            Error Loading status: {this.state.error}
+          </Alert>
           :
           <div>
             <Tabs className="tabs-inside-modal" defaultActiveKey="general" animation={false} id="components-migration-row-tabs">

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
+import {Table, Alert} from 'react-bootstrap';
 import {fromJS} from 'immutable';
-import {Table} from 'react-bootstrap';
 import classnames from 'classnames';
 import storageApi from '../../../components/StorageApi';
 import ColumnDataPreview from '../../../components/react/components/ColumnDataPreview';
@@ -80,14 +80,12 @@ export default React.createClass({
     return (
       <div>
         {!this.props.value.tableExist && (
-          <div className="alert alert-warning">
-            <h3>Table Missing</h3>
-            <div className="help-block">
-              <span>
-                Table <code>{this.props.value.tableId}</code> used in this configuration is missing in Storage. Running this configuration will fail.
-              </span>
-            </div>
-          </div>
+          <Alert bsStyle="warning">
+            <h4>Table Missing</h4>
+            <p>
+              Table <code>{this.props.value.tableId}</code> used in this configuration is missing in Storage. Running this configuration will fail.
+            </p>
+          </Alert>
         )}
         {this.props.value.columns.length > 0 && (
           <div>

--- a/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
+++ b/src/scripts/modules/configurations/utils/__snapshots__/createColumnsEditorSection.spec.js.snap
@@ -4,21 +4,18 @@ exports[`columns editor section test nonexisting table render 1`] = `
 <div>
   <div
     class="alert alert-warning"
+    role="alert"
   >
-    <h3>
+    <h4>
       Table Missing
-    </h3>
-    <div
-      class="help-block"
-    >
-      <span>
-        Table 
-        <code>
-          in.some.table
-        </code>
-         used in this configuration is missing in Storage. Running this configuration will fail.
-      </span>
-    </div>
+    </h4>
+    <p>
+      Table 
+      <code>
+        in.some.table
+      </code>
+       used in this configuration is missing in Storage. Running this configuration will fail.
+    </p>
   </div>
   <div>
     <h3>

--- a/src/scripts/modules/csv-import/react/Index/Index.jsx
+++ b/src/scripts/modules/csv-import/react/Index/Index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-bootstrap';
 
 // stores
 import ComponentStore from '../../../components/stores/ComponentsStore';
@@ -26,7 +27,6 @@ import LatestVersions from '../../../components/react/components/SidebarVersions
 
 // utils
 import {getDefaultTable} from '../../utils';
-// import {Map} from 'immutable';
 
 // CONSTS
 const COMPONENT_ID = 'keboola.csv-import';
@@ -65,18 +65,20 @@ export default React.createClass({
     const resultMessage = this.state.localState.get('resultMessage', '');
     const resultState = this.state.localState.get('resultState', '');
     if (resultMessage) {
-      var alertClassName = 'alert ';
+      var alertStyle = 'info';
       if (resultState === 'error') {
-        alertClassName += 'alert-danger';
+        alertStyle = 'danger';
       } else if (resultState === 'success') {
-        alertClassName += 'alert-success';
+        alertStyle = 'success';
       }
       return (
-        <div className={alertClassName} role="alert">
-          <button type="button" className="close" onClick={this.state.actions.dismissResult}><span aria-hidden="true">×</span><span
-            className="sr-only">Close</span></button>
+        <Alert bsStyle={alertStyle}>
+          <button type="button" className="close" onClick={this.state.actions.dismissResult}>
+            <span aria-hidden="true">×</span>
+            <span className="sr-only">Close</span>
+          </button>
           {resultMessage}
-        </div>
+        </Alert>
       );
     }
     return null;

--- a/src/scripts/modules/ex-db-generic/react/components/AsynchActionError.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/AsynchActionError.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Loader } from '@keboola/indigo-ui';
+import { Alert } from 'react-bootstrap';
 
 import { loadSourceTables } from '../../actionsProvisioning';
 
@@ -24,23 +25,21 @@ export default React.createClass({
     } = this.props;
     if (connectionError) {
       return (
-        <div>
-          <div className="alert alert-warning">
-            <h4>Connecting to the database failed, please check database credentials</h4>
-            <p>{connectionError}</p>
-            <p>
-              {connectionTesting && (
-                <span>
-                  <Loader /> Retrying the database connection
-                </span>
-              )}
-            </p>
-          </div>
-        </div>
+        <Alert bsStyle="warning">
+          <h4>Connecting to the database failed, please check database credentials</h4>
+          <p>{connectionError}</p>
+          <p>
+            {connectionTesting && (
+              <span>
+                <Loader /> Retrying the database connection
+              </span>
+            )}
+          </p>
+        </Alert>
       );
     } else if (sourceTablesError) {
       return (
-        <div className="alert alert-danger">
+        <Alert bsStyle="danger">
           <h4>An Error occurred fetching table listing</h4>
           <p>{sourceTablesError}</p>
           <p>
@@ -57,7 +56,7 @@ export default React.createClass({
               </button>
             )}
           </p>
-        </div>
+        </Alert>
       );
     }
     return null;

--- a/src/scripts/modules/ex-email-attachments/react/Index.jsx
+++ b/src/scripts/modules/ex-email-attachments/react/Index.jsx
@@ -23,7 +23,7 @@ import StorageBucketsStore from '../../components/stores/StorageBucketsStore';
 import ClipboardButton from '../../../react/common/Clipboard';
 import SapiTableLinkEx from '../../components/react/components/StorageApiTableLinkEx';
 import getDefaultBucket from '../../../utils/getDefaultBucket';
-import {FormGroup, FormControl, Form, ControlLabel, Col, InputGroup, Button, HelpBlock} from 'react-bootstrap';
+import {Alert, FormGroup, FormControl, Form, ControlLabel, Col, InputGroup, Button, HelpBlock} from 'react-bootstrap';
 import Processors from '../../components/react/components/Processors';
 
 
@@ -203,12 +203,10 @@ export default React.createClass({
     }
 
     return (
-      <div className="alert alert-danger">
-        Error: {message}
-        <div>
-          {code >= 500 ? error.get('exceptionId') : null}
-        </div>
-      </div>
+      <Alert bsStyle="danger">
+        <p>Error: {message}</p>
+        {code >= 500 ? <div>{error.get('exceptionId')}</div> : null}
+      </Alert>
     );
   },
 

--- a/src/scripts/modules/ex-facebook/react/Index/AccountsManagerModal.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/AccountsManagerModal.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 import {List, Map} from 'immutable';
-import {Modal} from 'react-bootstrap';
+import {Modal, Alert} from 'react-bootstrap';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 import {Loader} from '@keboola/indigo-ui';
 import {SearchBar} from '@keboola/indigo-ui';
@@ -113,12 +113,10 @@ export default React.createClass({
     }
 
     return (
-      <div className="alert alert-danger">
-        Error: {message}
-        <div>
-          {code >= 500 ? error.get('exceptionId') : null}
-        </div>
-      </div>
+      <Alert bsStyle="danger">
+        <p>Error: {message}</p>
+        {code >= 500 ? <div>{error.get('exceptionId')}</div> : null}
+      </Alert>
     );
   },
 

--- a/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/QuerySample.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/QuerySample.jsx
@@ -1,6 +1,6 @@
 import React, {PropTypes} from 'react';
 // import EmptyState from '../../../../components/react/components/ComponentEmptyState';
-import {Table} from 'react-bootstrap';
+import {Table, Alert} from 'react-bootstrap';
 import {Loader} from '@keboola/indigo-ui';
 import EmptyState from '../../../../components/react/components/ComponentEmptyState';
 
@@ -102,12 +102,10 @@ export default React.createClass({
       }
     }
     return (
-      <div className="alert alert-danger">
-        {message}
-        <div>
-          {code >= 500 ? error.get('exceptionId') : null}
-        </div>
-      </div>
+      <Alert bsStyle="danger">
+        <p>{message}</p>
+        {code >= 500 ? <div>{error.get('exceptionId')}</div> : null}
+      </Alert>
     );
   },
 

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
@@ -20,7 +20,7 @@ import Duration from '../../../../../react/common/Duration';
 import JobRunId from '../../../../../react/common/JobRunId';
 import JobStatsContainer from './JobStatsContainer';
 import GoodDataStatsContainer from './GoodDataStatsContainer';
-import { PanelGroup, Panel } from 'react-bootstrap';
+import { Alert, PanelGroup, Panel } from 'react-bootstrap';
 import getComponentId from '../../../getJobComponentId';
 import JobStatusLabel from '../../../../../react/common/JobStatusLabel';
 
@@ -227,8 +227,8 @@ export default React.createClass({
   _renderErrorResultRow(job) {
     return (
       <div className="row row-alert">
-        <div
-          className="alert alert-danger"
+        <Alert
+          bsStyle="danger"
           style={{
             marginBottom: 0,
             paddingLeft: '50px',
@@ -237,7 +237,7 @@ export default React.createClass({
           }}
         >
           {this._renderErrorDetails(job)}
-        </div>
+        </Alert>
       </div>
     );
   },
@@ -458,10 +458,10 @@ export default React.createClass({
         <div className="col-md-6">
           <h4>{'Results '}</h4>
           {status === 'error' && (
-            <div className="alert alert-danger">
+            <Alert bsStyle="danger">
               {exceptionId && <span>{`ExceptionId ${exceptionId}`}</span>}
               <p>{message}</p>
-            </div>
+            </Alert>
           )}
           {status !== 'error' && result && <Tree data={result} />}
         </div>

--- a/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
+++ b/src/scripts/modules/oauth-v2/react/AuthorizationModal.jsx
@@ -6,7 +6,7 @@ import DirectTokenInsertFields from './DirectTokenInsertFields';
 import CustomAuthorizationFields from './CustomAuthorizationFields';
 import * as oauthUtils from '../OauthUtils';
 import {Loader, ExternalLink} from '@keboola/indigo-ui';
-import { Button, ButtonToolbar, Modal, Tabs, Tab } from 'react-bootstrap';
+import { Alert, Button, ButtonToolbar, Modal, Tabs, Tab } from 'react-bootstrap';
 
 const DIRECT_TOKEN_COMPONENTS = ['keboola.ex-facebook', 'keboola.ex-facebook-ads', 'keboola.ex-instagram'];
 
@@ -121,7 +121,7 @@ export default React.createClass({
     return (
       <div>
         {!!this.getLimitsInfo() && (
-          <div className="alert alert-warning">{this.getLimitsInfo()}</div>
+          <Alert bsStyle="warning">{this.getLimitsInfo()}</Alert>
         )}
         <p>
           To authorize an account from a non-Keboola Connection user, generate a link to the external authorization app and send it to the user you want to have the authorized account for. The generated link is valid for <strong>48</strong> hours and will not be stored anywhere.

--- a/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
+++ b/src/scripts/modules/oauth-v2/react/InstantAuthorizationFields.jsx
@@ -1,4 +1,5 @@
 import React, {PropTypes} from 'react';
+import {Alert} from 'react-bootstrap';
 
 export default React.createClass({
 
@@ -14,7 +15,7 @@ export default React.createClass({
     return (
       <div>
         {!!this.props.infoText && (
-          <div className="alert alert-warning">{this.props.infoText}</div>
+          <Alert bsStyle="warning">{this.props.infoText}</Alert>
         )}
         <div className="form-group">
           <label className="control-label col-sm-3">

--- a/src/scripts/modules/sapi-events/react/EventDetail.jsx
+++ b/src/scripts/modules/sapi-events/react/EventDetail.jsx
@@ -4,13 +4,14 @@ import PureRendererMixin from 'react-immutable-render-mixin';
 import {Link} from 'react-router';
 import {NewLineToBr} from '@keboola/indigo-ui';
 import {Tree} from '@keboola/indigo-ui';
+import {Alert} from 'react-bootstrap';
 import FileLink  from './FileLink';
 
 const classMap = {
-  error: 'alert alert-danger',
-  warn: 'alert alert-warning',
-  success: 'alert alert-success',
-  info: 'well'
+  error: 'danger',
+  warn: 'warning',
+  success: 'success',
+  info: 'info'
 };
 
 export default React.createClass({
@@ -29,10 +30,10 @@ export default React.createClass({
         <h2>
           Event {event.get('id')}
         </h2>
-        <div className={this._eventClass()}>
+        <Alert bsStyle={this._eventStyle()}>
           <NewLineToBr text={event.get('message')} />
           {event.get('description') ? <p className="well">{event.get('description')}</p> : null }
-        </div>
+        </Alert>
         <div className="row">
           <div className="col-md-3">
             Created
@@ -123,7 +124,7 @@ export default React.createClass({
     );
   },
 
-  _eventClass() {
+  _eventStyle() {
     return classMap[this.props.event.get('type')];
   }
 });

--- a/src/scripts/modules/sapi-events/react/Events.jsx
+++ b/src/scripts/modules/sapi-events/react/Events.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Button} from 'react-bootstrap';
+import {Alert, Button} from 'react-bootstrap';
 import Immutable from 'immutable';
 import PureRendererMixin from 'react-immutable-render-mixin';
 import _ from 'underscore';
@@ -140,9 +140,9 @@ export default React.createClass({
   _renderEventsList() {
     if (this.state.errorMessage) {
       return (
-        <div className="alert alert-danger">
+        <Alert bsStyle="danger">
           {this.state.errorMessage}
-        </div>
+        </Alert>
       );
     }
     if (this.state.events.count()) {

--- a/src/scripts/modules/tokens/react/modals/RefreshTokenModal.jsx
+++ b/src/scripts/modules/tokens/react/modals/RefreshTokenModal.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import {Modal} from 'react-bootstrap';
+import {Alert, Modal} from 'react-bootstrap';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 import TokenString from '../components/TokenString';
 
@@ -60,9 +60,9 @@ export default React.createClass({
   renderRefreshed() {
     return (
       <div>
-        <p className="alert alert-success">
+        <Alert bsStyle="success">
           Token has been refreshed. Make sure to copy it. You won't be able to see it again.
-        </p>
+        </Alert>
         <TokenString token={this.state.newToken} />
       </div>
     );

--- a/src/scripts/modules/tokens/react/modals/SendTokenModal.jsx
+++ b/src/scripts/modules/tokens/react/modals/SendTokenModal.jsx
@@ -1,5 +1,5 @@
 import React, {PropTypes} from 'react';
-import {Modal} from 'react-bootstrap';
+import {Alert, Modal} from 'react-bootstrap';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 
 export default React.createClass({
@@ -92,9 +92,9 @@ export default React.createClass({
   renderInfo() {
     return (
       <div>
-        <p className="alert alert-info">
+        <Alert bsStyle="info">
           The recipient will receive an email with a link to retrieve the token. The link will expire in 24 hours.
-        </p>
+        </Alert>
       </div>
     );
   },

--- a/src/scripts/modules/transformations/react/components/validation/Result.jsx
+++ b/src/scripts/modules/transformations/react/components/validation/Result.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Alert } from 'react-bootstrap';
 import InvalidQuery from './InvalidQuery';
 import InvalidInput from './InvalidInput';
 import InvalidOutput from './InvalidOutput';
@@ -14,7 +15,7 @@ export default React.createClass({
   render() {
     if (this.props.result.count() > 0) {
       return (
-        <div className="alert alert-danger">
+        <Alert bsStyle="danger">
           <h4>Following errors found</h4>
           {this.props.result.map((error, index) => {
             switch (error.getIn(['object', 'type'])) {
@@ -62,7 +63,7 @@ export default React.createClass({
             Not an error?
             Please <a onClick={() => contactSupport({type: 'project'})}>contact us</a>.
           </p>
-        </div>);
+        </Alert>);
     } else {
       return (
         <span>SQL is valid.</span>

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Modal } from 'react-bootstrap';
-import { ButtonToolbar, Button } from 'react-bootstrap';
+import { Alert, ButtonToolbar, Button } from 'react-bootstrap';
 import SqlDepAnalyzerApi from '../../../sqldep-analyzer/Api';
 import { ExternalLink } from '@keboola/indigo-ui';
 import Result from '../components/validation/Result';
@@ -95,7 +95,7 @@ export default React.createClass({
   renderNotSavedWarning() {
     if (!this.props.isSaved) {
       return (
-        <p className="alert alert-warning">You have unsaved changes. Validation will only apply to the last version.</p>
+        <Alert bsStyle="warning">You have unsaved changes. Validation will only apply to the last version.</Alert>
       );
     }
   },

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -9,7 +9,7 @@ import InputMappingRow from './InputMappingRow';
 import InputMappingDetail from './InputMappingDetail';
 import OutputMappingRow from './OutputMappingRow';
 import OutputMappingDetail from './OutputMappingDetail';
-import { Panel } from 'react-bootstrap';
+import { Alert, Panel } from 'react-bootstrap';
 import TransformationTypeAndVersionLabel from '../../components/TransformationTypeAndVersionLabel';
 import Requires from './Requires';
 import Packages from './Packages';
@@ -250,21 +250,19 @@ export default React.createClass({
             </div>
           ]}
           {this._isMySqlTransformation() && (
-            <div className="alert alert-warning">
-              <h3>MySQL Deprecation Warning</h3>
-              <div className="help-block">
-                <span>
-                  {'MySQL transformations are deprecated. '}
-                  {'Please migrate this transformation to Snowflake. '}
-                  {'If you encounter any issues, please contact us using the Support button in the menu on the left. '}
-                  {'Learn more about the MySQL transformation deprecation '}
-                  <ExternalLink href="http://status.keboola.com/deprecating-mysql-storage-and-transformations">
-                    timeline and reasons
-                  </ExternalLink>
-                  .
-                </span>
-              </div>
-            </div>
+            <Alert bsStyle="warning">
+              <h4>MySQL Deprecation Warning</h4>
+              <p>
+                {'MySQL transformations are deprecated. '}
+                {'Please migrate this transformation to Snowflake. '}
+                {'If you encounter any issues, please contact us using the Support button in the menu on the left. '}
+                {'Learn more about the MySQL transformation deprecation '}
+                <ExternalLink href="http://status.keboola.com/deprecating-mysql-storage-and-transformations">
+                  timeline and reasons
+                </ExternalLink>
+                .
+              </p>
+            </Alert>
           )}
           <ConfigurationRowEditField
             componentId="transformation"


### PR DESCRIPTION
Jde o to sjednocení Alertů. Myslím že pro začátek je dobrý mít vše jako react-bootstrap komponentu místo používaní tříd.

Hledal jsem aplikaci použít "alert alert-" a toto upravoval na Alert komponetu. Snad se zachytilo vše teda.

1) Pokud tam rovnou text tak bez html značky `<Alert>text</Alert>`
2) Pokud tam je více řádků tak obaluji do `p`.
3) Pokud tam je nadpis tak použiji `h4`.

Větší změna je na detailu eventu. Pro `info` tam byl styl "wall", který neexistuje u klasického alertu. Tak jsem to nahradil za `info` (modrá barva).
Pak ta změna u `StorageTableColumnsEditor` kde tam byl uvnitř "help-block" a celkově to bylo upraveno aby to vypadalo jinak, tak teď je to klasický alert box, stejný jako ostatní.