### PR TITLE
GoodData Writer Migration Row

### DIFF
--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -32,6 +32,7 @@ const PERMANENT_MIGRATION_COMPONENTS = [
 const MIGRATION_COMPONENT_ID = 'keboola.config-migration-tool';
 
 const componentNameMap = Map({
+  'gooddata-writer': 'keboola.gooddata-writer',
   'ex-gooddata': 'keboola.ex-gooddata',
   'ex-google-analytics': 'keboola.ex-google-analytics',
   'ex-google-drive': 'keboola.ex-google-drive',

--- a/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
@@ -24,6 +24,7 @@ import AddNewTableButton from '../../components/AddNewTableButton';
 import TableRow from './TableRow';
 import goodDataWriterStore from '../../../store';
 import actionCreators from '../../../actionCreators';
+import MigrationRow from '../../../../components/react/components/MigrationRow';
 
 export default React.createClass({
   mixins: [
@@ -94,6 +95,10 @@ export default React.createClass({
     const writer = this.state.writer.get('config');
     return (
       <div className="container-fluid">
+        <MigrationRow
+          componentId="gooddata-writer"
+          replacementAppId="keboola.gooddata-writer"
+        />
         <div className="col-md-9 kbc-main-content">
           <div className="kbc-inner-padding kbc-inner-padding-with-bottom-border">
             <ComponentDescription componentId="gooddata-writer" configId={writer.get('id')} />

--- a/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
@@ -3,6 +3,7 @@ import { Map, List } from 'immutable';
 import { Alert, DropdownButton } from 'react-bootstrap';
 import { Loader, SearchBar, Protected } from '@keboola/indigo-ui';
 import { Link } from 'react-router';
+import hiddenComponents from '../../../../components/utils/hiddenComponents';
 
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
@@ -95,10 +96,12 @@ export default React.createClass({
     const writer = this.state.writer.get('config');
     return (
       <div className="container-fluid">
-        <MigrationRow
-          componentId="gooddata-writer"
-          replacementAppId="keboola.gooddata-writer"
-        />
+        { hiddenComponents.hasCurrentUserDevelPreview() &&
+          <MigrationRow
+            componentId="gooddata-writer"
+            replacementAppId="keboola.gooddata-writer"
+          />
+        }
         <div className="col-md-9 kbc-main-content">
           <div className="kbc-inner-padding kbc-inner-padding-with-bottom-border">
             <ComponentDescription componentId="gooddata-writer" configId={writer.get('id')} />


### PR DESCRIPTION
Jednoducha uprava ktora zobrazi Migration Row komponentu na detaile GoodData Writer stranky iba pre adminov ktory maju zapnutu featuru `ui-devel-preview`. Tym sa nam zjedodusi testovanie migracie, pripadne to mozeme zapnut nejakym analytikom.

Na stranke Overview a detailu GoodData writer komponenty sa komponenta zobrazi az ked sa prepne do stavu `deprecated`.

![image](https://user-images.githubusercontent.com/1412120/50983715-5a427980-1500-11e9-8d99-ca0e5e8269ea.png)

