### PR TITLE
Storage Explorer - Time Travel Modal - update table name when change date

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
@@ -105,7 +105,7 @@ export default React.createClass({
   handleTimestamp(timestamp) {
     let tableName = this.state.tableName;
 
-    if (this.state.tableName.match(/_\d{14}/)) {
+    if (this.state.tableName.match(/_\d{14}$/)) {
       tableName = this.props.table.get('name') + '_' + moment(timestamp).format('YYYYMMDDHHmmss');
     }
 

--- a/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
@@ -103,8 +103,15 @@ export default React.createClass({
   },
 
   handleTimestamp(timestamp) {
+    let tableName = this.state.tableName;
+
+    if (this.state.tableName.match(/_\d{14}/)) {
+      tableName = this.props.table.get('name') + '_' + moment(timestamp).format('YYYYMMDDHHmmss');
+    }
+
     this.setState({
-      timestamp
+      timestamp,
+      tableName
     });
   },
 


### PR DESCRIPTION
Related #2402
Fixes: #2678 

Nevím zda to tu přepisovat vždy nebo jen pokud to končí datumem (default), zatím jsem tam dal takovou menší kontrolu zda to končí 14 čístly (asi datum v tom našem formátu) tak to upravím jinak ne. Když si to uživatel sám asi nějak přepsal. Ale taky to nezachytí vše. Když si uživatel přepíše třeba jen název ale ne datum, tak mu to upraví.
Nebo neměl by být ten input jen readonly?

