### PR TITLE
Storage Explorer - Files - Examples Modal, searchById

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
@@ -63,9 +63,12 @@ export default React.createClass({
     return (
       <tr key={file.get('id')}>
         <td>
-          <span className="kbc-sapi-table-link" onClick={() => this.props.onSearchQuery(`id:${file.get('id')}`)}>
+          <button
+            className="btn btn-link btn-link-inline"
+            onClick={() => this.props.onSearchQuery(`id:${file.get('id')}`)}
+          >
             {file.get('id')}
-          </span>
+          </button>
         </td>
         <td>{format(file.get('created'), 'YYYY-MM-DD HH:mm')}</td>
         <td>

--- a/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
@@ -16,8 +16,7 @@ export default React.createClass({
 
   propTypes: {
     files: PropTypes.object.isRequired,
-    onSearchById: PropTypes.func.isRequired,
-    onSearchByTag: PropTypes.func.isRequired,
+    onSearchQuery: PropTypes.func.isRequired,
     onDeleteFile: PropTypes.func.isRequired,
     isDeleting: PropTypes.object.isRequired
   },
@@ -64,7 +63,7 @@ export default React.createClass({
     return (
       <tr key={file.get('id')}>
         <td>
-          <span className="kbc-sapi-table-link" onClick={() => this.props.onSearchById(file.get('id'))}>
+          <span className="kbc-sapi-table-link" onClick={() => this.props.onSearchQuery(`id:${file.get('id')}`)}>
             {file.get('id')}
           </span>
         </td>
@@ -92,7 +91,7 @@ export default React.createClass({
               key={index}
               className="kbc-cursor-pointer"
               bsStyle="success"
-              onClick={() => this.props.onSearchByTag(tag)}
+              onClick={() => this.props.onSearchQuery(`tags:${tag}`)}
             >
               {tag}
             </Label>

--- a/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/FilesTable.jsx
@@ -16,6 +16,7 @@ export default React.createClass({
 
   propTypes: {
     files: PropTypes.object.isRequired,
+    onSearchById: PropTypes.func.isRequired,
     onSearchByTag: PropTypes.func.isRequired,
     onDeleteFile: PropTypes.func.isRequired,
     isDeleting: PropTypes.object.isRequired
@@ -62,7 +63,11 @@ export default React.createClass({
   renderRow(file) {
     return (
       <tr key={file.get('id')}>
-        <td>{file.get('id')}</td>
+        <td>
+          <span className="kbc-sapi-table-link" onClick={() => this.props.onSearchById(file.get('id'))}>
+            {file.get('id')}
+          </span>
+        </td>
         <td>{format(file.get('created'), 'YYYY-MM-DD HH:mm')}</td>
         <td>
           <FileLink file={file} showFilesize={false} />

--- a/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
@@ -54,12 +54,12 @@ export default React.createClass({
           {this.state.examples.map((example, index) => {
             return (
               <Well bsSize="sm" key={index}>
-                <Label bsStyle="info">Search:</Label>
-                <span className="kbc-sapi-table-link" onClick={() => this.selectExample(example)}>
+                <Label bsStyle="info">Search</Label>
+                <span className="btn-link-inline kbc-cursor-pointer" onClick={() => this.selectExample(example)}>
                   {example.query}
                 </span>
                 <br />
-                <Label bsStyle="warning">Shows:</Label>
+                <Label bsStyle="warning">Shows</Label>
                 <span>{example.description}</span>
               </Well>
             );

--- a/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
@@ -55,9 +55,9 @@ export default React.createClass({
             return (
               <Well bsSize="sm" key={index}>
                 <Label bsStyle="info">Search</Label>
-                <span className="btn-link-inline kbc-cursor-pointer" onClick={() => this.selectExample(example)}>
+                <Button bsStyle="link" className="btn-link-inline" onClick={() => this.selectExample(example)}>
                   {example.query}
-                </span>
+                </Button>
                 <br />
                 <Label bsStyle="warning">Shows</Label>
                 <span>{example.description}</span>

--- a/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/FilesSearchExamplesModal.jsx
@@ -1,0 +1,86 @@
+import React, { PropTypes } from 'react';
+import { Modal, Button, Label, Well } from 'react-bootstrap';
+import { ExternalLink } from '@keboola/indigo-ui';
+
+export default React.createClass({
+  propTypes: {
+    show: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired,
+    onSelectExample: PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return {
+      examples: [
+        {
+          query: 'token.name:john.doe@company.com',
+          description: 'Files uploaded by John Doe'
+        },
+        {
+          query: 'name:devel',
+          description: 'Files with a name that contains "devel"'
+        },
+        {
+          query: 'isPublic',
+          description: 'Public files only'
+        },
+        {
+          query: '-isPublic',
+          description: 'Everything except public files'
+        },
+        {
+          query: 'created:>2018-01-31',
+          description: 'Files created after 2018-01-31'
+        },
+        {
+          query: 'sizeBytes:>10000',
+          description: 'Files bigger than 10kB'
+        },
+        {
+          query: 'tags:table-export',
+          description: 'Files tagged "table-export"'
+        }
+      ]
+    };
+  },
+
+  render() {
+    return (
+      <Modal show={this.props.show} onHide={this.props.onHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>Search syntax &amp; Examples</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          {this.state.examples.map((example, index) => {
+            return (
+              <Well bsSize="sm" key={index}>
+                <Label bsStyle="info">Search:</Label>
+                <span className="kbc-sapi-table-link" onClick={() => this.selectExample(example)}>
+                  {example.query}
+                </span>
+                <br />
+                <Label bsStyle="warning">Shows:</Label>
+                <span>{example.description}</span>
+              </Well>
+            );
+          })}
+          <p>
+            <ExternalLink href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax">
+              Read full syntax guide
+            </ExternalLink>
+          </p>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.props.onHide} bsStyle="link">
+            Cancel
+          </Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  },
+
+  selectExample(example) {
+    this.props.onSelectExample(example.query);
+    this.props.onHide();
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
-import { Button } from 'react-bootstrap';
+import { ButtonToolbar, Button } from 'react-bootstrap';
 import { SearchBar } from '@keboola/indigo-ui';
 
+import Tooltip from '../../../../../react/common/Tooltip';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
 import FilesLocalStore from '../../../FilesLocalStore';
@@ -10,6 +11,7 @@ import StorageActionCreators from '../../../../components/StorageActionCreators'
 import FilesTable from '../../components/FilesTable';
 import NavButtons from '../../components/NavButtons';
 import UploadModal from '../../modals/UploadModal';
+import ExamplesModal from '../../modals/FilesSearchExamplesModal';
 import { updateSearchQuery, resetSearchQuery } from '../../../Actions';
 import { filesLimit } from '../../../Constants';
 
@@ -35,6 +37,7 @@ export default React.createClass({
 
   getInitialState() {
     return {
+      openExamplesModal: false,
       openUploadModal: false
     };
   },
@@ -51,9 +54,16 @@ export default React.createClass({
               onChange={this.handleQueryChange}
               onSubmit={this.fetchFiles}
               additionalActions={
-                <Button bsStyle="primary" onClick={this.openUploadModal}>
-                  <i className="fa fa-arrow-circle-o-up" /> Upload File
-                </Button>
+                <ButtonToolbar>
+                  <Tooltip tooltip="Search syntax &amp; Examples" placement="top">
+                    <Button bsStyle="default" onClick={this.openExamplesModal}>
+                      <i className="fa fa-question-circle" />
+                    </Button>
+                  </Tooltip>
+                  <Button bsStyle="primary" onClick={this.openUploadModal}>
+                    <i className="fa fa-arrow-circle-o-up" /> Upload File
+                  </Button>
+                </ButtonToolbar>
               }
             />
           </div>
@@ -64,8 +74,7 @@ export default React.createClass({
             <div>
               <FilesTable
                 files={this.state.files}
-                onSearchById={this.searchById}
-                onSearchByTag={this.searchByTag}
+                onSearchQuery={this.searchQuery}
                 onDeleteFile={this.handleDeleteFile}
                 isDeleting={this.state.isDeleting}
               />
@@ -75,6 +84,7 @@ export default React.createClass({
         </div>
 
         {this.renderUploadModal()}
+        {this.renderExamplesModal()}
       </div>
     );
   },
@@ -104,6 +114,16 @@ export default React.createClass({
     );
   },
 
+  renderExamplesModal() {
+    return (
+      <ExamplesModal
+        show={this.state.openExamplesModal}
+        onHide={this.closeExamplesModal}
+        onSelectExample={this.searchQuery}
+      />
+    );
+  },
+
   handleQueryChange(query) {
     updateSearchQuery(query);
   },
@@ -120,17 +140,24 @@ export default React.createClass({
     });
   },
 
+  openExamplesModal() {
+    this.setState({
+      openExamplesModal: true
+    });
+  },
+
+  closeExamplesModal() {
+    this.setState({
+      openExamplesModal: false
+    });
+  },
+
   handleUploadFile(file, params) {
     return StorageActionCreators.uploadFile(DIRECT_UPLOAD, file, params).then(() => this.fetchFiles());
   },
 
-  searchByTag(tag) {
-    updateSearchQuery(`tags:${tag}`);
-    setTimeout(this.fetchFiles, 50);
-  },
-
-  searchById(id) {
-    updateSearchQuery(`id:${id}`);
+  searchQuery(query) {
+    updateSearchQuery(query);
     setTimeout(this.fetchFiles, 50);
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
@@ -64,6 +64,7 @@ export default React.createClass({
             <div>
               <FilesTable
                 files={this.state.files}
+                onSearchById={this.searchById}
                 onSearchByTag={this.searchByTag}
                 onDeleteFile={this.handleDeleteFile}
                 isDeleting={this.state.isDeleting}
@@ -125,6 +126,11 @@ export default React.createClass({
 
   searchByTag(tag) {
     updateSearchQuery(`tags:${tag}`);
+    setTimeout(this.fetchFiles, 50);
+  },
+
+  searchById(id) {
+    updateSearchQuery(`id:${id}`);
     setTimeout(this.fetchFiles, 50);
   },
 


### PR DESCRIPTION
Related #2402
Fixes: #2681 
Fixes: #2682

Tu a ještě někde v předešlém PR zneužívám třídu "kbc-sapi-table-link", aby třeba span vypadal jako odkaz, button má "btn-link" ale tam je navíc padding apod. Toto třída je docela obecné, možná kdyby se přejmenovala v Indigu i v Kbc-ui, tak by to bylo lepší.