### PR TITLE
Transformation - SQL Validation modal - Validace -> Run

### DIFF
--- a/src/scripts/modules/transformations/react/components/ValidateQueriesButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ValidateQueriesButton.jsx
@@ -1,30 +1,27 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
+import { Label } from 'react-bootstrap';
 import Modal from '../modals/ValidateQueriesModal';
 
 export default React.createClass({
   propTypes: {
-    transformationId: React.PropTypes.string.isRequired,
-    bucketId: React.PropTypes.string.isRequired,
-    backend: React.PropTypes.string.isRequired,
-    modalOpen: React.PropTypes.bool.isRequired,
-    onModalOpen: React.PropTypes.func.isRequired,
-    onModalClose: React.PropTypes.func.isRequired,
-    isSaved: React.PropTypes.bool.isRequired
+    transformationId: PropTypes.string.isRequired,
+    bucketId: PropTypes.string.isRequired,
+    backend: PropTypes.string.isRequired,
+    modalOpen: PropTypes.bool.isRequired,
+    onModalOpen: PropTypes.func.isRequired,
+    onModalClose: PropTypes.func.isRequired,
+    isSaved: PropTypes.bool.isRequired
   },
 
   handleOpenButtonClick(e) {
     e.preventDefault();
-    return this.props.onModalOpen();
+    this.props.onModalOpen();
   },
 
   render() {
     return (
       <a onClick={this.handleOpenButtonClick}>
-        <i className="fa fa-check-square-o fa-fw" />
-        {' '}Validate
-        <span>{' '}
-          <span className="label label-info">BETA</span>
-        </span>
+        <i className="fa fa-check-square-o fa-fw" /> Validate <Label bsStyle="info">BETA</Label>
         <Modal
           transformationId={this.props.transformationId}
           bucketId={this.props.bucketId}
@@ -33,7 +30,6 @@ export default React.createClass({
           onHide={this.props.onModalClose}
           isSaved={this.props.isSaved}
         />
-
       </a>
     );
   }

--- a/src/scripts/modules/transformations/react/components/ValidateQueriesButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ValidateQueriesButton.jsx
@@ -4,9 +4,9 @@ import Modal from '../modals/ValidateQueriesModal';
 
 export default React.createClass({
   propTypes: {
-    transformationId: PropTypes.string.isRequired,
-    bucketId: PropTypes.string.isRequired,
     backend: PropTypes.string.isRequired,
+    bucketId: PropTypes.string.isRequired,
+    transformation: PropTypes.object.isRequired,
     modalOpen: PropTypes.bool.isRequired,
     onModalOpen: PropTypes.func.isRequired,
     onModalClose: PropTypes.func.isRequired,
@@ -23,9 +23,9 @@ export default React.createClass({
       <a onClick={this.handleOpenButtonClick}>
         <i className="fa fa-check-square-o fa-fw" /> Validate <Label bsStyle="info">BETA</Label>
         <Modal
-          transformationId={this.props.transformationId}
-          bucketId={this.props.bucketId}
           backend={this.props.backend}
+          bucketId={this.props.bucketId}
+          transformation={this.props.transformation}
           show={this.props.modalOpen}
           onHide={this.props.onModalClose}
           isSaved={this.props.isSaved}

--- a/src/scripts/modules/transformations/react/components/validation/Result.jsx
+++ b/src/scripts/modules/transformations/react/components/validation/Result.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { Alert } from 'react-bootstrap';
 import InvalidQuery from './InvalidQuery';
 import InvalidInput from './InvalidInput';
@@ -7,9 +7,9 @@ import contactSupport from '../../../../../utils/contactSupport';
 
 export default React.createClass({
   propTypes: {
-    bucketId: React.PropTypes.string.isRequired,
-    result: React.PropTypes.object.isRequired,
-    onRedirect: React.PropTypes.func.isRequired
+    bucketId: PropTypes.string.isRequired,
+    result: PropTypes.object.isRequired,
+    onRedirect: PropTypes.func.isRequired
   },
 
   render() {
@@ -17,57 +17,63 @@ export default React.createClass({
       return (
         <Alert bsStyle="danger">
           <h4>Following errors found</h4>
-          {this.props.result.map((error, index) => {
-            switch (error.getIn(['object', 'type'])) {
-              case 'query':
-                return (
-                  <InvalidQuery
-                    bucketId={this.props.bucketId}
-                    key={index}
-                    transformationId={error.get('transformation')}
-                    queryNumber={parseInt(error.getIn(['object', 'id']), 10)}
-                    message={error.get('message')}
-                    onClick={this.props.onRedirect}
-                  />
-                );
-              case 'input':
-                return (
-                  <InvalidInput
-                    bucketId={this.props.bucketId}
-                    key={index}
-                    transformationId={error.get('transformation')}
-                    tableId={error.getIn(['object', 'id'])}
-                    message={error.get('message')}
-                    onClick={this.props.onRedirect}
-                  />
-                );
-              case 'output':
-              case 'output_consistency':
-                return (
-                  <InvalidOutput
-                    bucketId={this.props.bucketId}
-                    key={index}
-                    transformationId={error.get('transformation')}
-                    tableId={error.getIn(['object', 'id'])}
-                    message={error.get('message')}
-                    onClick={this.props.onRedirect}
-                  />
-                );
-              default:
-                return (
-                  <p>{error.get('message')}</p>
-                );
-            }
-          }).toArray()}
+          {this.props.result.map(this.renderResult).toArray()}
           <p>
-            Not an error?
-            Please <a onClick={() => contactSupport({type: 'project'})}>contact us</a>.
+            Not an error? Please <a onClick={() => contactSupport({ type: 'project' })}>contact us</a>.
           </p>
-        </Alert>);
-    } else {
-      return (
-        <span>SQL is valid.</span>
+        </Alert>
       );
     }
+
+    return (
+      <Alert bsStyle="success">
+        <i className="fa fa-check" /> SQL is valid.
+      </Alert>
+    );
+  },
+
+  renderResult(error, index) {
+    const type = error.getIn(['object', 'type']);
+
+    if (type === 'query') {
+      return (
+        <InvalidQuery
+          bucketId={this.props.bucketId}
+          key={index}
+          transformationId={error.get('transformation')}
+          queryNumber={parseInt(error.getIn(['object', 'id']), 10)}
+          message={error.get('message')}
+          onClick={this.props.onRedirect}
+        />
+      );
+    }
+
+    if (type === 'input') {
+      return (
+        <InvalidInput
+          bucketId={this.props.bucketId}
+          key={index}
+          transformationId={error.get('transformation')}
+          tableId={error.getIn(['object', 'id'])}
+          message={error.get('message')}
+          onClick={this.props.onRedirect}
+        />
+      );
+    }
+
+    if (['output', 'output_consistency'].includes(type)) {
+      return (
+        <InvalidOutput
+          bucketId={this.props.bucketId}
+          key={index}
+          transformationId={error.get('transformation')}
+          tableId={error.getIn(['object', 'id'])}
+          message={error.get('message')}
+          onClick={this.props.onRedirect}
+        />
+      );
+    }
+
+    return <p key={index}>{error.get('message')}</p>;
   }
 });

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -95,9 +95,7 @@ export default React.createClass({
 
   onRunTransformation() {
     InstalledComponentsActionCreators.runComponent({
-      method: 'run',
       component: 'transformation',
-      notify: true,
       data: {
         configBucketId: this.props.bucketId,
         transformations: [this.props.transformation.get('id')]

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -47,26 +47,6 @@ export default React.createClass({
     );
   },
 
-  renderResult() {
-    if (!this.state.result) {
-      return null;
-    }
-
-    return (
-      <span style={{ maxHeight: '300px', overflow: 'scroll' }}>
-        <Result result={this.state.result} bucketId={this.props.bucketId} onRedirect={this.onHide} />
-      </span>
-    );
-  },
-
-  renderNotSavedWarning() {
-    if (this.props.isSaved) {
-      return null;
-    }
-
-    return <Alert bsStyle="warning">You have unsaved changes. Validation will only apply to the last version.</Alert>;
-  },
-
   renderBody() {
     if (this.isValidBackend()) {
       return (
@@ -84,6 +64,26 @@ export default React.createClass({
     }
 
     return <p>SQL validation is available for Snowflake transformations only.</p>;
+  },
+
+  renderNotSavedWarning() {
+    if (this.props.isSaved) {
+      return null;
+    }
+
+    return <Alert bsStyle="warning">You have unsaved changes. Validation will only apply to the last version.</Alert>;
+  },
+
+  renderResult() {
+    if (!this.state.result) {
+      return null;
+    }
+
+    return (
+      <span style={{ maxHeight: '300px', overflow: 'scroll' }}>
+        <Result result={this.state.result} bucketId={this.props.bucketId} onRedirect={this.onHide} />
+      </span>
+    );
   },
 
   onHide() {

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -52,7 +52,11 @@ export default React.createClass({
       return null;
     }
 
-    return <Result result={this.state.result} bucketId={this.props.bucketId} onRedirect={this.onHide} />;
+    return (
+      <span style={{ maxHeight: '300px', overflow: 'scroll' }}>
+        <Result result={this.state.result} bucketId={this.props.bucketId} onRedirect={this.onHide} />
+      </span>
+    );
   },
 
   renderNotSavedWarning() {
@@ -74,7 +78,7 @@ export default React.createClass({
           </p>
           <p>Tables defined in output mapping that does not yet exist in Storage are not validated.</p>
           {this.renderNotSavedWarning()}
-          <span style={{ maxHeight: '300px', overflow: 'scroll' }}>{this.renderResult()}</span>
+          {this.renderResult()}
         </span>
       );
     }

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -10,6 +10,7 @@ import Result from '../components/validation/Result';
 const INITIAL_STATE = {
   isLoading: false,
   isValid: false,
+  isRunning: false,
   result: null
 };
 
@@ -36,7 +37,7 @@ export default React.createClass({
         <Modal.Body>{this.renderBody()}</Modal.Body>
         <Modal.Footer>
           <ConfirmButtons
-            isSaving={this.state.isLoading}
+            isSaving={this.state.isLoading || this.state.isRunning}
             isDisabled={this.isDisabled()}
             onCancel={this.onHide}
             onSave={this.state.isValid ? this.onRunTransformation : this.onRunValidation}
@@ -89,19 +90,22 @@ export default React.createClass({
   },
 
   onHide() {
-    this.setState(INITIAL_STATE);
-    this.props.onHide();
+    this.setState(INITIAL_STATE, this.props.onHide);
   },
 
   onRunTransformation() {
-    InstalledComponentsActionCreators.runComponent({
-      component: 'transformation',
-      data: {
-        configBucketId: this.props.bucketId,
-        transformations: [this.props.transformation.get('id')]
-      }
+    this.setState({
+      isRunning: true
     });
-    this.onHide();
+    InstalledComponentsActionCreators
+      .runComponent({
+        component: 'transformation',
+        data: {
+          configBucketId: this.props.bucketId,
+          transformations: [this.props.transformation.get('id')]
+        }
+      })
+      .finally(this.onHide);
   },
 
   onRunValidation() {

--- a/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ValidateQueriesModal.jsx
@@ -40,14 +40,18 @@ export default React.createClass({
             isSaving={this.state.isLoading || this.state.isRunning}
             isDisabled={this.isDisabled()}
             onCancel={this.onHide}
-            onSave={this.state.isValid ? this.onRunTransformation : this.onRunValidation}
-            saveLabel={this.state.isValid ? 'Run transformation' : 'Validate'}
+            onSave={this.isEligibleToRun() ? this.onRunTransformation : this.onRunValidation}
+            saveLabel={this.isEligibleToRun() ? 'Run transformation' : 'Validate'}
             saveStyle="primary"
             saveButtonType="submit"
           />
         </Modal.Footer>
       </Modal>
     );
+  },
+
+  isEligibleToRun() {
+    return this.state.isValid && !this.props.transformation.get('disabled');
   },
 
   renderBody() {

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -214,7 +214,7 @@ export default React.createClass({
                 <ValidateQueriesButton
                   backend={backend}
                   bucketId={this.state.bucketId}
-                  transformationId={this.state.transformationId}
+                  transformation={this.state.transformation}
                   modalOpen={this.state.validateModalOpen}
                   onModalOpen={() => {
                     return this.setState({ validateModalOpen: true });


### PR DESCRIPTION
Fixes #2701

Jsem si říkal že upravím i ty dvě, tři komponenty když už tam něco upravuji. Jako klasika bootstrap komponenty apod. Je to rozděleno na commity, takže i kdyby ta funkce nešla použít třeba by šly jen ty úpravy nebo naopak.

Když je SQL validní tak jsem to také hodil do Alertu, přišlo mi že je to takové nevýrazné. Ale nevím zda to je takto lepší, ještě s tou ikonkou to je zas možná moc.

Pokud SQL projde tak tam skočí tlačítko "Run transformation". Pokud neprojde tak tam nebude.
Navíc jsem koukal že "disabled" transformace končí chybou takže pokud SQL projde a je transformace disabled tak tam tlačítko sice skočí ale je disabled. Není tam teda vysvětleno proč, nevím zda ještě nějak nedodat případně.