### PR TITLE
Orchestrations - Retry job - Orchestration config name

### DIFF
--- a/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
     const parameters = this.props.task.get('actionParameters');
 
     if (parameters.size === 1 && parameters.has('config') && this.props.component) {
-      const config = InstalledComponentsStore.getConfig(this.props.component.get('id'), parameters.get('config'));
+      const config = InstalledComponentsStore.getConfig(this.props.component.get('id'), parameters.get('config').toString());
       return config.get('name', parameters.get('config'));
     }
 


### PR DESCRIPTION
Fixes #2689

Ochestrace mají v parameters config jako number (ostatní asi string), tak převádím vše na string aby se vše hledalo stejně.