### PR TITLE
RouterStore - update getCurrentRouteConfig 

### DIFF
--- a/src/scripts/stores/RoutesStore.js
+++ b/src/scripts/stores/RoutesStore.js
@@ -136,7 +136,7 @@ const RoutesStore = StoreUtils.createStore({
   },
 
   getCurrentRouteConfig() {
-    return _store.getIn(['routesByName', getCurrentRouteName(_store)]);
+    return getRoute(_store, getCurrentRouteName(_store));
   },
 
   getRouterState() {


### PR DESCRIPTION
Fixes #2716

Zvolil jsme jednu z těch možností které si nabídl. Tato se mi líbí více, u té druhé mohla být jedna routa v tom seznamu dvakrát tuším (když má `name` i `defaultRouteName`).¨

Lepší to asi opravit co nejdřív, i když to bylo tam vyřešeno jinak. Mohla by se ta "chyba" objevit někde jinde když by člověk zas použil "getCurrentRouteConfig". V tom Storage už to asi nechám jak to je, tam byl mixin i předtím, takže bych si moc nepomohl.