### PR TITLE
Component name/id to MigrationRow

### DIFF
--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -243,31 +243,42 @@ export default React.createClass({
   },
 
   getInfo() {
-    let replacedApp = this.props.componentId;
     let replacementApp = this.props.replacementAppId;
 
-    if (descriptionsMap.has(replacedApp)) {
-      return descriptionsMap.get(replacedApp);
+    if (descriptionsMap.has(this.props.componentId)) {
+      return descriptionsMap.get(this.props.componentId);
     }
 
     if (!replacementApp) {
       return '';
     }
 
-    if (ComponentsStore.hasComponent(replacedApp) && ComponentsStore.hasComponent(replacementApp)) {
-      replacedApp = ComponentsStore.getComponent(replacedApp).get('name');
-      replacementApp = ComponentsStore.getComponent(replacementApp).get('name');
-    }
-
     return (
       <p>
-        {'Migration process will migrate all configurations of '}<b>{replacedApp}</b>{' to new '}
-        {'configurations of '}<b>{replacementApp}</b>{' component within this project. Any encrypted '}
+        {'Migration process will migrate all configurations of '}
+        {this.renderComponentName(this.props.componentId)}
+        {' to new configurations of '}
+        {this.renderComponentName(this.props.replacementAppId)}
+        {' component within this project. Any encrypted '}
         {'values or authorized accounts will not be migrated and have to be entered/authorized manually '}
-        {'again. Beside that all orchestration tasks of the '}<b>{replacedApp}</b>{' configurations will '}
-        {'be replaced with configurations of the new '}<b>{replacementApp}</b>{'.'}
+        {'again. Beside that all orchestration tasks of the '}
+        {this.renderComponentName(this.props.componentId)}
+        {' configurations will '}
+        {'be replaced with configurations of the new '}
+        {this.renderComponentName(this.props.replacementAppId)}{'.'}
       </p>
     );
+  },
+
+  renderComponentName(componentId) {
+    return ComponentsStore.hasComponent(componentId)
+      ? (
+        <span>
+          <strong>{ComponentsStore.getComponent(componentId).get('name')}</strong> ({componentId})
+        </span>
+      ) : (
+        componentId
+      );
   },
 
   renderModal(title, body, footer, props) {

--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -14,6 +14,7 @@ import DockerActionFn from '../../DockerActionsApi';
 import date from '../../../../utils/date';
 import JobStatusLabel from '../../../../react/common/JobStatusLabel';
 import Tooltip from '../../../../react/common/Tooltip';
+import ComponentsStore from '../../stores/ComponentsStore';
 import InstalledComponentsStore from '../../stores/InstalledComponentsStore';
 import ComponentConfigurationLink from './ComponentConfigurationLink';
 import ComponentEmptyState from '../../../components/react/components/ComponentEmptyState';
@@ -233,11 +234,7 @@ export default React.createClass({
       <AlertBlock type="warning" title="This component has been deprecated">
         <Row>
           <Col md={9}>
-            <span>
-              <p>
-                {this.getInfo()}
-              </p>
-            </span>
+            {this.getInfo()}
             {this.renderMigrationButton()}
           </Col>
         </Row>
@@ -246,14 +243,31 @@ export default React.createClass({
   },
 
   getInfo() {
-    const replacementApp = this.props.replacementAppId;
+    let replacedApp = this.props.componentId;
+    let replacementApp = this.props.replacementAppId;
+
     if (descriptionsMap.has(this.props.componentId)) {
       return descriptionsMap.get(this.props.componentId);
     }
-    if (replacementApp) {
-      return `Migration process will migrate all configurations of ${this.props.componentId} to new configurations of ${replacementApp} component within this project. Any encrypted values or authorized accounts will not be migrated and have to be entered/authorized manually again. Beside that all orchestration tasks of the ${this.props.componentId} configurations will be replaced with configurations of the new ${replacementApp}`;
+
+    if (!replacementApp) {
+      return '';
     }
-    return '';
+
+    if (ComponentsStore.hasComponent(replacedApp) && ComponentsStore.hasComponent(replacementApp)) {
+      replacedApp = ComponentsStore.getComponent(replacedApp).get('name');
+      replacementApp = ComponentsStore.getComponent(replacementApp).get('name');
+    }
+
+    return (
+      <p>
+        {'Migration process will migrate all configurations of '}<b>{replacedApp}</b>{' to new '}
+        {'configurations of '}<b>{replacementApp}</b>{' component within this project. Any encrypted '}
+        {'values or authorized accounts will not be migrated and have to be entered/authorized manually '}
+        {'again. Beside that all orchestration tasks of the '}<b>{replacedApp}</b>{' configurations will '}
+        {'be replaced with configurations of the new '}<b>{replacementApp}</b>{'.'}
+      </p>
+    );
   },
 
   renderModal(title, body, footer, props) {

--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -246,8 +246,8 @@ export default React.createClass({
     let replacedApp = this.props.componentId;
     let replacementApp = this.props.replacementAppId;
 
-    if (descriptionsMap.has(this.props.componentId)) {
-      return descriptionsMap.get(this.props.componentId);
+    if (descriptionsMap.has(replacedApp)) {
+      return descriptionsMap.get(replacedApp);
     }
 
     if (!replacementApp) {


### PR DESCRIPTION
Fixes #2645

Používám tam `ComponentsStore` napřímo ale koukal jsme že stejně tak tam je `InstalledComponentsStore`. Kontroluji obě naráz abych tam neměl třeba jedno ID a druhý Name. Takto buď obojí bude name nebo obojí ID (snad).