### PR TITLE
Storage Explorer - StorageActionsCreators

### DIFF
--- a/src/scripts/modules/components/StorageActionCreators.js
+++ b/src/scripts/modules/components/StorageActionCreators.js
@@ -921,11 +921,16 @@ module.exports = {
           return fileId;
         });
     }).catch(error => {
+      var message;
+      message = error;
+      if (error.message) {
+        message = error.message;
+      }
       dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_FILE_UPLOAD_ERROR,
         id: id
       });
-      throw error;
+      throw message;
     });
   },
 

--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -52,9 +52,7 @@ const deleteBucket = (bucketId, forceDelete) => {
 };
 
 const createTable = (bucketId, params) => {
-  return StorageActionCreators
-    .createTable(bucketId, params)
-    .catch(errorNotification);
+  return StorageActionCreators.createTable(bucketId, params);
 };
 
 const deleteTable = (bukcetId, tableId, forceDelete) => {
@@ -198,11 +196,7 @@ const unshareBucket = (bucketId) => {
 };
 
 const uploadFile = (id, file, params) => {
-  return StorageActionCreators
-    .uploadFile(id, file, params)
-    .catch(HttpError, error => {
-      throw error.message;
-    });
+  return StorageActionCreators.uploadFile(id, file, params);
 };
 
 const deleteFile = (fileId) => {

--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -17,16 +17,54 @@ const errorNotification = (message) => {
   });
 };
 
+const loadJobs = (params) => {
+  return StorageActionCreators.loadJobs(params);
+};
+
+const loadMoreJobs = (params) => {
+  return StorageActionCreators.loadMoreJobs(params);
+};
+
+const loadBuckets = () => {
+  return StorageActionCreators.loadBucketsForce();
+};
+
+const loadTable = (tableId, params) => {
+  return StorageActionCreators.loadTable(tableId, params);
+};
+
+const loadTables = () => {
+  return StorageActionCreators.loadTables();
+};
+
+const createBucket = (newBucket) => {
+  return StorageActionCreators
+    .createBucket(newBucket)
+    .then(bucket => {
+      navigateToBucketDetail(bucket.id);
+    });
+};
+
 const deleteBucket = (bucketId, forceDelete) => {
   return StorageActionCreators.deleteBucket(bucketId, forceDelete).then(() => {
     RoutesStore.getRouter().transitionTo('storage-explorer');
   });
 };
 
+const createTable = (bucketId, params) => {
+  return StorageActionCreators
+    .createTable(bucketId, params)
+    .catch(errorNotification);
+};
+
 const deleteTable = (bukcetId, tableId, forceDelete) => {
   return StorageActionCreators.deleteTable(tableId, forceDelete).then(() => {
     navigateToBucketDetail(bukcetId);
   });
+};
+
+const createAliasTable = (bucketId, params) => {
+  return StorageActionCreators.createAliasTable(bucketId, params);
 };
 
 const navigateToBucketDetail = bucketId => {
@@ -57,6 +95,22 @@ const addTableColumn = (tableId, params) => {
   return StorageActionCreators
     .addTableColumn(tableId, params)
     .catch(errorNotification);
+};
+
+const setAliasTableFilter = (tableId, params) => {
+  return StorageActionCreators
+    .setAliasTableFilter(tableId, params)
+    .catch(HttpError, error => {
+      throw error.message;
+    });
+};
+
+const removeAliasTableFilter = (tableId) => {
+  return StorageActionCreators
+    .removeAliasTableFilter(tableId)
+    .catch(HttpError, error => {
+      throw error.message;
+    });
 };
 
 const dataPreview = (tableId, params) => {
@@ -127,6 +181,39 @@ const exportTable = tableId => {
     });
 };
 
+const createSnapshot = (tableId, params) => {
+  return StorageActionCreators.createSnapshot(tableId, params);
+};
+
+const deleteSnapshot = (snapshotId) => {
+  return StorageActionCreators.deleteSnapshot(snapshotId);
+};
+
+const shareBucket = (bucketId, params) => {
+  return StorageActionCreators.shareBucket(bucketId, params);
+};
+
+const unshareBucket = (bucketId) => {
+  return StorageActionCreators.unshareBucket(bucketId);
+};
+
+const uploadFile = (id, file, params) => {
+  return StorageActionCreators
+    .uploadFile(id, file, params)
+    .catch(HttpError, error => {
+      throw error.message;
+    });
+};
+
+const deleteFile = (fileId) => {
+  return StorageActionCreators
+    .deleteFile(fileId)
+    .catch(HttpError, error => {
+      throw error.message;
+    })
+    .catch(errorNotification);
+};
+
 const loadFiles = params => {
   return StorageActionCreators
     .loadFilesForce(params)
@@ -162,19 +249,35 @@ const resetFilesSearchQuery = () => {
 };
 
 export {
+  loadJobs,
+  loadMoreJobs,
+  loadBuckets,
+  loadTable,
+  loadTables,
+  createBucket,
   deleteBucket,
+  createTable,
   deleteTable,
+  createAliasTable,
   navigateToBucketDetail,
   createTablePrimaryKey,
   removeTablePrimaryKey,
   deleteTableColumn,
   addTableColumn,
+  setAliasTableFilter,
+  removeAliasTableFilter,
   dataPreview,
   createTableFromSnapshot,
   restoreUsingTimeTravel,
   truncateTable,
   createTableFromTextInput,
   exportTable,
+  createSnapshot,
+  deleteSnapshot,
+  shareBucket,
+  unshareBucket,
+  uploadFile,
+  deleteFile,
   loadFiles,
   loadMoreFiles,
   updateFilesSearchQuery,

--- a/src/scripts/modules/storage-explorer/Routes.js
+++ b/src/scripts/modules/storage-explorer/Routes.js
@@ -5,15 +5,14 @@ import Table from './react/pages/Table/Table';
 import Bucket from './react/pages/Bucket/Bucket';
 import FilesReloaderButton from './react/components/FilesReloaderButton';
 import JobsReloaderButton from './react/components/JobsReloaderButton';
-import StorageActions from '../components/StorageActionCreators';
 import { filesLimit, jobsLimit } from './Constants';
-import { loadFiles, updateFilesSearchQuery } from './Actions';
+import { loadBuckets, loadTables, loadJobs, loadFiles, updateFilesSearchQuery } from './Actions';
 
 export default {
   name: 'storage-explorer',
   title: 'Storage Explorer',
   defaultRouteHandler: Index,
-  requireData: [() => StorageActions.loadBuckets(), () => StorageActions.loadTables()],
+  requireData: [() => loadBuckets(), () => loadTables()],
   childRoutes: [
     {
       name: 'storage-explorer-files',
@@ -40,7 +39,7 @@ export default {
       defaultRouteHandler: Jobs,
       reloaderHandler: JobsReloaderButton,
       title: 'Jobs',
-      requireData: [() => StorageActions.loadJobs({ limit: jobsLimit })]
+      requireData: [() => loadJobs({ limit: jobsLimit })]
     },
     {
       name: 'storage-explorer-bucket',

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -8,10 +8,9 @@ import matchByWords from '../../../../utils/matchByWords';
 import Tooltip from '../../../../react/common/Tooltip';
 import BucketsStore from '../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../components/stores/StorageTablesStore';
-import StorageActionCreators from '../../../components/StorageActionCreators';
 import CreateBucketModal from '../modals/CreateBucketModal';
 import BucketsList from './BucketsList';
-import { navigateToBucketDetail } from '../../Actions';
+import { loadBuckets, createBucket } from '../../Actions';
 
 export default React.createClass({
   mixins: [ImmutableRenderMixin, createStoreMixin(BucketsStore, TablesStore, ApplicationStore)],
@@ -58,7 +57,7 @@ export default React.createClass({
           </Button>
         </Tooltip>
         <Tooltip tooltip="Refresh buckets" placement="top">
-          <Button onClick={this.handleRefresh}>
+          <Button onClick={loadBuckets}>
             <RefreshIcon isLoading={this.state.isLoading} title="" />
           </Button>
         </Tooltip>
@@ -93,14 +92,8 @@ export default React.createClass({
     return buckets;
   },
 
-  handleRefresh() {
-    StorageActionCreators.loadBucketsForce();
-  },
-
   handleCreateBucket(newBucket) {
-    return StorageActionCreators.createBucket(newBucket).then(bucket => {
-      navigateToBucketDetail(bucket.id);
-    });
+    return createBucket(newBucket);
   },
 
   handleQueryChange(query) {

--- a/src/scripts/modules/storage-explorer/react/components/FilesReloaderButton.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/FilesReloaderButton.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
-import StorageActionCreators from '../../../components/StorageActionCreators';
 import FilesStore from '../../../components/stores/StorageFilesStore';
 import FilesLocalStore from '../../FilesLocalStore';
 import { filesLimit } from '../../Constants';
+import { loadFiles } from '../../Actions';
 import { RefreshIcon } from '@keboola/indigo-ui';
 
 export default React.createClass({
@@ -25,7 +25,7 @@ export default React.createClass({
       params.q = this.state.searchQuery;
     }
 
-    return StorageActionCreators.loadFilesForce(params);
+    return loadFiles(params);
   },
 
   render() {

--- a/src/scripts/modules/storage-explorer/react/components/JobsReloaderButton.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/JobsReloaderButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
-import StorageActionCreators from '../../../components/StorageActionCreators';
 import JobsStore from '../../../components/stores/StorageJobsStore';
 import { jobsLimit } from '../../Constants';
+import { loadJobs } from '../../Actions';
 import { RefreshIcon } from '@keboola/indigo-ui';
 
 export default React.createClass({
@@ -19,7 +19,7 @@ export default React.createClass({
       limit: jobsLimit
     };
 
-    return StorageActionCreators.loadJobs(params);
+    return loadJobs(params);
   },
 
   render() {

--- a/src/scripts/modules/storage-explorer/react/components/TableAliasFilter.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/TableAliasFilter.jsx
@@ -3,10 +3,10 @@ import { Map } from 'immutable';
 import { Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 
-import StorageActionCreators from '../../../components/StorageActionCreators';
 import Tooltip from '../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../react/common/ConfirmModal';
 import AliasFilterModal from '../modals/AliasFilterModal';
+import { setAliasTableFilter, removeAliasTableFilter } from '../../Actions';
 
 export default React.createClass({
   propTypes: {
@@ -113,7 +113,7 @@ export default React.createClass({
 
   handleSubmit(params) {
     const tableId = this.props.table.get('id');
-    return StorageActionCreators.setAliasTableFilter(tableId, params);
+    return setAliasTableFilter(tableId, params);
   },
 
   handleSetFilter(filterOptions) {
@@ -121,12 +121,12 @@ export default React.createClass({
     const params = {
       filterOptions
     };
-    return StorageActionCreators.setAliasTableFilter(tableId, params);
+    return setAliasTableFilter(tableId, params);
   },
 
   handleRemoveFilter() {
     const tableId = this.props.table.get('id');
-    return StorageActionCreators.removeAliasTableFilter(tableId);
+    return removeAliasTableFilter(tableId);
   },
 
   openUpdateModal() {

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -7,14 +7,13 @@ import RoutesStore from '../../../../../stores/RoutesStore';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 
 import { factory as eventsFactory } from '../../../../sapi-events/BucketEventsService';
 import BucketEvents from '../../components/Events';
 import DeleteBucketModal from '../../modals/DeleteBucketModal';
 import BucketOverview from './BucketOverview';
 import BucketTables from './BucketTables';
-import { deleteBucket, createTableFromTextInput } from '../../../Actions';
+import { createTable, deleteBucket, createAliasTable, createTableFromTextInput, uploadFile } from '../../../Actions';
 
 export default React.createClass({
   mixins: [createStoreMixin(BucketsStore, ApplicationStore, TablesStore, FilesStore)],
@@ -119,11 +118,8 @@ export default React.createClass({
 
   handleCreateTableFromCsv(file, params) {
     const bucketId = this.state.bucket.get('id');
-    return StorageActionCreators.uploadFile(bucketId, file).then(fileId => {
-      return StorageActionCreators.createTable(bucketId, {
-        ...params,
-        dataFileId: fileId
-      });
+    return uploadFile(bucketId, file).then(fileId => {
+      return createTable(bucketId, { ...params, dataFileId: fileId });
     });
   },
 
@@ -134,7 +130,7 @@ export default React.createClass({
 
   handleCreateAliasTable(params) {
     const bucketId = this.state.bucket.get('id');
-    return StorageActionCreators.createAliasTable(bucketId, params);
+    return createAliasTable(bucketId, params);
   },
 
   handleDeleteBucket() {

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
@@ -6,8 +6,8 @@ import Hint from '../../../../../react/common/Hint';
 import FileSize from '../../../../../react/common/FileSize';
 import Tooltip from '../../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../../react/common/ConfirmModal';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 import ShareBucketModal from '../../modals/ShareBucketModal';
+import { shareBucket, unshareBucket } from '../../../Actions';
 
 export default React.createClass({
   propTypes: {
@@ -172,13 +172,13 @@ export default React.createClass({
     const bucketId = this.props.bucket.get('id');
     const params = { sharing: sharingType };
 
-    return StorageActionCreators.shareBucket(bucketId, params);
+    return shareBucket(bucketId, params);
   },
 
   handleUnshareBucket() {
     const bucketId = this.props.bucket.get('id');
 
-    return StorageActionCreators.unshareBucket(bucketId);
+    return unshareBucket(bucketId);
   },
 
   sharingInfo(bucket) {

--- a/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Files/Files.jsx
@@ -8,12 +8,19 @@ import Tooltip from '../../../../../react/common/Tooltip';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
 import FilesLocalStore from '../../../FilesLocalStore';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 import FilesTable from '../../components/FilesTable';
 import NavButtons from '../../components/NavButtons';
 import UploadModal from '../../modals/UploadModal';
 import ExamplesModal from '../../modals/FilesSearchExamplesModal';
-import { loadFiles, loadMoreFiles, filterFiles, updateFilesSearchQuery, resetFilesSearchQuery } from '../../../Actions';
+import {
+  uploadFile,
+  deleteFile,
+  loadFiles,
+  loadMoreFiles,
+  filterFiles,
+  updateFilesSearchQuery,
+  resetFilesSearchQuery
+} from '../../../Actions';
 import { filesLimit } from '../../../Constants';
 
 const DIRECT_UPLOAD = 'direct-upload';
@@ -152,11 +159,11 @@ export default React.createClass({
   },
 
   handleUploadFile(file, params) {
-    return StorageActionCreators.uploadFile(DIRECT_UPLOAD, file, params).then(() => this.fetchFiles());
+    return uploadFile(DIRECT_UPLOAD, file, params).then(() => this.fetchFiles());
   },
 
   handleDeleteFile(fileId) {
-    return StorageActionCreators.deleteFile(fileId);
+    return deleteFile(fileId);
   },
 
   getSearchParams(offset) {

--- a/src/scripts/modules/storage-explorer/react/pages/Jobs/Jobs.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Jobs/Jobs.jsx
@@ -4,9 +4,9 @@ import { Button } from 'react-bootstrap';
 
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import JobsStore from '../../../../components/stores/StorageJobsStore';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 import JobsTable from '../../components/JobsTable';
 import { jobsLimit } from '../../../Constants';
+import { loadMoreJobs } from '../../../Actions';
 import NavButtons from '../../components/NavButtons';
 
 export default React.createClass({
@@ -63,6 +63,6 @@ export default React.createClass({
 
   fetchMoreJobs() {
     const offset = this.state.jobs.count();
-    return StorageActionCreators.loadMoreJobs(this.getParams(offset));
+    return loadMoreJobs(this.getParams(offset));
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/SnapshotRestore.jsx
@@ -7,12 +7,11 @@ import CreatedWithIcon from '../../../../../react/common/CreatedWithIcon';
 import Tooltip from '../../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../../react/common/ConfirmModal';
 import StorageApi from '../../../../components/StorageApi';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 
 import CreateSnapshotModal from '../../modals/CreateSnapshotModal';
 import CreateTableFromSnapshotModal from '../../modals/CreateTableFromSnapshotModal';
 import TimeTravelModal from '../../modals/TimeTravelModal';
-import { createTableFromSnapshot, restoreUsingTimeTravel } from '../../../Actions';
+import { createSnapshot, deleteSnapshot, createTableFromSnapshot, restoreUsingTimeTravel } from '../../../Actions';
 
 export default React.createClass({
   propTypes: {
@@ -300,7 +299,7 @@ export default React.createClass({
     const tableId = this.props.table.get('id');
     const params = { description };
 
-    return StorageActionCreators.createSnapshot(tableId, params).then(() => {
+    return createSnapshot(tableId, params).then(() => {
       this.refetchSnapshots();
     });
   },
@@ -317,7 +316,7 @@ export default React.createClass({
   handleRemoveSnapshot() {
     const snapshotId = this.state.selectedSnapshot.get('id');
 
-    return StorageActionCreators.deleteSnapshot(snapshotId).then(() => {
+    return deleteSnapshot(snapshotId).then(() => {
       this.setState({
         selectedSnapshot: null
       });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -11,9 +11,8 @@ import TablesStore from '../../../../components/stores/StorageTablesStore';
 import DataSample from '../../components/DataSample';
 import { deleteTable, truncateTable } from '../../../Actions';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
 import storageApi from '../../../../components/StorageApi';
-import { exportTable } from '../../../Actions';
+import { exportTable, uploadFile, loadTable } from '../../../Actions';
 
 import TruncateTableModal from '../../modals/TruncateTableModal';
 import DeleteTableModal from '../../modals/DeleteTableModal';
@@ -294,11 +293,8 @@ export default React.createClass({
     const bucketId = this.state.bucket.get('id');
     const tableId = this.state.table.get('id');
 
-    return StorageActionCreators.uploadFile(bucketId, file).then(fileId => {
-      return StorageActionCreators.loadTable(tableId, {
-        ...params,
-        dataFileId: fileId
-      });
+    return uploadFile(bucketId, file).then(fileId => {
+      return loadTable(tableId, { ...params, dataFileId: fileId });
     });
   },
 


### PR DESCRIPTION
Related #2402

Kvůli konzistenci jsem přesunul všechny akce do Action (ty které volaly akce z StorageActionsCreators).

U `uploadFile` jsem ještě upravil chytání erroru, aby chodila message. Zkoušel jsem to hodit jen do Action jako chytat HttpError, ale nezachytilo to. Tak jsem to upravil přímo ve "StorageActionCreators" stejně jak ostatní funkce tam.