### PR TITLE
Update jsdiff to v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "d3": "~3.5.6",
     "dagre-d3": "git+https://git@github.com/keboola/dagre-d3.git#6b444d10ddb5276789b4b2bc1eafcd22a767968a",
     "deep-equal": "^1.0.1",
-    "diff": "^3.5.0",
+    "diff": "^4.0.1",
     "dimple": "git+https://github.com/PMSI-AlignAlytics/dimple.git",
     "filesize": "~2.0.4",
     "flux": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2569,9 +2569,14 @@ detective@^4.3.1:
     acorn "^3.1.0"
     defined "^1.0.0"
 
-diff@^3.2.0, diff@^3.5.0:
+diff@^3.2.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
+diff@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.1.tgz#0c667cb467ebbb5cea7f14f135cc2dba7780a8ff"
+  integrity sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"


### PR DESCRIPTION
Venku nová major verze. Žádný BC break plus pár oprav samotného diffu, což se může hodit.

https://github.com/kpdecker/jsdiff/blob/master/release-notes.md
