### PR TITLE
Storage Explorer - cancelable request, removed isMount

### DIFF
--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -62,7 +62,7 @@ const addTableColumn = (tableId, params) => {
 const dataPreview = (tableId, params) => {
   return StorageApi
     .tableDataJsonPreview(tableId, { limit: 20, ...params })
-    .catch(HttpError, (error) => {
+    .catch(HttpError, error => {
       throw error.message;
     });
 };

--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -62,16 +62,8 @@ const addTableColumn = (tableId, params) => {
 const dataPreview = (tableId, params) => {
   return StorageApi
     .tableDataJsonPreview(tableId, { limit: 20, ...params })
-    .catch(error => {
-      if (!error.response || !error.response.body) {
-        throw new Error(JSON.stringify(error));
-      }
-
-      if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
-        return 'Data sample cannot be displayed. Too many columns.';
-      }
-
-      return error.response.body.message;
+    .catch(HttpError, (error) => {
+      throw error.message;
     });
 };
 

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -175,7 +175,6 @@ export default React.createClass({
     this.setState({ loading: true });
 
     this.cancellablePromise = dataPreview(this.props.table.get('id'), params)
-      .cancellable()
       .then(json => {
         this.setState({ data: json, loading: false });
       })

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -26,7 +26,7 @@ export default React.createClass({
   },
 
   componentWillUnmount() {
-    this.fetchingPromise && this.fetchingPromise.cancel();
+    this.cancellablePromise && this.cancellablePromise.cancel();
   },
 
   render() {
@@ -174,7 +174,8 @@ export default React.createClass({
   fetchDataPreview(params = {}) {
     this.setState({ loading: true });
 
-    this.fetchingPromise = dataPreview(this.props.table.get('id'), params)
+    this.cancellablePromise = dataPreview(this.props.table.get('id'), params)
+      .cancellable()
       .then(json => {
         this.setState({ data: json, loading: false });
       })

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -25,6 +25,10 @@ export default React.createClass({
     this.fetchDataPreview();
   },
 
+  componentWillUnmount() {
+    this.fetchingPromise && this.fetchingPromise.cancel();
+  },
+
   render() {
     return (
       <div>
@@ -170,15 +174,16 @@ export default React.createClass({
   fetchDataPreview(params = {}) {
     this.setState({ loading: true });
 
-    return dataPreview(this.props.table.get('id'), params)
+    this.fetchingPromise = dataPreview(this.props.table.get('id'), params)
       .then(json => {
-        this.setState({ data: json });
+        this.setState({ data: json, loading: false });
       })
-      .catch(errorMessage => {
-        this.setState({ data: [], error: errorMessage });
-      })
-      .finally(() => {
-        this.setState({ loading: false });
+      .catch(({ message, response }) => {
+        const errorMessage =
+          response.body.code === 'storage.maxNumberOfColumnsExceed'
+            ? 'Data sample cannot be displayed. Too many columns.'
+            : message;
+        this.setState({ data: [], error: errorMessage, loading: false });
       });
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/LatestImports.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/LatestImports.jsx
@@ -65,11 +65,9 @@ export default React.createClass({
   },
 
   handleChange() {
-    if (this.isMounted()) {
-      this.setState({
-        events: this._events.getEvents(),
-        isLoading: this._events.getIsLoading()
-      });
-    }
+    this.setState({
+      events: this._events.getEvents(),
+      isLoading: this._events.getIsLoading()
+    });
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
@@ -50,6 +50,10 @@ export default React.createClass({
     }
   },
 
+  componentWillUnmount() {
+    this.fetchingPromise && this.fetchingPromise.cancel();
+  },
+
   render() {
     return (
       <div>
@@ -174,11 +178,7 @@ export default React.createClass({
                       </Button>
                     </Tooltip>
                     <Tooltip tooltip="Delete snapshot" placement="top">
-                      <Button
-                        bsStyle="link"
-                        onClick={() => this.openRemoveSnapshotModal(snapshot)}
-                        disabled={deleting}
-                      >
+                      <Button bsStyle="link" onClick={() => this.openRemoveSnapshotModal(snapshot)} disabled={deleting}>
                         {deleting ? <Loader /> : <i className="fa fa-trash-o" />}
                       </Button>
                     </Tooltip>
@@ -344,16 +344,14 @@ export default React.createClass({
     };
 
     this.setState({ loading: true });
-    StorageApi.loadTableSnapshots(tableId, params)
+    this.fetchingPromise = StorageApi.loadTableSnapshots(tableId, params)
       .then(data => {
         this.setState({
+          loading: false,
           hasMore: data.length > this.state.pagingCount,
           snapshots: fromJS(refetch ? data : this.state.snapshots.toArray().concat(data)),
           offset: this.state.pagingCount + 1
         });
-      })
-      .finally(() => {
-        this.setState({ loading: false });
       });
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
@@ -51,7 +51,7 @@ export default React.createClass({
   },
 
   componentWillUnmount() {
-    this.fetchingPromise && this.fetchingPromise.cancel();
+    this.cancellablePromise && this.cancellablePromise.cancel();
   },
 
   render() {
@@ -344,7 +344,8 @@ export default React.createClass({
     };
 
     this.setState({ loading: true });
-    this.fetchingPromise = StorageApi.loadTableSnapshots(tableId, params)
+    this.cancellablePromise = StorageApi.loadTableSnapshots(tableId, params)
+      .cancellable()
       .then(data => {
         this.setState({
           loading: false,

--- a/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
@@ -345,7 +345,6 @@ export default React.createClass({
 
     this.setState({ loading: true });
     this.cancellablePromise = StorageApi.loadTableSnapshots(tableId, params)
-      .cancellable()
       .then(data => {
         this.setState({
           loading: false,

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
   },
 
   componentWillUnmount() {
-    this.fetchingPromise && this.fetchingPromise.cancel();
+    this.cancellablePromise && this.cancellablePromise.cancel();
     window.removeEventListener('resize', this.handleResize);
   },
 
@@ -121,7 +121,8 @@ export default React.createClass({
 
   loadData() {
     this.setState({ loading: true });
-    this.fetchingPromise = TableGraphApi.load(this.props.table.get('id'), this.state.direction)
+    this.cancellablePromise = TableGraphApi.load(this.props.table.get('id'), this.state.direction)
+      .cancellable()
       .then(data => {
         data.nodes = graphUtils.addLinksToNodes(data.nodes);
         this.setState({ data, loading: false });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
@@ -34,6 +34,7 @@ export default React.createClass({
   },
 
   componentWillUnmount() {
+    this.fetchingPromise && this.fetchingPromise.cancel();
     window.removeEventListener('resize', this.handleResize);
   },
 
@@ -120,13 +121,10 @@ export default React.createClass({
 
   loadData() {
     this.setState({ loading: true });
-    return TableGraphApi.load(this.props.table.get('id'), this.state.direction)
+    this.fetchingPromise = TableGraphApi.load(this.props.table.get('id'), this.state.direction)
       .then(data => {
         data.nodes = graphUtils.addLinksToNodes(data.nodes);
-        this.setState({ data });
-      })
-      .finally(() => {
-        this.setState({ loading: false });
+        this.setState({ data, loading: false });
       });
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableGraph.jsx
@@ -122,7 +122,6 @@ export default React.createClass({
   loadData() {
     this.setState({ loading: true });
     this.cancellablePromise = TableGraphApi.load(this.props.table.get('id'), this.state.direction)
-      .cancellable()
       .then(data => {
         data.nodes = graphUtils.addLinksToNodes(data.nodes);
         this.setState({ data, loading: false });


### PR DESCRIPTION
Related #2402
Fixes: #2684 
Fixes #2686 

Ten check `isMount` jsme tuším už mazal jinde ale nevadí. Jak tam jsou listenery, tak by to tam vůbec nemuselo být potřeba co jsem koukal.

Zkusil jsem ještě využít možnost "zrušit" request (cancel). Příjde mi že těch varování v konzoli je méně ale beztak tam jsou. Nevím moc co s tím. Podle google ale bluebird issues to vypadá že to je lépe implementováno až v novější verzi. Je tu na ní také připravený https://github.com/keboola/kbc-ui/pull/2305.
Taky tam chytám `CancellationError` error. Což je taky divný, `catch` ani `then` by se podle dokumentace nemělo volat po zrušení. Myslím že ten update by mohl vyřešit i toto a mohlo by se to vyhodit.
