### PR TITLE
Use `expect` instead of `assert` in tests.

### DIFF
--- a/src/scripts/modules/app-snowflake-dwh-manager/adapters/row.spec.js
+++ b/src/scripts/modules/app-snowflake-dwh-manager/adapters/row.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration } from './row';
 import { cases } from './row.spec.def';
@@ -7,7 +6,7 @@ describe('row', function() {
   describe('createConfiguration()', function() {
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
@@ -15,7 +14,7 @@ describe('row', function() {
   describe('parseConfiguration()', function() {
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });

--- a/src/scripts/modules/billing/react/datesForMonthlyUsage.test.js
+++ b/src/scripts/modules/billing/react/datesForMonthlyUsage.test.js
@@ -1,48 +1,47 @@
-var assert = require('assert');
 var computeDatesForMonthlyUsage = require('./datesForMonthlyUsage').compute;
 var moment = require('moment');
 
 describe('computeDatesForMonthlyUsage', function() {
   describe('#computeDatesForMonthlyUsage()', function() {
     it('it should return previous day for both dates', function() {
-      assert.deepEqual(computeDatesForMonthlyUsage(
+      expect(computeDatesForMonthlyUsage(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2017-05-17') // projectCreation
-      ), {
+      )).toEqual({
         dateFrom: '2017-05-16',
         dateTo: '2017-05-16'
       });
     });
 
     it('it should return computation start date and previous day', function() {
-      assert.deepEqual(computeDatesForMonthlyUsage(
+      expect(computeDatesForMonthlyUsage(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment(null) // projectCreation not set
-      ), {
+      )).toEqual({
         dateFrom: '2017-01-01',
         dateTo: '2017-05-16'
       });
     });
 
     it('it should return computation start date and previous day', function() {
-      assert.deepEqual(computeDatesForMonthlyUsage(
+      expect(computeDatesForMonthlyUsage(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2016-08-01') // projectCreation before computation
-      ), {
+      )).toEqual({
         dateFrom: '2017-01-01',
         dateTo: '2017-05-16'
       });
     });
 
     it('it should return previous day for both dates', function() {
-      assert.deepEqual(computeDatesForMonthlyUsage(
+      expect(computeDatesForMonthlyUsage(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2017-05-30') // projectCreation in future
-      ), {
+      )).toEqual({
         dateFrom: '2017-05-16',
         dateTo: '2017-05-16'
       });

--- a/src/scripts/modules/components/utils/mappingDefinitions.spec.js
+++ b/src/scripts/modules/components/utils/mappingDefinitions.spec.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var mappingDefinitions = require('./mappingDefinitions');
 var Immutable = require('immutable');
 
@@ -20,13 +19,13 @@ describe('mappingDefinitions', function() {
       var value = Immutable.fromJS({
         destination: 'data.csv'
       });
-      assert.deepEqual(inputMappingDefinition.toJS(), mappingDefinitions.findInputMappingDefinition(inputMappingDefinitions, value).toJS());
+      expect(inputMappingDefinition.toJS()).toEqual(mappingDefinitions.findInputMappingDefinition(inputMappingDefinitions, value).toJS());
     });
     it('should return empty map when not present', function() {
       var value = Immutable.fromJS({
         destination: 'notfound.csv'
       });
-      assert.deepEqual({}, mappingDefinitions.findInputMappingDefinition(inputMappingDefinitions, value).toJS());
+      expect({}).toEqual(mappingDefinitions.findInputMappingDefinition(inputMappingDefinitions, value).toJS());
     });
   });
 
@@ -35,13 +34,13 @@ describe('mappingDefinitions', function() {
       var value = Immutable.fromJS({
         source: 'data.csv'
       });
-      assert.deepEqual(outputMappingDefinition.toJS(), mappingDefinitions.findOutputMappingDefinition(outputMappingDefinitions, value).toJS());
+      expect(outputMappingDefinition.toJS()).toEqual(mappingDefinitions.findOutputMappingDefinition(outputMappingDefinitions, value).toJS());
     });
     it('should return empty map when not present', function() {
       var value = Immutable.fromJS({
         source: 'notfound.csv'
       });
-      assert.deepEqual({}, mappingDefinitions.findOutputMappingDefinition(outputMappingDefinitions, value).toJS());
+      expect({}).toEqual(mappingDefinitions.findOutputMappingDefinition(outputMappingDefinitions, value).toJS());
     });
   });
 
@@ -54,7 +53,7 @@ describe('mappingDefinitions', function() {
           'destination': 'data.csv'
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
     });
     it('should add input mapping to an existing value', function() {
       const value = Immutable.fromJS(
@@ -75,7 +74,7 @@ describe('mappingDefinitions', function() {
           'destination': 'data.csv'
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
     });
     it('should not overwrite existing input mapping', function() {
       const value = Immutable.fromJS(
@@ -100,7 +99,7 @@ describe('mappingDefinitions', function() {
           'destination': 'data.csv'
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getInputMappingValue(inputMappingDefinitions, value).toJS());
     });
   });
 
@@ -114,7 +113,7 @@ describe('mappingDefinitions', function() {
           'destination': ''
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
     });
     it('should add out mapping to an existing value', function() {
       const value = Immutable.fromJS(
@@ -135,7 +134,7 @@ describe('mappingDefinitions', function() {
           'destination': ''
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
     });
     it('should not overwrite existing output mapping', function() {
       const value = Immutable.fromJS(
@@ -160,7 +159,7 @@ describe('mappingDefinitions', function() {
           'destination': 'out.c-main.data'
         }
       ];
-      assert.deepEqual(expected, mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
+      expect(expected).toEqual(mappingDefinitions.getOutputMappingValue(outputMappingDefinitions, value).toJS());
     });
   });
 });

--- a/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
+++ b/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
@@ -1,28 +1,27 @@
-var assert = require('assert');
 var preferEncryptedAttributes = require('./preferEncryptedAttributes');
 
 describe('preferEncryptedAttributes', function() {
   describe('#preferEncryptedAttributes()', function() {
     it('should return scalar when scalar', function() {
-      assert.equal('test', preferEncryptedAttributes('test'));
+      expect('test').toEqual(preferEncryptedAttributes('test'));
     });
 
     it('should return only encrypted key', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key1': 'val1',
         '#key1': 'val2'
-      }), {
+      })).toEqual({
         '#key1': 'val2'
       });
     });
 
     it('should return only encrypted key in array', function() {
-      assert.deepEqual(preferEncryptedAttributes([
+      expect(preferEncryptedAttributes([
         {
           'key1': 'val1',
           '#key1': 'val2'
         }
-      ]), [
+      ])).toEqual([
         {
           '#key1': 'val2'
         }
@@ -30,12 +29,12 @@ describe('preferEncryptedAttributes', function() {
     });
 
     it('should return only encrypted key in nested object', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key2': {
           'key1': 'val1',
           '#key1': 'val2'
         }
-      }), {
+      })).toEqual({
         'key2': {
           '#key1': 'val2'
         }
@@ -43,14 +42,14 @@ describe('preferEncryptedAttributes', function() {
     });
 
     it('should return only encrypted key in array nested', function() {
-      assert.deepEqual(preferEncryptedAttributes([
+      expect(preferEncryptedAttributes([
         {
           'key2': {
             'key1': 'val1',
             '#key1': 'val2'
           }
         }
-      ]), [
+      ])).toEqual([
         {
           'key2': {
             '#key1': 'val2'
@@ -60,31 +59,31 @@ describe('preferEncryptedAttributes', function() {
     });
 
     it('should replace by plain value if encrypted key is empty string', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key1': 'val2',
         '#key1': ''
-      }), {
+      })).toEqual({
         '#key1': 'val2'
       });
     });
 
     it('should replace by plain value if encrypted key is null', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key1': 'val2',
         '#key1': null
-      }), {
+      })).toEqual({
         '#key1': 'val2'
       });
     });
 
     // multiple
     it('should return only encrypted keys', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key1': 'val1',
         '#key1': 'val2',
         'key2': 'val3',
         '#key2': 'val4'
-      }), {
+      })).toEqual({
         '#key1': 'val2',
         '#key2': 'val4'
       });
@@ -92,7 +91,7 @@ describe('preferEncryptedAttributes', function() {
 
     // multiple nested
     it('should return only encrypted key in nested object', function() {
-      assert.deepEqual(preferEncryptedAttributes({
+      expect(preferEncryptedAttributes({
         'key2': {
           'key1': 'val1',
           '#key1': 'val2'
@@ -108,7 +107,7 @@ describe('preferEncryptedAttributes', function() {
           '#key5': 'val6'
         },
         '#key5': 'val7'
-      }), {
+      })).toEqual({
         'key2': {
           '#key1': 'val2'
         },

--- a/src/scripts/modules/components/utils/templateFinder.spec.js
+++ b/src/scripts/modules/components/utils/templateFinder.spec.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var Immutable = require('immutable');
 var templateFinder = require('./templateFinder');
 
@@ -35,17 +34,17 @@ describe('templateFinder', function() {
   describe('#templateFinder()', function() {
     it('should return 0 templates on empty config', function() {
       var config = Immutable.Map();
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on config with no matching keys', function() {
       var config = Immutable.fromJS({'someotherKey': false});
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on config with one matching key (of three)', function() {
       var config = Immutable.fromJS({'boolKey': true});
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 1 templates on match', function() {
@@ -54,7 +53,7 @@ describe('templateFinder', function() {
         'objectKey': {},
         'arrayKey': []
       });
-      assert.equal(1, templateFinder(templates, config).count());
+      expect(1).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on type mismatch', function() {
@@ -63,7 +62,7 @@ describe('templateFinder', function() {
         'objectKey': {},
         'arrayKey': []
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on type mismatch', function() {
@@ -72,7 +71,7 @@ describe('templateFinder', function() {
         'objectKey': [],
         'arrayKey': []
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on type mismatch', function() {
@@ -81,7 +80,7 @@ describe('templateFinder', function() {
         'objectKey': {},
         'arrayKey': {}
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 1 templates on deep match', function() {
@@ -102,7 +101,7 @@ describe('templateFinder', function() {
           }
         ]
       });
-      assert.equal(1, templateFinder(templates, config).count());
+      expect(1).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on deep mismatch', function() {
@@ -123,7 +122,7 @@ describe('templateFinder', function() {
           }
         ]
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on deep mismatch', function() {
@@ -144,7 +143,7 @@ describe('templateFinder', function() {
           }
         ]
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
 
     it('should return 0 templates on deep mismatch', function() {
@@ -165,7 +164,7 @@ describe('templateFinder', function() {
           }
         ]
       });
-      assert.equal(0, templateFinder(templates, config).count());
+      expect(0).toEqual(templateFinder(templates, config).count());
     });
   });
 });

--- a/src/scripts/modules/configurations/adapters/oauth.spec.js
+++ b/src/scripts/modules/configurations/adapters/oauth.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './oauth';
 import { cases } from './oauth.spec.def';
@@ -6,33 +5,33 @@ import { cases } from './oauth.spec.def';
 describe('oauth', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration and context', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({}), Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({}), Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration and context', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration), Immutable.fromJS(cases[key].context)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration), Immutable.fromJS(cases[key].context)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false if the config is not complete or empty', function() {
-      assert.equal(false, adapter.isComplete(Immutable.fromJS({})));
-      assert.equal(false, adapter.isComplete(Immutable.fromJS({authorization: {oauth_api: {id: ''}}})));
+      expect(false).toEqual(adapter.isComplete(Immutable.fromJS({})));
+      expect(false).toEqual(adapter.isComplete(Immutable.fromJS({authorization: {oauth_api: {id: ''}}})));
     });
     it('should return true if the config is complete', function() {
-      assert.equal(true, adapter.isComplete(Immutable.fromJS({authorization: {oauth_api: {id: 'test'}}})));
+      expect(true).toEqual(adapter.isComplete(Immutable.fromJS({authorization: {oauth_api: {id: 'test'}}})));
     });
   });
 });

--- a/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
+++ b/src/scripts/modules/configurations/utils/createColumnsEditorSection.spec.js
@@ -1,15 +1,14 @@
-import assert from 'assert';
-import React, {PropTypes} from 'react';
+import React, { PropTypes } from 'react';
 import createColumnsEditorSection from './createColumnsEditorSection';
-import {fromJS} from 'immutable';
+import { fromJS } from 'immutable';
 
-const ColumnMapping = ({column, disabled, onChange, showAdvanced, context}) => (
+const ColumnMapping = ({ column, disabled, onChange, showAdvanced, context }) => (
   <span disabled={disabled}>
     <div>{column.columnId}</div>
     <div>{column.type}</div>
     <div>{context.tableId}</div>
     <div>{context.columnsCount}</div>
-    <span onClick={() => onChange({...column, type: 'ignore'})}> ignore column</span>
+    <span onClick={() => onChange({ ...column, type: 'ignore' })}> ignore column</span>
     {showAdvanced && <span> show advanced</span>}
   </span>
 );
@@ -22,15 +21,16 @@ ColumnMapping.propTypes = {
   showAdvanced: PropTypes.bool
 };
 
-
 const configuration = fromJS({
   parameters: {
     storage: {
       input: {
-        tables: [{
-          source: 'in.some.table',
-          columns: ['age', 'person', 'deletedColumn']
-        }]
+        tables: [
+          {
+            source: 'in.some.table',
+            columns: ['age', 'person', 'deletedColumn']
+          }
+        ]
       }
     },
     tableId: 'in.some.table',
@@ -61,20 +61,22 @@ const sectionContext = fromJS({
 
 const editorSectionDefinition = {
   matchColumnKey: 'columnId',
-  onLoadColumns: (config) => config.getIn(['parameters', 'columns']),
-  onSaveColumns: (tableId, columnsList) => fromJS({
-    parameters: {
-      tableId: tableId,
-      columns: columnsList
-    }
-  }),
+  onLoadColumns: config => config.getIn(['parameters', 'columns']),
+  onSaveColumns: (tableId, columnsList) =>
+    fromJS({
+      parameters: {
+        tableId: tableId,
+        columns: columnsList
+      }
+    }),
   isColumnIgnored: column => column.get('type') === 'ignore',
-  initColumnFn: columnName => fromJS({columnId: columnName, type: 'ignore'}),
+  initColumnFn: columnName => fromJS({ columnId: columnName, type: 'ignore' }),
   isColumnValidFn: column => ['varchar', 'number'].includes(column.type),
-  prepareColumnContext: (context, allColumns) => fromJS({
-    tableId: context.getIn(['table', 'id']),
-    columnsCount: allColumns.count()
-  }),
+  prepareColumnContext: (context, allColumns) =>
+    fromJS({
+      tableId: context.getIn(['table', 'id']),
+      columnsCount: allColumns.count()
+    }),
   getInitialShowAdvanced: () => false,
   columnsMappings: [
     {
@@ -88,9 +90,51 @@ describe('columns editor section', () => {
   it('test onLoad and onSave section functions', () => {
     const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
     const localState = editorSection.onLoad(configuration, sectionContext);
-    assert.deepEqual(
-      localState.toJS(),
-      {
+    expect(localState.toJS()).toEqual({
+      columns: [
+        {
+          columnId: 'age',
+          type: 'number'
+        },
+        {
+          columnId: 'person',
+          type: 'varchar'
+        },
+        {
+          columnId: 'otherColumn',
+          type: 'ignore'
+        },
+        {
+          columnId: 'deletedColumn',
+          type: 'varchar'
+        }
+      ],
+      tableExist: true,
+      tableId: 'in.some.table',
+      columnsMappings: editorSectionDefinition.columnsMappings,
+      context: {
+        tableId: 'in.some.table',
+        columnsCount: 4
+      },
+      matchColumnKey: 'columnId',
+      getInitialShowAdvanced: editorSectionDefinition.getInitialShowAdvanced,
+      isColumnValidFn: editorSectionDefinition.isColumnValidFn
+    });
+
+    const configToSave = editorSection.onSave(localState);
+    expect(configToSave.toJS()).toEqual({
+      storage: {
+        input: {
+          tables: [
+            {
+              source: 'in.some.table',
+              columns: ['age', 'person', 'deletedColumn']
+            }
+          ]
+        }
+      },
+      parameters: {
+        tableId: 'in.some.table',
         columns: [
           {
             columnId: 'age',
@@ -101,89 +145,27 @@ describe('columns editor section', () => {
             type: 'varchar'
           },
           {
-            columnId: 'otherColumn',
-            type: 'ignore'
-          },
-          {
             columnId: 'deletedColumn',
             type: 'varchar'
           }
-        ],
-        tableExist: true,
-        tableId: 'in.some.table',
-        columnsMappings: editorSectionDefinition.columnsMappings,
-        context: {
-          tableId: 'in.some.table',
-          columnsCount: 4
-        },
-        matchColumnKey: 'columnId',
-        getInitialShowAdvanced: editorSectionDefinition.getInitialShowAdvanced,
-        isColumnValidFn: editorSectionDefinition.isColumnValidFn
+        ]
       }
-    );
-
-    const configToSave = editorSection.onSave(localState);
-    assert.deepEqual(
-      configToSave.toJS(),
-      {
-        storage: {
-          input: {
-            tables: [
-              {
-                source: 'in.some.table',
-                columns: [
-                  'age',
-                  'person',
-                  'deletedColumn'
-                ]
-              }
-            ]
-          }
-        },
-        parameters: {
-          tableId: 'in.some.table',
-          columns: [
-            {
-              columnId: 'age',
-              type: 'number'
-            },
-            {
-              columnId: 'person',
-              type: 'varchar'
-            },
-            {
-              columnId: 'deletedColumn',
-              type: 'varchar'
-            }
-          ]
-        }
-      }
-    );
+    });
   });
   it('test nonexisting table render', () => {
     const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
-    const nonExistingTableContext =  fromJS({
+    const nonExistingTableContext = fromJS({
       table: null,
       tableId: 'in.some.table'
     });
     const localState = editorSection.onLoad(configuration, nonExistingTableContext).toJS();
     const EditorComponent = editorSection.render;
-    renderSnapshot(
-      <EditorComponent
-        value={localState}
-        onChange={() => null}
-        disabled={false}/>
-    );
+    renderSnapshot(<EditorComponent value={localState} onChange={() => null} disabled={false} />);
   });
   it('test render', () => {
     const editorSection = createColumnsEditorSection(editorSectionDefinition).toJS();
     const localState = editorSection.onLoad(configuration, sectionContext).toJS();
     const EditorComponent = editorSection.render;
-    renderSnapshot(
-      <EditorComponent
-        value={localState}
-        onChange={() => null}
-        disabled={false}/>
-    );
+    renderSnapshot(<EditorComponent value={localState} onChange={() => null} disabled={false} />);
   });
 });

--- a/src/scripts/modules/configurations/utils/isParsableConfiguration.spec.js
+++ b/src/scripts/modules/configurations/utils/isParsableConfiguration.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import isParsableConfiguration from './isParsableConfiguration';
 
@@ -25,7 +24,7 @@ const parse = function(configuration) {
 describe('isParsableConfiguration', function() {
   it('empty configuration should be parsable', function() {
     const configuration = Immutable.fromJS({});
-    assert.equal(true, isParsableConfiguration(configuration, parse, create));
+    expect(true).toEqual(isParsableConfiguration(configuration, parse, create));
   });
   it('simple full configuration should be parsable', function() {
     const configuration = Immutable.fromJS({
@@ -36,7 +35,7 @@ describe('isParsableConfiguration', function() {
         key2: 'test4'
       }
     });
-    assert.equal(true, isParsableConfiguration(configuration, parse, create));
+    expect(true).toEqual(isParsableConfiguration(configuration, parse, create));
   });
   it('invalid configuration should not be parsable', function() {
     const configuration = Immutable.fromJS({
@@ -48,6 +47,6 @@ describe('isParsableConfiguration', function() {
         key2: 'test4'
       }
     });
-    assert.equal(false, isParsableConfiguration(configuration, parse, create));
+    expect(false).toEqual(isParsableConfiguration(configuration, parse, create));
   });
 });

--- a/src/scripts/modules/configurations/utils/sections.spec.js
+++ b/src/scripts/modules/configurations/utils/sections.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import sections from './sections';
 
@@ -35,7 +34,7 @@ describe('sections makeParseFn()', function() {
         key2: 'val2'
       }
     ];
-    assert.deepEqual(expected, parseFn(configuration).toJS());
+    expect(expected).toEqual(parseFn(configuration).toJS());
   });
   it('should not map invalid values', function() {
     const parseFn = sections.makeParseFn(sectionsDefinition, null);
@@ -54,7 +53,7 @@ describe('sections makeParseFn()', function() {
         key2: 'val2'
       }
     ];
-    assert.deepEqual(expected, parseFn(configuration).toJS());
+    expect(expected).toEqual(parseFn(configuration).toJS());
   });
 
   it('should use provided conform function', function() {
@@ -82,7 +81,7 @@ describe('sections makeParseFn()', function() {
         key2: 'val2'
       }
     ];
-    assert.deepEqual(expected, parseFn(configuration).toJS());
+    expect(expected).toEqual(parseFn(configuration).toJS());
   });
 });
 
@@ -123,7 +122,7 @@ describe('sections makeCreateFn()', function() {
         key2: 'val2'
       }
     };
-    assert.deepEqual(expected, createFn(localState).toJS());
+    expect(expected).toEqual(createFn(localState).toJS());
   });
   it('should not map invalid values', function() {
     const createFn = sections.makeCreateFn(sectionsDefinition);
@@ -143,7 +142,7 @@ describe('sections makeCreateFn()', function() {
         key2: 'val2'
       }
     };
-    assert.deepEqual(expected, createFn(localState).toJS());
+    expect(expected).toEqual(createFn(localState).toJS());
   });
 });
 
@@ -180,7 +179,7 @@ describe('sections makeCreateEmptyFn()', function() {
         key2: ''
       }
     };
-    assert.deepEqual(expected, createEmptyFn('myName', 'myWebalized').toJS());
+    expect(expected).toEqual(createEmptyFn('myName', 'myWebalized').toJS());
   });
 });
 
@@ -198,7 +197,7 @@ describe('sections isComplete', function() {
     }
   ]);
   it('should return true for a complete config', function() {
-    assert.equal(true, sections.isComplete(sectionsDefinition, Immutable.fromJS({
+    expect(true).toEqual(sections.isComplete(sectionsDefinition, Immutable.fromJS({
       parameters: {
         key1: 'val1',
         key2: 'val2'
@@ -206,16 +205,16 @@ describe('sections isComplete', function() {
     })));
   });
   it('should return false for an empty config', function() {
-    assert.equal(false, sections.isComplete(sectionsDefinition, Immutable.fromJS({})));
+    expect(false).toEqual(sections.isComplete(sectionsDefinition, Immutable.fromJS({})));
   });
   it('should return false for an incomplete complete config', function() {
-    assert.equal(false, sections.isComplete(sectionsDefinition, Immutable.fromJS({
+    expect(false).toEqual(sections.isComplete(sectionsDefinition, Immutable.fromJS({
       parameters: {
         key1: '',
         key2: 'val2'
       }
     })));
-    assert.equal(false, sections.isComplete(sectionsDefinition, Immutable.fromJS({
+    expect(false).toEqual(sections.isComplete(sectionsDefinition, Immutable.fromJS({
       parameters: {
         key1: 'val1',
         key2: ''
@@ -274,7 +273,7 @@ describe('sections parse(create())', function() {
         key2: 'value2'
       }
     });
-    assert.deepEqual(configuration.toJS(), createBySectionsFn(parseBySectionsFn(configuration)).toJS());
+    expect(configuration.toJS()).toEqual(createBySectionsFn(parseBySectionsFn(configuration)).toJS());
   });
 
   it('should deep merge', function() {
@@ -332,7 +331,7 @@ describe('sections parse(create())', function() {
         }
       }
     });
-    assert.deepEqual(configuration.toJS(), createBySectionsFn(parseBySectionsFn(configuration)).toJS());
+    expect(configuration.toJS()).toEqual(createBySectionsFn(parseBySectionsFn(configuration)).toJS());
   });
 
   it('unknown key shall not pass', function() {
@@ -372,7 +371,7 @@ describe('sections parse(create())', function() {
         key: 'value'
       }
     };
-    assert.deepEqual(expected, createBySectionsFn(parseBySectionsFn(configuration)).toJS());
+    expect(expected).toEqual(createBySectionsFn(parseBySectionsFn(configuration)).toJS());
   });
 
   it('should aggressively conform parsed config with missing value', function() {
@@ -391,7 +390,7 @@ describe('sections parse(create())', function() {
     const rowSections = Immutable.fromJS([{onLoad, onSave}]);
     const parseBySectionsFn = sections.makeParseFn(rowSections, conformFn);
     const createBySectionsFn = sections.makeCreateFn(rowSections);
-    assert.deepEqual(expected, createBySectionsFn(parseBySectionsFn(configuration)).toJS());
+    expect(expected).toEqual(createBySectionsFn(parseBySectionsFn(configuration)).toJS());
   });
 
   it('should conform parsed config with existing value', function() {
@@ -409,7 +408,7 @@ describe('sections parse(create())', function() {
     const rowSections = Immutable.fromJS([{onLoad, onSave}]);
     const parseBySectionsFn = sections.makeParseFn(rowSections, conformFn);
     const createBySectionsFn = sections.makeCreateFn(rowSections);
-    assert.deepEqual(expected, createBySectionsFn(parseBySectionsFn(configuration)).toJS());
+    expect(expected).toEqual(createBySectionsFn(parseBySectionsFn(configuration)).toJS());
   });
 
   it('should pass context to section parse section fn', function() {
@@ -431,6 +430,6 @@ describe('sections parse(create())', function() {
     const rowSections = Immutable.fromJS([{onLoad}]);
     const parseBySectionsFn = sections.makeParseFn(rowSections, null, context);
     const localState = parseBySectionsFn(configuration);
-    assert.deepEqual(expectedSectionsLocalState, localState.toJS());
+    expect(expectedSectionsLocalState).toEqual(localState.toJS());
   });
 });

--- a/src/scripts/modules/ex-aws-s3/adapters/conform.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/conform.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import conform  from './conform';
 
@@ -81,7 +80,7 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
   it('should remove columns property from processor-create-manifest if columns_from is set to auto', function() {
     const configuration = {
@@ -161,7 +160,7 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
 
   it('should not remove columns property from processor-create-manifest if columns_from is not set', function() {
@@ -241,6 +240,6 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
 });

--- a/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/credentials.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, isComplete } from './credentials';
 import { cases } from './credentials.spec.def';
@@ -6,36 +5,36 @@ import { cases } from './credentials.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({})));
     });
     it('should return false with only one parameter filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {accessKeyId: 'a'}})), false);
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'#secretAccessKey': 'a'}})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({parameters: {accessKeyId: 'a'}})));
+      expect(false).toEqual(isComplete(Immutable.fromJS({parameters: {'#secretAccessKey': 'a'}})));
     });
     it('should return true when both parameters are filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'accessKeyId': 'a', '#secretAccessKey': 'a'}})), true);
+      expect(true).toEqual(isComplete(Immutable.fromJS({parameters: {'accessKeyId': 'a', '#secretAccessKey': 'a'}})));
     });
   });
 });

--- a/src/scripts/modules/ex-aws-s3/adapters/row.spec.js
+++ b/src/scripts/modules/ex-aws-s3/adapters/row.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, createEmptyConfiguration } from './row';
 import { cases } from './row.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './row.spec.def';
 describe('row', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default config with the webalized name filled in', function() {
-      assert.deepEqual(createEmptyConfiguration('My Test', 'my-test').toJS(), createConfiguration(Immutable.fromJS({name: 'my-test'})).toJS());
+      expect(createEmptyConfiguration('My Test', 'my-test').toJS()).toEqual(createConfiguration(Immutable.fromJS({name: 'my-test'})).toJS());
     });
   });
 });

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
@@ -1,5 +1,3 @@
-let assert = require('assert');
-
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -25,10 +23,7 @@ const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysq
 describe('shouldDestinationHaveOldFormat test 1', function() {
   describe('shouldDestinationHaveOldFormat', function() {
     it('it should have new format (no tables)', function() {
-      assert.equal(
-        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
-        false
-      );
+      expect(false).toEqual(store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'));
     });
   });
 });

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
@@ -1,5 +1,3 @@
-let assert = require('assert');
-
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -39,10 +37,7 @@ const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysq
 describe('shouldDestinationHaveOldFormat test 2', function() {
   describe('shouldDestinationHaveOldFormat', function() {
     it('it should have old format (only old tables)', function() {
-      assert.equal(
-        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
-        true
-      );
+      expect(true).toEqual(store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'));
     });
   });
 });

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
@@ -1,5 +1,3 @@
-let assert = require('assert');
-
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -33,10 +31,7 @@ const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysq
 describe('shouldDestinationHaveOldFormat test 3', function() {
   describe('shouldDestinationHaveOldFormat', function() {
     it('it should have new format (custom destination)', function() {
-      assert.equal(
-        store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'),
-        false
-      );
+      expect(false).toEqual(store.shouldDestinationHaveOldFormat('in.c-keboola-ex-db-mysql'));
     });
   });
 });

--- a/src/scripts/modules/ex-ftp/adapters/SourcePath.js
+++ b/src/scripts/modules/ex-ftp/adapters/SourcePath.js
@@ -127,7 +127,7 @@ const parseConfiguration = function(configuration) {
   return Immutable.fromJS({
     path: configuration.getIn(['parameters', 'path'], ''),
     name: processorMoveFiles.getIn(['parameters', 'folder'], ''),
-    onlyNewFiles: configuration.getIn(['parameters', 'onlyNewFiles'], ''),
+    onlyNewFiles: configuration.getIn(['parameters', 'onlyNewFiles'], false),
     incremental: processorCreateManifest.getIn(['parameters', 'incremental'], false),
     primaryKey: processorCreateManifest.getIn(['parameters', 'primary_key'], Immutable.List()).toJS(),
     delimiter: processorCreateManifest.getIn(['parameters', 'delimiter'], ','),

--- a/src/scripts/modules/ex-ftp/adapters/SourcePath.spec.js
+++ b/src/scripts/modules/ex-ftp/adapters/SourcePath.spec.js
@@ -1,30 +1,33 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import sourcePathAdapter from './SourcePath';
-import {cases} from './SourcePath.spec.def';
+import { cases } from './SourcePath.spec.def';
 
 describe('sourcePath', function() {
   describe('createConfiguration', function() {
     it('should return default configuration', function() {
-      assert.deepEqual(
-        cases.emptyWithDefaults.configuration,
-        sourcePathAdapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(
+        sourcePathAdapter
+          .createConfiguration(Immutable.fromJS(sourcePathAdapter.createConfiguration(Immutable.fromJS({})).toJS()))
+          .toJS()
+      );
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, sourcePathAdapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(
+          sourcePathAdapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS()
+        );
       });
     });
   });
   describe('parseConfiguration', function() {
     it('should return default configuration', function() {
-      assert.deepEqual(
-        cases.emptyWithDefaults.localState,
-        sourcePathAdapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(sourcePathAdapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].localState, sourcePathAdapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(
+          sourcePathAdapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS()
+        );
       });
     });
   });

--- a/src/scripts/modules/ex-ftp/adapters/SourceServer.spec.js
+++ b/src/scripts/modules/ex-ftp/adapters/SourceServer.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import sourceServerAdapter from './SourceServer';
 import {cases} from './SourceServer.spec.def';
@@ -6,25 +5,21 @@ import {cases} from './SourceServer.spec.def';
 describe('sourceServer', function() {
   describe('createConfiguration', function() {
     it('should return default configuration', function() {
-      assert.deepEqual(
-        cases.emptyConfig.configuration,
-        sourceServerAdapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyConfig.configuration).toEqual(sourceServerAdapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, sourceServerAdapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(sourceServerAdapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
   describe('parseConfiguration', function() {
     it('should return default configuration', function() {
-      assert.deepEqual(
-        cases.emptyConfig.localState,
-        sourceServerAdapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyConfig.localState).toEqual(sourceServerAdapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for local state with ' + key, function() {
-        assert.deepEqual(cases[key].localState, sourceServerAdapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(sourceServerAdapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });

--- a/src/scripts/modules/ex-http/adapters/conform.spec.js
+++ b/src/scripts/modules/ex-http/adapters/conform.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import conform  from './conform';
 
@@ -81,7 +80,7 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
   it('should remove columns property from processor-create-manifest if columns_from is set to auto', function() {
     const configuration = {
@@ -161,7 +160,7 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
 
   it('should not remove columns property from processor-create-manifest if columns_from is not set', function() {
@@ -241,6 +240,6 @@ describe('conform', function() {
         ]
       }
     };
-    assert.deepEqual(expected, conform(Immutable.fromJS(configuration)).toJS());
+    expect(expected).toEqual(conform(Immutable.fromJS(configuration)).toJS());
   });
 });

--- a/src/scripts/modules/ex-http/adapters/credentials.spec.js
+++ b/src/scripts/modules/ex-http/adapters/credentials.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, isComplete } from './credentials';
 import { cases } from './credentials.spec.def';
@@ -6,32 +5,32 @@ import { cases } from './credentials.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({})));
     });
     it('should return true when parameters are filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'baseUrl': 'a'}})), true);
+      expect(true).toEqual(isComplete(Immutable.fromJS({parameters: {'baseUrl': 'a'}})));
     });
   });
 });

--- a/src/scripts/modules/ex-http/adapters/row.spec.js
+++ b/src/scripts/modules/ex-http/adapters/row.spec.js
@@ -1,34 +1,33 @@
-import assert from 'assert';
 import Immutable from 'immutable';
-import { createConfiguration, parseConfiguration, createEmptyConfiguration }  from './row';
+import { createConfiguration, parseConfiguration, createEmptyConfiguration } from './row';
 import { cases } from './row.spec.def';
 
 describe('row', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default config with the webalized name filled in', function() {
-      assert.deepEqual(createEmptyConfiguration('My Test', 'my-test').toJS(), createConfiguration(Immutable.fromJS({name: 'my-test'})).toJS());
+      expect(createEmptyConfiguration('My Test', 'my-test').toJS()).toEqual(createConfiguration(Immutable.fromJS({ name: 'my-test' })).toJS());
     });
   });
 });

--- a/src/scripts/modules/ex-mongodb/storeProvisioning.test.js
+++ b/src/scripts/modules/ex-mongodb/storeProvisioning.test.js
@@ -1,53 +1,52 @@
-import assert from 'assert';
 import { Map } from 'immutable';
 import { isJsonValid, isMappingValid, isValidQuery } from './storeProvisioning';
 
 describe('mongodb export validation', function() {
   describe('validate json', function() {
     it('should return that json is valid for: {"a": "b"} ', function() {
-      assert.equal(true, isJsonValid('{"a": "b"}'));
+      expect(true).toEqual(isJsonValid('{"a": "b"}'));
     });
     it('should return that json is not valid for: {"a": "b}', function() {
-      assert.equal(false, isJsonValid('{"a": "b}'));
+      expect(false).toEqual(isJsonValid('{"a": "b}'));
     });
     it('should return that json is not valid for: (empty string)', function() {
-      assert.equal(false, isJsonValid(''));
+      expect(false).toEqual(isJsonValid(''));
     });
     it('should return that json is not valid', function() {
-      assert.equal(false, isJsonValid(null));
+      expect(false).toEqual(isJsonValid(null));
     });
     it('should return that json is not valid', function() {
-      assert.equal(false, isJsonValid());
+      expect(false).toEqual(isJsonValid());
     });
   });
 
   describe('validate mapping', function() {
     it('should return that mapping is valid for: {"a": "b"}', function() {
-      assert.equal(true, isMappingValid('{"a": "b"}'));
+      expect(true).toEqual(isMappingValid('{"a": "b"}'));
     });
     it('should return that mapping is valid for Map({"a": "b"})', function() {
-      assert.equal(true, isMappingValid(Map({'a': 'b'})));
+      expect(true).toEqual(isMappingValid(Map({'a': 'b'})));
     });
     it('should return that mapping is not valid for: {"a": "b}', function() {
-      assert.equal(false, isMappingValid('{"a": "b}'));
+      expect(false).toEqual(isMappingValid('{"a": "b}'));
     });
     it('should return that mapping is not valid for: (empty string)', function() {
-      assert.equal(false, isMappingValid(''));
+      expect(false).toEqual(isMappingValid(''));
     });
   });
 
   describe('validate whole export', function() {
     it('should return that mapping is valid for Map({"name": "b", "collection": "b", "mode": "raw"})', function() {
-      assert.equal(true, isValidQuery(Map({'name': 'b', 'collection': 'b', 'mode': 'raw'})));
+      expect(true).toEqual(isValidQuery(Map({'name': 'b', 'collection': 'b', 'mode': 'raw'})));
     });
     it('should return that mapping is valid for Map({"name": "b", "collection": "b", "mapping": Map({"a": "b"})})', function() {
-      assert.equal(true, isValidQuery(Map({'name': 'b', 'collection': 'b', 'mapping': Map({'a': 'b'})})));
+      expect(true).toEqual(isValidQuery(Map({'name': 'b', 'collection': 'b', 'mapping': Map({'a': 'b'})})));
     });
     it('should return that mapping is valid for Map({"name": "b", "collection": "b", "mapping": \'{"a": "b"}\'})', function() {
-      assert.equal(true, isValidQuery(Map({'name': 'b', 'collection': 'b', 'mapping': '{"a": "b"}'})));
+      expect(true).toEqual(isValidQuery(Map({'name': 'b', 'collection': 'b', 'mapping': '{"a": "b"}'})));
     });
     it('should return that mapping is not valid for Map({"name": "b", "collection": "b"})', function() {
-      assert.equal(false, isValidQuery(Map({'name': 'b', 'collection': 'b'})));
+      expect(false).toEqual(isValidQuery(Map({'name': 'b', 'collection': 'b'})));
     });
   });
 });

--- a/src/scripts/modules/ex-s3/utils.spec.js
+++ b/src/scripts/modules/ex-s3/utils.spec.js
@@ -175,6 +175,7 @@ describe('utils', function() {
       expect(true).toEqual(hasWildcard('*'));
     });
     it('should return false on string without wildcard', function() {
+      expect(false).toEqual(hasWildcard('my*key'));
     });
     it('should return true on wildcard', function() {
       expect(true).toEqual(hasWildcard('myKey*'));

--- a/src/scripts/modules/ex-s3/utils.spec.js
+++ b/src/scripts/modules/ex-s3/utils.spec.js
@@ -1,4 +1,3 @@
-var assert = require('assert');
 var Immutable = require('immutable');
 var getDefaultTable = require('./utils').getDefaultTable;
 var hasWildcard = require('./utils').hasWildcard;
@@ -158,60 +157,59 @@ const wildcardConfiguration = {
 describe('utils', function() {
   describe('#getDefaultTable()', function() {
     it('should return default table', function() {
-      assert.equal('in.c-keboola-ex-s3-123.data', getDefaultTable('123'));
+      expect('in.c-keboola-ex-s3-123.data').toEqual(getDefaultTable('123'));
     });
   });
 
   describe('#getDefaultBucket()', function() {
     it('should return default bucket', function() {
-      assert.equal('in.c-keboola-ex-s3-123', getDefaultBucket('123'));
+      expect('in.c-keboola-ex-s3-123').toEqual(getDefaultBucket('123'));
     });
   });
 
   describe('#hasWildcard()', function() {
     it('should return false on empty string', function() {
-      assert.equal(false, hasWildcard(''));
+      expect(false).toEqual(hasWildcard(''));
     });
     it('should return true on wildcard only', function() {
-      assert.equal(true, hasWildcard('*'));
+      expect(true).toEqual(hasWildcard('*'));
     });
     it('should return false on string without wildcard', function() {
-      assert.equal(false, hasWildcard('my*key'));
     });
     it('should return true on wildcard', function() {
-      assert.equal(true, hasWildcard('myKey*'));
+      expect(true).toEqual(hasWildcard('myKey*'));
     });
   });
 
   describe('#createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(emptyConfigurationWithDefauls, createConfiguration(Immutable.fromJS(emptyLocalState), 'test'));
+      expect(emptyConfigurationWithDefauls).toEqual(createConfiguration(Immutable.fromJS(emptyLocalState), 'test'));
     });
     it('should return an empty config with defaults from a local state with defaults', function() {
-      assert.deepEqual(emptyConfigurationWithDefauls, createConfiguration(Immutable.fromJS(emptyLocalStateWithDefaults), 'test'));
+      expect(emptyConfigurationWithDefauls).toEqual(createConfiguration(Immutable.fromJS(emptyLocalStateWithDefaults), 'test'));
     });
 
     it('should return a valid config for a single file local state', function() {
-      assert.deepEqual(singleFileConfiguration, createConfiguration(Immutable.fromJS(singleFileLocalState), 'test'));
+      expect(singleFileConfiguration).toEqual(createConfiguration(Immutable.fromJS(singleFileLocalState), 'test'));
     });
 
     it('should return a valid config for a wildcard local state', function() {
-      assert.deepEqual(wildcardConfiguration, createConfiguration(Immutable.fromJS(wildcardLocalState), 'test'));
+      expect(wildcardConfiguration).toEqual(createConfiguration(Immutable.fromJS(wildcardLocalState), 'test'));
     });
   });
 
   describe('#parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(emptyLocalStateWithDefaults, parseConfiguration(emptyConfiguration, 'test'));
+      expect(emptyLocalStateWithDefaults).toEqual(parseConfiguration(emptyConfiguration, 'test'));
     });
     it('should return empty localState with defaults from empty configuration with defaults', function() {
-      assert.deepEqual(emptyLocalStateWithDefaults, parseConfiguration(emptyConfigurationWithDefauls, 'test'));
+      expect(emptyLocalStateWithDefaults).toEqual(parseConfiguration(emptyConfigurationWithDefauls, 'test'));
     });
     it('should return a correct single file localState', function() {
-      assert.deepEqual(singleFileLocalState, parseConfiguration(singleFileConfiguration, 'test'));
+      expect(singleFileLocalState).toEqual(parseConfiguration(singleFileConfiguration, 'test'));
     });
     it('should return a correct wildcard localState', function() {
-      assert.deepEqual(wildcardLocalState, parseConfiguration(wildcardConfiguration, 'test'));
+      expect(wildcardLocalState).toEqual(parseConfiguration(wildcardConfiguration, 'test'));
     });
   });
 });

--- a/src/scripts/modules/ex-storage/adapters/saveSettings.spec.js
+++ b/src/scripts/modules/ex-storage/adapters/saveSettings.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './saveSettings';
 import { cases } from './saveSettings.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './saveSettings.spec.def';
 describe('row', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default config with the webalized name filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration().toJS(), adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(adapter.createEmptyConfiguration().toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
   });
 });

--- a/src/scripts/modules/ex-storage/adapters/sourceProject.spec.js
+++ b/src/scripts/modules/ex-storage/adapters/sourceProject.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './sourceProject';
 import { cases } from './sourceProject.spec.def';
@@ -6,32 +5,32 @@ import { cases } from './sourceProject.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(adapter.isComplete(Immutable.fromJS({})));
     });
     it('should return true when parameters are filled', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({parameters: {'url': 'a', '#token': 'b', 'bucket': 'c'}})), true);
+      expect(true).toEqual(adapter.isComplete(Immutable.fromJS({parameters: {'url': 'a', '#token': 'b', 'bucket': 'c'}})));
     });
   });
 });

--- a/src/scripts/modules/ex-storage/adapters/sourceTable.spec.js
+++ b/src/scripts/modules/ex-storage/adapters/sourceTable.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './sourceTable';
 import { cases } from './sourceTable.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './sourceTable.spec.def';
 describe('inputMapping', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default configuration with the table details filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration('in.c-bucket.test').toJS(), adapter.createConfiguration(Immutable.fromJS({source: 'in.c-bucket.test'})).toJS());
+      expect(adapter.createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({source: 'in.c-bucket.test'})).toJS());
     });
   });
 });

--- a/src/scripts/modules/gooddata-writer-v3/helpers/getInitialShowAdvanced.spec.js
+++ b/src/scripts/modules/gooddata-writer-v3/helpers/getInitialShowAdvanced.spec.js
@@ -1,9 +1,8 @@
-import assert from 'assert';
 import getInitialShowAdvanced from './getInitialShowAdvanced';
 
 describe('get initial show advanced test', () => {
   it('should test empty columns case', () => {
-    assert.ok(!getInitialShowAdvanced([]));
+    expect(true).toEqual(!getInitialShowAdvanced([]));
   });
 
   it('should test nonempty columns case and return false', () => {
@@ -11,7 +10,7 @@ describe('get initial show advanced test', () => {
       {bar: 'identifier'},
       {a: 1}
     ];
-    assert.ok(!getInitialShowAdvanced(columns));
+    expect(true).toEqual(!getInitialShowAdvanced(columns));
   });
 
   it('should test nonempty columns case and return true', () => {
@@ -21,6 +20,6 @@ describe('get initial show advanced test', () => {
       {identifierSortLabel: 'foo bar'},
       {a: 1}
     ];
-    assert.ok(getInitialShowAdvanced(columns));
+    expect(true).toEqual(getInitialShowAdvanced(columns));
   });
 });

--- a/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.spec.js
+++ b/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.spec.js
@@ -1,6 +1,5 @@
 import makeColumnDefinition from './makeColumnDefinition';
-import {Types, DataTypes} from '../constants';
-import assert from 'assert';
+import { Types, DataTypes } from '../constants';
 
 describe('makeColumnDefinition', () => {
   it('test empty connection point setup', () => {
@@ -8,17 +7,17 @@ describe('makeColumnDefinition', () => {
       id: 'id',
       type: Types.CONNECTION_POINT
     });
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: 'IGNORE'
     });
-    assert.deepEqual(definition.fields.title, {
+    expect(definition.fields.title).toEqual({
       show: true,
       invalidReason: 'GoodData Title can not be empty',
       defaultValue: 'id'
     });
-    assert.deepEqual(definition.fields.dataType, {
+    expect(definition.fields.dataType).toEqual({
       show: true
     });
   });
@@ -32,32 +31,32 @@ describe('makeColumnDefinition', () => {
       dataTypeSize: '255'
     });
 
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: 'IGNORE'
     });
-    assert.deepEqual(definition.fields.title, {
+    expect(definition.fields.title).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: 'id'
     });
-    assert.deepEqual(definition.fields.dataType, {
+    expect(definition.fields.dataType).toEqual({
       show: true
     });
     delete definition.fields.dataTypeSize.onChange;
-    assert.deepEqual(definition.fields.dataTypeSize, {
+    expect(definition.fields.dataTypeSize).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: '255'
     });
-    assert.deepEqual(definition.fields.identifier, {
+    expect(definition.fields.identifier).toEqual({
       show: true
     });
-    assert.deepEqual(definition.fields.identifierLabel, {
+    expect(definition.fields.identifierLabel).toEqual({
       show: true
     });
-    assert.deepEqual(definition.fields.identifierSortLabel, {
+    expect(definition.fields.identifierSortLabel).toEqual({
       show: true
     });
   });
@@ -69,27 +68,26 @@ describe('makeColumnDefinition', () => {
       title: 'datum',
       dateDimension: 'dimenze'
     });
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: 'IGNORE'
     });
-    assert.deepEqual(definition.fields.title, {
+    expect(definition.fields.title).toEqual({
       show: false,
       invalidReason: false,
       defaultValue: 'date'
     });
-    assert.deepEqual(definition.fields.dateDimension, {
+    expect(definition.fields.dateDimension).toEqual({
       show: true,
       invalidReason: false
     });
-    assert.deepEqual(definition.fields.format, {
+    expect(definition.fields.format).toEqual({
       show: true,
       invalidReason: 'Date format can not be empty',
       defaultValue: 'yyyy-MM-dd HH:mm:ss'
     });
   });
-
 
   it('test schema reference setup', () => {
     const definition = makeColumnDefinition({
@@ -97,12 +95,12 @@ describe('makeColumnDefinition', () => {
       type: Types.REFERENCE,
       schemaReference: 'tableId'
     });
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       invalidReason: false,
       defaultValue: 'IGNORE'
     });
-    assert.deepEqual(definition.fields.schemaReference, {
+    expect(definition.fields.schemaReference).toEqual({
       show: true
     });
   });

--- a/src/scripts/modules/gooddata-writer-v3/helpers/prepareColumnContext.spec.js
+++ b/src/scripts/modules/gooddata-writer-v3/helpers/prepareColumnContext.spec.js
@@ -1,6 +1,5 @@
-import assert from 'assert';
 import prepareColumnContext from './prepareColumnContext';
-import {fromJS, Map, List} from 'immutable';
+import { fromJS, Map, List } from 'immutable';
 
 const tableId = 'in.some.table';
 const configuration = fromJS({
@@ -51,7 +50,6 @@ const allColumns = fromJS([
     id: 'id',
     type: 'CONNECTION_POINT',
     title: 'id'
-
   },
   {
     type: 'ATTRIBUTE',
@@ -69,42 +67,25 @@ const allColumns = fromJS([
 describe('prepareColumnContext tests', () => {
   it('should pass empty', () => {
     const columnContext = prepareColumnContext(Map(), Map(), tableId, List());
-    assert.deepEqual(
-      columnContext.toJS(),
-      {
-        referencableTables: [],
-        referencableColumns: [],
-        sortLabelsColumns: {},
-        dimensions: []
-      }
-    );
+    expect(columnContext.toJS()).toEqual({
+      referencableTables: [],
+      referencableColumns: [],
+      sortLabelsColumns: {},
+      dimensions: []
+    });
   });
 
   it('should pass with some context and columns', () => {
     const configParameters = configuration.get('parameters');
     const allTables = configuration.getIn(['parameters', 'tables']);
     const columnContext = prepareColumnContext(configParameters, allTables, tableId, allColumns);
-    assert.deepEqual(
-      columnContext.toJS(),
-      {
-        referencableTables: [
-          'in.OTHER.TABLE'
-        ],
-        referencableColumns: [
-          'id',
-          'city'
-        ],
-        sortLabelsColumns: {
-          name: [
-            'refColumn'
-          ]
-        },
-        dimensions: [
-          'dim1',
-          'dim2',
-          'dim3'
-        ]
-      }
-    );
+    expect(columnContext.toJS()).toEqual({
+      referencableTables: ['in.OTHER.TABLE'],
+      referencableColumns: ['id', 'city'],
+      sortLabelsColumns: {
+        name: ['refColumn']
+      },
+      dimensions: ['dim1', 'dim2', 'dim3']
+    });
   });
 });

--- a/src/scripts/modules/htns.ex-salesforce/adapters/credentials.spec.js
+++ b/src/scripts/modules/htns.ex-salesforce/adapters/credentials.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, isComplete } from './credentials';
 import { cases } from './credentials.spec.def';
@@ -6,37 +5,37 @@ import { cases } from './credentials.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({})));
     });
     it('should return false with only one parameter filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'loginname': 'a'}})), false);
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'#password': 'a'}})), false);
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'#securitytoken': 'a'}})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({ parameters: { loginname: 'a' } })));
+      expect(false).toEqual(isComplete(Immutable.fromJS({ parameters: { '#password': 'a' } })));
+      expect(false).toEqual(isComplete(Immutable.fromJS({ parameters: { '#securitytoken': 'a' } })));
     });
     it('should return true when all parameters are filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'loginname': 'a', '#password': 'a', '#securitytoken': 'a'}})), true);
+      expect(true).toEqual(isComplete(Immutable.fromJS({ parameters: { loginname: 'a', '#password': 'a', '#securitytoken': 'a' } })));
     });
   });
 });

--- a/src/scripts/modules/htns.ex-salesforce/adapters/row.spec.js
+++ b/src/scripts/modules/htns.ex-salesforce/adapters/row.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, createEmptyConfiguration } from './row';
 import { cases } from './row.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './row.spec.def';
 describe('row', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default config with the webalized name filled in', function() {
-      assert.deepEqual(createEmptyConfiguration('User', 'user').toJS(), createConfiguration(Immutable.fromJS({object: 'User'})).toJS());
+      expect(createEmptyConfiguration('User', 'user').toJS()).toEqual(createConfiguration(Immutable.fromJS({ object: 'User' })).toJS());
     });
   });
 });

--- a/src/scripts/modules/htns.ex-salesforce/migrations/legacyUIMigration.spec.js
+++ b/src/scripts/modules/htns.ex-salesforce/migrations/legacyUIMigration.spec.js
@@ -1,11 +1,10 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import * as legacyUIMigration from './legacyUIMigration';
 
 describe('legacyUIMigration', function() {
   describe('isMigrated()', function() {
     it('should return a true for a migrated config', function() {
-      assert.strictEqual(true, legacyUIMigration.isMigrated(Immutable.fromJS({
+      expect(true).toEqual(legacyUIMigration.isMigrated(Immutable.fromJS({
         configuration: {
           parameters: {
             loginname: '',
@@ -17,7 +16,7 @@ describe('legacyUIMigration', function() {
       })));
     });
     it('should return false for a config with objects key', function() {
-      assert.strictEqual(false, legacyUIMigration.isMigrated(Immutable.fromJS({
+      expect(false).toEqual(legacyUIMigration.isMigrated(Immutable.fromJS({
         configuration: {
           parameters: {
             objects: []
@@ -26,7 +25,7 @@ describe('legacyUIMigration', function() {
       })));
     });
     it('should return false for a config with sinceLast key', function() {
-      assert.strictEqual(false, legacyUIMigration.isMigrated(Immutable.fromJS({
+      expect(false).toEqual(legacyUIMigration.isMigrated(Immutable.fromJS({
         configuration: {
           parameters: {
             sinceLast: false
@@ -46,7 +45,7 @@ describe('legacyUIMigration', function() {
           sandbox: false
         }
       };
-      assert.deepStrictEqual(expected, legacyUIMigration.getRootConfiguration(Immutable.fromJS({configuration: {}})).toJS());
+      expect(expected).toEqual(legacyUIMigration.getRootConfiguration(Immutable.fromJS({configuration: {}})).toJS());
     });
     it('should return correct config for a populated config', function() {
       const configuration = {
@@ -69,31 +68,31 @@ describe('legacyUIMigration', function() {
           sandbox: true
         }
       };
-      assert.deepStrictEqual(expected, legacyUIMigration.getRootConfiguration(Immutable.fromJS(configuration)).toJS());
+      expect(expected).toEqual(legacyUIMigration.getRootConfiguration(Immutable.fromJS(configuration)).toJS());
     });
   });
 
   describe('getRootState()', function() {
     it('should return empty state defaults for an empty state', function() {
-      assert.deepStrictEqual({}, legacyUIMigration.getRootState(Immutable.fromJS({state: {}})).toJS());
+      expect({}).toEqual(legacyUIMigration.getRootState(Immutable.fromJS({state: {}})).toJS());
     });
     it('should return correct value for a populated state', function() {
       const configuration = {
         state: {key: 'val'}
       };
-      assert.deepStrictEqual(configuration.state, legacyUIMigration.getRootState(Immutable.fromJS(configuration)).toJS());
+      expect(configuration.state).toEqual(legacyUIMigration.getRootState(Immutable.fromJS(configuration)).toJS());
     });
   });
 
   describe('getRowsCount()', function() {
     it('should return 0 for missing objects prop', function() {
-      assert.strictEqual(0, legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {}})));
+      expect(0).toEqual(legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {}})));
     });
     it('should return 0 for empty objects prop', function() {
-      assert.strictEqual(0, legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {parameters: {objects: []}}})));
+      expect(0).toEqual(legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {parameters: {objects: []}}})));
     });
     it('should return 2 for 2 objects', function() {
-      assert.strictEqual(2, legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {parameters: {objects: [{}, {}]}}})));
+      expect(2).toEqual(legacyUIMigration.getRowsCount(Immutable.fromJS({configuration: {parameters: {objects: [{}, {}]}}})));
     });
   });
 
@@ -107,8 +106,8 @@ describe('legacyUIMigration', function() {
           }
         }
       };
-      assert.strictEqual('Unknown object', legacyUIMigration.getRowName(Immutable.fromJS(configuration), 0));
-      assert.strictEqual('Unknown object', legacyUIMigration.getRowName(Immutable.fromJS(configuration), 1));
+      expect('Unknown object').toEqual(legacyUIMigration.getRowName(Immutable.fromJS(configuration), 0));
+      expect('Unknown object').toEqual(legacyUIMigration.getRowName(Immutable.fromJS(configuration), 1));
     });
     it('should return correct name for a populated config', function() {
       const configuration = {
@@ -127,8 +126,8 @@ describe('legacyUIMigration', function() {
           }
         }
       };
-      assert.strictEqual('Account', legacyUIMigration.getRowName(Immutable.fromJS(configuration), 0));
-      assert.strictEqual('User', legacyUIMigration.getRowName(Immutable.fromJS(configuration), 1));
+      expect('Account').toEqual(legacyUIMigration.getRowName(Immutable.fromJS(configuration), 0));
+      expect('User').toEqual(legacyUIMigration.getRowName(Immutable.fromJS(configuration), 1));
     });
   });
 
@@ -152,8 +151,8 @@ describe('legacyUIMigration', function() {
           ]
         }
       };
-      assert.deepStrictEqual(expected, legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 0).toJS());
-      assert.deepStrictEqual(expected, legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 1).toJS());
+      expect(expected).toEqual(legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 0).toJS());
+      expect(expected).toEqual(legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 1).toJS());
     });
     it('should return correct config for a populated config', function() {
       const configuration = {
@@ -195,22 +194,22 @@ describe('legacyUIMigration', function() {
           ]
         }
       };
-      assert.deepStrictEqual(expected0, legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 0).toJS());
-      assert.deepStrictEqual(expected1, legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 1).toJS());
+      expect(expected0).toEqual(legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 0).toJS());
+      expect(expected1).toEqual(legacyUIMigration.getRowConfiguration(Immutable.fromJS(configuration), 1).toJS());
     });
   });
 
   describe('getRowState()', function() {
     it('should return empty state defaults for an empty state', function() {
-      assert.deepStrictEqual({}, legacyUIMigration.getRowState(Immutable.fromJS({state: {}}), 0).toJS());
-      assert.deepStrictEqual({}, legacyUIMigration.getRowState(Immutable.fromJS({state: {}}), 1).toJS());
+      expect({}).toEqual(legacyUIMigration.getRowState(Immutable.fromJS({state: {}}), 0).toJS());
+      expect({}).toEqual(legacyUIMigration.getRowState(Immutable.fromJS({state: {}}), 1).toJS());
     });
     it('should return correct value for a populated state', function() {
       const configuration = {
         state: {key: 'val'}
       };
-      assert.deepStrictEqual(configuration.state, legacyUIMigration.getRowState(Immutable.fromJS(configuration), 0).toJS());
-      assert.deepStrictEqual(configuration.state, legacyUIMigration.getRowState(Immutable.fromJS(configuration), 1).toJS());
+      expect(configuration.state).toEqual(legacyUIMigration.getRowState(Immutable.fromJS(configuration), 0).toJS());
+      expect(configuration.state).toEqual(legacyUIMigration.getRowState(Immutable.fromJS(configuration), 1).toJS());
     });
   });
 });

--- a/src/scripts/modules/transformations/react/components/backend-version/versions.moment.mock.test.js
+++ b/src/scripts/modules/transformations/react/components/backend-version/versions.moment.mock.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { hasVersions, getVersions } from './versions';
 import { transformationType } from '../../../Constants';
 
@@ -12,12 +11,12 @@ jest.mock('moment', () => {
 
 describe('hasVersions', () => {
   it('should return true for date before until', () => {
-    assert.strictEqual(true, hasVersions(transformationType.R));
+    expect(true).toEqual(hasVersions(transformationType.R));
   });
 });
 
 describe('getVersions', () => {
   it('should return non empty array for date before until', () => {
-    assert.strictEqual(true, getVersions(transformationType.R).length >= 2);
+    expect(true).toEqual(getVersions(transformationType.R).length >= 2);
   });
 });

--- a/src/scripts/modules/transformations/react/components/backend-version/versions.test.js
+++ b/src/scripts/modules/transformations/react/components/backend-version/versions.test.js
@@ -1,27 +1,26 @@
-import assert from 'assert';
 import { hasVersions, getVersions } from './versions';
 import { transformationType } from '../../../Constants';
 
 describe('hasVersions', () => {
   it('should return true for date before until', () => {
-    assert.strictEqual(true, hasVersions(transformationType.R, '2018-12-31'));
+    expect(true).toEqual(hasVersions(transformationType.R, '2018-12-31'));
   });
   it('should return false for date after until', () => {
-    assert.strictEqual(false, hasVersions(transformationType.R, '2100-01-01'));
+    expect(false).toEqual(hasVersions(transformationType.R, '2100-01-01'));
   });
   it('should return false unknown backend', () => {
-    assert.strictEqual(false, hasVersions('random-backend'));
+    expect(false).toEqual(hasVersions('random-backend'));
   });
 });
 
 describe('getVersions', () => {
   it('should return non empty array for date before until', () => {
-    assert.strictEqual(true, getVersions(transformationType.R, '2018-12-31').length >= 2);
+    expect(true).toEqual(getVersions(transformationType.R, '2018-12-31').length >= 2);
   });
   it('should return array with latest version for date after until', () => {
-    assert.strictEqual(true, getVersions(transformationType.R, '2019-01-02').length >= 1);
+    expect(true).toEqual(getVersions(transformationType.R, '2019-01-02').length >= 1);
   });
   it('should return empty array for unknown backend', () => {
-    assert.strictEqual(true, getVersions('random-backend').length === 0);
+    expect(true).toEqual(getVersions('random-backend').length === 0);
   });
 });

--- a/src/scripts/modules/transformations/react/components/duplicite-output-mapping/detect.spec.js
+++ b/src/scripts/modules/transformations/react/components/duplicite-output-mapping/detect.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import getConflicts from './detect';
 
@@ -137,13 +136,13 @@ const t3 = {
 
 describe('getConflicts', () => {
   it('should return empty array for a single transformation', () => {
-    assert.deepEqual([], getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1})).toJS());
+    expect([]).toEqual(getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1})).toJS());
   });
   it('should return empty array for conflict in different phases', () => {
-    assert.deepEqual([], getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '2': t2})).toJS());
+    expect([]).toEqual(getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '2': t2})).toJS());
   });
   it('should return conflicting transformations', () => {
-    assert.deepEqual([
+    expect([
       {
         'id': '1a',
         'destination': 'out.c-duplicite-output-mapping.test'
@@ -152,8 +151,8 @@ describe('getConflicts', () => {
         'id': '1a',
         'destination': 'out.c-duplicite-output-mapping.different_source'
       }
-    ], getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '1a': t1a, '1b': t1b})).toJS());
-    assert.deepEqual([
+    ]).toEqual(getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '1a': t1a, '1b': t1b})).toJS());
+    expect([
       {
         'id': '1',
         'destination': 'out.c-duplicite-output-mapping.test'
@@ -162,18 +161,18 @@ describe('getConflicts', () => {
         'id': '1',
         'destination': 'out.c-duplicite-output-mapping.different_source'
       }
-    ], getConflicts(Immutable.fromJS(t1a), Immutable.fromJS({'1': t1, '1a': t1a, '1b': t1b})).toJS());
+    ]).toEqual(getConflicts(Immutable.fromJS(t1a), Immutable.fromJS({'1': t1, '1a': t1a, '1b': t1b})).toJS());
   });
   it('should return empty array for no conflicts', () => {
-    assert.deepEqual([], getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '1b': t1b})).toJS());
-    assert.deepEqual([], getConflicts(Immutable.fromJS(t1a), Immutable.fromJS({'1a': t1a, '1b': t1b})).toJS());
+    expect([]).toEqual(getConflicts(Immutable.fromJS(t1), Immutable.fromJS({'1': t1, '1b': t1b})).toJS());
+    expect([]).toEqual(getConflicts(Immutable.fromJS(t1a), Immutable.fromJS({'1a': t1a, '1b': t1b})).toJS());
   });
   it('should detect self conflicts', () => {
-    assert.deepEqual([
+    expect([
       {
         'id': '3',
         'destination': 'out.c-duplicite-output-mapping.conflict'
       }
-    ], getConflicts(Immutable.fromJS(t3), Immutable.fromJS({'3': t3})).toJS());
+    ]).toEqual(getConflicts(Immutable.fromJS(t3), Immutable.fromJS({'3': t3})).toJS());
   });
 });

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.test.js
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditorHelper.test.js
@@ -1,14 +1,15 @@
-import assert from 'assert';
 import { getMetadataDataTypes } from './InputMappingRowSnowflakeEditorHelper';
 import { fromJS } from 'immutable';
 
 describe('getMetadataDataType', function() {
   it('should not break on empty input', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({})), fromJS({}));
+    expect(fromJS({})).toEqual(getMetadataDataTypes(fromJS({})));
   });
 
   it('should return null with KBC.datatype.length only (no base type)', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: null
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349672',
@@ -18,13 +19,13 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: null
-    }));
+    })));
   });
 
   it('should return null with KBC.datatype.nullable only (no base type)', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: null
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349670',
@@ -34,13 +35,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: null
-    }));
+    })));
   });
 
   it('should work with KBC.datatype.basetype only', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: {
+        column: 'Price',
+        type: 'NUMBER',
+        length: null,
+        convertEmptyValuesToNull: false
+      }
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349671',
@@ -50,18 +56,13 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: {
-        column: 'Price',
-        type: 'NUMBER',
-        length: null,
-        convertEmptyValuesToNull: false
-      }
-    }));
+    })));
   });
 
   it('should return null for nonexistent KBC.datatype.basetype', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: null
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349671',
@@ -71,13 +72,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: null
-    }));
+    })));
   });
 
   it('should work with KBC.datatype.basetype and KBC.datatype.nullable', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: {
+        column: 'Price',
+        type: 'NUMBER',
+        length: null,
+        convertEmptyValuesToNull: true
+      }
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349671',
@@ -94,18 +100,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
+    })));
+  });
+
+  it('should work with KBC.datatype.basetype and KBC.datatype.nullable (nullable set to 0)', function() {
+    expect(fromJS({
       Price: {
         column: 'Price',
         type: 'NUMBER',
         length: null,
-        convertEmptyValuesToNull: true
+        convertEmptyValuesToNull: false
       }
-    }));
-  });
-
-  it('should work with KBC.datatype.basetype and KBC.datatype.nullable (nullable set to 0)', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349671',
@@ -122,18 +128,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: {
-        column: 'Price',
-        type: 'NUMBER',
-        length: null,
-        convertEmptyValuesToNull: false
-      }
-    }));
+    })));
   });
 
   it('should work with KBC.datatype.basetype and KBC.datatype.length', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: {
+        column: 'Price',
+        type: 'NUMBER',
+        length: '19,4',
+        convertEmptyValuesToNull: false
+      }
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349671',
@@ -150,18 +156,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: {
-        column: 'Price',
-        type: 'NUMBER',
-        length: '19,4',
-        convertEmptyValuesToNull: false
-      }
-    }));
+    })));
   });
 
   it('should work with KBC.datatype.basetype and KBC.datatype.length (should keep the length)', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: {
+        column: 'Price',
+        type: 'VARCHAR',
+        length: '123',
+        convertEmptyValuesToNull: false
+      }
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349679',
@@ -178,18 +184,18 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: {
-        column: 'Price',
-        type: 'VARCHAR',
-        length: '123',
-        convertEmptyValuesToNull: false
-      }
-    }));
+    })));
   });
 
   it('should work with KBC.datatype.basetype and KBC.datatype.length (should decrease length)', function() {
-    assert.deepStrictEqual(getMetadataDataTypes(fromJS({
+    expect(fromJS({
+      Price: {
+        column: 'Price',
+        type: 'VARCHAR',
+        length: 16777216,
+        convertEmptyValuesToNull: false
+      }
+    })).toEqual(getMetadataDataTypes(fromJS({
       Price: [
         {
           id: '85349679',
@@ -206,13 +212,6 @@ describe('getMetadataDataType', function() {
           timestamp: '2018-11-19T13:04:43+0100'
         }
       ]
-    })), fromJS({
-      Price: {
-        column: 'Price',
-        type: 'VARCHAR',
-        length: 16777216,
-        convertEmptyValuesToNull: false
-      }
-    }));
+    })));
   });
 });

--- a/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.spec.js
+++ b/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.spec.js
@@ -1,18 +1,17 @@
-var assert = require('assert');
 var Immutable = require('immutable');
 var getDatatypeLabel = require('./getDatatypeLabel');
 
 describe('getDatatypeLabel', function() {
   describe('#getDatatypeLabel()', function() {
     it('should return string', function() {
-      assert.equal('test', getDatatypeLabel('test'));
+      expect('test').toEqual(getDatatypeLabel('test'));
     });
 
     it('should return VARCHAR', function() {
       const definition = Immutable.fromJS({
         type: 'VARCHAR'
       });
-      assert.equal('VARCHAR', getDatatypeLabel(definition));
+      expect('VARCHAR').toEqual(getDatatypeLabel(definition));
     });
 
     it('should return VARCHAR', function() {
@@ -21,7 +20,7 @@ describe('getDatatypeLabel', function() {
         length: null,
         compression: null
       });
-      assert.equal('VARCHAR', getDatatypeLabel(definition));
+      expect('VARCHAR').toEqual(getDatatypeLabel(definition));
     });
 
     it('should return VARCHAR(255)', function() {
@@ -29,7 +28,7 @@ describe('getDatatypeLabel', function() {
         type: 'VARCHAR',
         length: '255'
       });
-      assert.equal('VARCHAR(255)', getDatatypeLabel(definition));
+      expect('VARCHAR(255)').toEqual(getDatatypeLabel(definition));
     });
 
     it('should return VARCHAR(255) ENCODE LZO', function() {
@@ -38,7 +37,7 @@ describe('getDatatypeLabel', function() {
         length: '255',
         compression: 'LZO'
       });
-      assert.equal('VARCHAR(255) ENCODE LZO', getDatatypeLabel(definition));
+      expect('VARCHAR(255) ENCODE LZO').toEqual(getDatatypeLabel(definition));
     });
   });
 });

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/normalizeNewines.test.js
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/normalizeNewines.test.js
@@ -1,53 +1,31 @@
-var assert = require('assert');
 var normalizeNewlines = require('./normalizeNewlines').default;
 
 describe('normalizeNewlines', function() {
   it('it should replace CRLF with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r\n SELECT 2;'),
-      'SELECT 1; \n SELECT 2;'
-    );
+    expect('SELECT 1; \n SELECT 2;').toEqual(normalizeNewlines('SELECT 1; \r\n SELECT 2;'));
   });
 
   it('it should replace CR with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r SELECT 2;'),
-      'SELECT 1; \n SELECT 2;'
-    );
+    expect('SELECT 1; \n SELECT 2;').toEqual(normalizeNewlines('SELECT 1; \r SELECT 2;'));
   });
 
   it('it should replace mixed CRLF and CR with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r\n SELECT 2; \r SELECT 3;'),
-      'SELECT 1; \n SELECT 2; \n SELECT 3;'
-    );
+    expect('SELECT 1; \n SELECT 2; \n SELECT 3;').toEqual(normalizeNewlines('SELECT 1; \r\n SELECT 2; \r SELECT 3;'));
   });
 
   it('it should replace multiple CRLF with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r\n SELECT 2; \r\n SELECT 3;'),
-      'SELECT 1; \n SELECT 2; \n SELECT 3;'
-    );
+    expect('SELECT 1; \n SELECT 2; \n SELECT 3;').toEqual(normalizeNewlines('SELECT 1; \r\n SELECT 2; \r\n SELECT 3;'));
   });
 
   it('it should replace multiple CR with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r SELECT 2; \r SELECT 3;'),
-      'SELECT 1; \n SELECT 2; \n SELECT 3;'
-    );
+    expect('SELECT 1; \n SELECT 2; \n SELECT 3;').toEqual(normalizeNewlines('SELECT 1; \r SELECT 2; \r SELECT 3;'));
   });
 
   it('it should replace multiple mixed CRLF and CR with LF', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; \r\n SELECT 2; \r SELECT 3; \r\n SELECT 4; \r SELECT 5;'),
-      'SELECT 1; \n SELECT 2; \n SELECT 3; \n SELECT 4; \n SELECT 5;'
-    );
+    expect('SELECT 1; \n SELECT 2; \n SELECT 3; \n SELECT 4; \n SELECT 5;').toEqual(normalizeNewlines('SELECT 1; \r\n SELECT 2; \r SELECT 3; \r\n SELECT 4; \r SELECT 5;'));
   });
 
   it('it should not change value', function() {
-    assert.deepEqual(
-      normalizeNewlines('SELECT 1; SELECT 2;'),
-      'SELECT 1; SELECT 2;'
-    );
+    expect('SELECT 1; SELECT 2;').toEqual(normalizeNewlines('SELECT 1; SELECT 2;'));
   });
 });

--- a/src/scripts/modules/transformations/utils/parseDataType.spec.js
+++ b/src/scripts/modules/transformations/utils/parseDataType.spec.js
@@ -1,5 +1,4 @@
-import {parseDataTypeFromString} from './parseDataType';
-import assert from 'assert';
+import { parseDataTypeFromString } from './parseDataType';
 
 describe('parseDataTypeFromString()', () => {
   it('should parse empty string', () => {
@@ -9,57 +8,57 @@ describe('parseDataTypeFromString()', () => {
       type: '',
       length: null
     };
-    assert.deepEqual(test, expected);
+    expect(expected).toEqual(test);
   });
 
   it('should parse string defined data types', () => {
-    assert.deepEqual({
+    expect({
       type: 'VARCHAR',
       length: null,
       column: 'name'
-    }, parseDataTypeFromString('VARCHAR', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('VARCHAR', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'NUMBER',
       length: null,
       column: 'name'
-    }, parseDataTypeFromString('NUMBER', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('NUMBER', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'DATE',
       length: null,
       column: 'name'
-    }, parseDataTypeFromString('DATE', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('DATE', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'BIGINT UNSIGNED',
       length: null,
       column: 'name'
-    }, parseDataTypeFromString('BIGINT UNSIGNED', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('BIGINT UNSIGNED', 'name').toJS());
   });
   it('should parse string defined data types with length', () => {
-    assert.deepEqual({
+    expect({
       type: 'VARCHAR',
       length: '255',
       column: 'name'
-    }, parseDataTypeFromString('VARCHAR (255)', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('VARCHAR (255)', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'VARCHAR',
       length: '255',
       column: 'name'
-    }, parseDataTypeFromString('VARCHAR(255)', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('VARCHAR(255)', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'NUMBER',
       length: '12,2',
       column: 'name'
-    }, parseDataTypeFromString('NUMBER (12,2)', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('NUMBER (12,2)', 'name').toJS());
 
-    assert.deepEqual({
+    expect({
       type: 'NUMBER',
       length: '12,2',
       column: 'name'
-    }, parseDataTypeFromString('NUMBER(12,2)', 'name').toJS());
+    }).toEqual(parseDataTypeFromString('NUMBER(12,2)', 'name').toJS());
   });
 });

--- a/src/scripts/modules/wr-aws-s3/adapters/configuration.spec.js
+++ b/src/scripts/modules/wr-aws-s3/adapters/configuration.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, createEmptyConfiguration } from './configuration';
 import { cases } from './configuration.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './configuration.spec.def';
 describe('row', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default config with the webalized name filled in', function() {
-      assert.deepEqual(createEmptyConfiguration('in.c-bucket.test').toJS(), createConfiguration(Immutable.fromJS({source: 'in.c-bucket.test', destination: 'test.csv'})).toJS());
+      expect(createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(createConfiguration(Immutable.fromJS({ source: 'in.c-bucket.test', destination: 'test.csv' })).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-aws-s3/adapters/credentials.spec.js
+++ b/src/scripts/modules/wr-aws-s3/adapters/credentials.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import { createConfiguration, parseConfiguration, isComplete } from './credentials';
 import { cases } from './credentials.spec.def';
@@ -6,36 +5,36 @@ import { cases } from './credentials.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({})));
     });
     it('should return false with only one parameter filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {accessKeyId: 'a'}})), false);
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'#secretAccessKey': 'a'}})), false);
+      expect(false).toEqual(isComplete(Immutable.fromJS({ parameters: { accessKeyId: 'a' } })));
+      expect(false).toEqual(isComplete(Immutable.fromJS({ parameters: { '#secretAccessKey': 'a' } })));
     });
     it('should return true when all parameters are filled', function() {
-      assert.equal(isComplete(Immutable.fromJS({parameters: {'accessKeyId': 'a', '#secretAccessKey': 'a', 'bucket': 'mybucket'}})), true);
+      expect(true).toEqual(isComplete(Immutable.fromJS({ parameters: { accessKeyId: 'a', '#secretAccessKey': 'a', bucket: 'mybucket' } })));
     });
   });
 });

--- a/src/scripts/modules/wr-db/columnTypeValidation.spec.js
+++ b/src/scripts/modules/wr-db/columnTypeValidation.spec.js
@@ -1,95 +1,94 @@
-import assert from 'assert';
 import { validate } from './columnTypeValidation';
 
 describe('columnTypeValidation', () => {
   describe('binary', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('binary', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('binary', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('binary', 0), false));
-    it('must be numeric', () => assert.equal(validate('binary', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('binary', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('binary', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('binary', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('binary', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('binary', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('binary', '')).toEqual(false));
   });
 
   describe('char', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('char', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('char', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('char', 0), false));
-    it('must be numeric', () => assert.equal(validate('char', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('char', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('char', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('char', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('char', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('char', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('char', '')).toEqual(false));
   });
 
   describe('character', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('character', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('character', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('character', 0), false));
-    it('must be numeric', () => assert.equal(validate('character', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('character', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('character', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('character', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('character', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('character', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('character', '')).toEqual(false));
   });
 
   describe('string', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('string', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('string', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('string', 0), false));
-    it('must be numeric', () => assert.equal(validate('string', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('string', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('string', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('string', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('string', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('string', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('string', '')).toEqual(false));
   });
 
   describe('text', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('text', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('text', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('text', 0), false));
-    it('must be numeric', () => assert.equal(validate('text', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('text', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('text', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('text', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('text', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('text', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('text', '')).toEqual(false));
   });
 
   describe('varchar', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('varchar', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('varchar', '5'), true));
-    it('must be bigger that zero', () => assert.equal(validate('varchar', 0), false));
-    it('must be numeric', () => assert.equal(validate('varchar', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('varchar', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('varchar', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('varchar', '5')).toEqual(true));
+    it('must be bigger that zero', () => expect(validate('varchar', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('varchar', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('varchar', '')).toEqual(false));
   });
 
   describe('decimal', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('decimal', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('decimal', '5'), true));
-    it('can accept precizion', () => assert.equal(validate('decimal', '5,2'), true));
-    it('dot delimiter is not valid', () => assert.equal(validate('decimal', '5.2'), false));
-    it('must be bigger that zero', () => assert.equal(validate('decimal', 0), false));
-    it('must be numeric', () => assert.equal(validate('decimal', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('decimal', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('decimal', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('decimal', '5')).toEqual(true));
+    it('can accept precizion', () => expect(validate('decimal', '5,2')).toEqual(true));
+    it('dot delimiter is not valid', () => expect(validate('decimal', '5.2')).toEqual(false));
+    it('must be bigger that zero', () => expect(validate('decimal', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('decimal', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('decimal', '')).toEqual(false));
   });
 
   describe('number', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('number', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('number', '5'), true));
-    it('can accept precizion', () => assert.equal(validate('number', '5,2'), true));
-    it('dot delimiter is not valid', () => assert.equal(validate('number', '5.2'), false));
-    it('must be bigger that zero', () => assert.equal(validate('number', 0), false));
-    it('must be numeric', () => assert.equal(validate('number', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('number', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('number', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('number', '5')).toEqual(true));
+    it('can accept precizion', () => expect(validate('number', '5,2')).toEqual(true));
+    it('dot delimiter is not valid', () => expect(validate('number', '5.2')).toEqual(false));
+    it('must be bigger that zero', () => expect(validate('number', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('number', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('number', '')).toEqual(false));
   });
 
   describe('numeric', () => {
-    it('number bigger that zero is fine', () => assert.equal(validate('numeric', 10), true));
-    it('even string numeric value is fine', () => assert.equal(validate('numeric', '5'), true));
-    it('can accept precizion', () => assert.equal(validate('numeric', '5,2'), true));
-    it('dot delimiter is not valid', () => assert.equal(validate('numeric', '5.2'), false));
-    it('must be bigger that zero', () => assert.equal(validate('numeric', 0), false));
-    it('must be numeric', () => assert.equal(validate('numeric', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('numeric', ''), false));
+    it('number bigger that zero is fine', () => expect(validate('numeric', 10)).toEqual(true));
+    it('even string numeric value is fine', () => expect(validate('numeric', '5')).toEqual(true));
+    it('can accept precizion', () => expect(validate('numeric', '5,2')).toEqual(true));
+    it('dot delimiter is not valid', () => expect(validate('numeric', '5.2')).toEqual(false));
+    it('must be bigger that zero', () => expect(validate('numeric', 0)).toEqual(false));
+    it('must be numeric', () => expect(validate('numeric', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('numeric', '')).toEqual(false));
   });
 
   describe('time', () => {
     it('number in range 0-9', () => {
-      assert.equal(validate('time', 0), true);
-      assert.equal(validate('time', 3), true);
-      assert.equal(validate('time', 9), true);
+      expect(validate('time', 0)).toEqual(true);
+      expect(validate('time', 3)).toEqual(true);
+      expect(validate('time', 9)).toEqual(true);
     });
-    it('even string numeric value is fine', () => assert.equal(validate('time', '5'), true));
-    it('number bigger than 9 is invalid', () => assert.equal(validate('time', 10), false));
-    it('number smaller than 0 is invalid', () => assert.equal(validate('time', -1), false));
-    it('must be numeric', () => assert.equal(validate('time', 'baz'), false));
-    it('can not be empty', () => assert.equal(validate('time', ''), false));
+    it('even string numeric value is fine', () => expect(validate('time', '5')).toEqual(true));
+    it('number bigger than 9 is invalid', () => expect(validate('time', 10)).toEqual(false));
+    it('number smaller than 0 is invalid', () => expect(validate('time', -1)).toEqual(false));
+    it('must be numeric', () => expect(validate('time', 'baz')).toEqual(false));
+    it('can not be empty', () => expect(validate('time', '')).toEqual(false));
   });
 });

--- a/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { fromJS } from 'immutable';
 import { prepareColumnsTypes } from './columnsMetadata';
 
@@ -33,40 +32,33 @@ function defaultMysqlType(column) {
 
 describe('prepareColumnsTypes', function() {
   it('it return null for unknown componentId', () => {
-    assert.equal(prepareColumnsTypes('keboola.wr-db-unknown', table), null);
+    expect(null).toEqual(prepareColumnsTypes('keboola.wr-db-unknown', table));
   });
 
   it('only table with snowflake backend can read metadata, default values is returned for others backend', () => {
-    assert.deepStrictEqual(
-      prepareColumnsTypes('keboola.wr-db-mysql', table),
-      fromJS([defaultMysqlType('country'), defaultMysqlType('cars')])
-    );
+    expect(prepareColumnsTypes('keboola.wr-db-mysql', table)).toEqual(fromJS([defaultMysqlType('country'), defaultMysqlType('cars')]));
   });
 
   it('snowflake backend can read metadata, default values is returned for columns without metadata', () => {
     const expected = fromJS([metadataSnowflakeType('country'), defaultSnowflakeType('cars')]);
-
-    assert.deepStrictEqual(prepareColumnsTypes(SnowflakeComponentId, table), expected);
+    expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, table));
   });
 
   it('if metadata has no basetype, default values are returned', () => {
     const withoutMetadataBasetype = table.deleteIn(['columnMetadata', 'country', 0]);
     const expected = fromJS([defaultSnowflakeType('country'), defaultSnowflakeType('cars')]);
-
-    assert.deepStrictEqual(prepareColumnsTypes(SnowflakeComponentId, withoutMetadataBasetype), expected);
+    expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, withoutMetadataBasetype));
   });
 
   it('if metadata has unknown basetype, default values are returned', () => {
     const uknownMetadataBasetype = table.setIn(['columnMetadata', 'country', 0, 'value'], 'UNKNOWN');
     const expected = fromJS([defaultSnowflakeType('country'), defaultSnowflakeType('cars')]);
-
-    assert.deepStrictEqual(prepareColumnsTypes(SnowflakeComponentId, uknownMetadataBasetype), expected);
+    expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, uknownMetadataBasetype));
   });
 
   it('if length value from metadata is bigger than allowed, default size is used', () => {
     const updatedTable = table.setIn(['columnMetadata', 'country', 3, 'value'], 26777216);
     const expected = fromJS([metadataSnowflakeType('country'), defaultSnowflakeType('cars')]);
-
-    assert.deepStrictEqual(prepareColumnsTypes(SnowflakeComponentId, updatedTable), expected);
+    expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, updatedTable));
   });
 });

--- a/src/scripts/modules/wr-google-bigquery/adapters/loadType.spec.js
+++ b/src/scripts/modules/wr-google-bigquery/adapters/loadType.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './loadType';
 import { cases } from './loadType.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './loadType.spec.def';
 describe('loadType', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default configuration with the table details filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration('in.c-bucket.test').toJS(), adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(adapter.createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-google-bigquery/adapters/targetDataset.spec.js
+++ b/src/scripts/modules/wr-google-bigquery/adapters/targetDataset.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './targetDataset';
 import {cases} from './targetDataset.spec.def';
@@ -6,32 +5,32 @@ import {cases} from './targetDataset.spec.def';
 describe('targetDataset', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config from an empty local state', function() {
-      assert.deepEqual({}, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect({}).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(adapter.isComplete(Immutable.fromJS({})));
     });
     it('should return true when parameters are filled', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({parameters: {'project': 'a', 'dataset': 'b'}})), true);
+      expect(true).toEqual(adapter.isComplete(Immutable.fromJS({parameters: {'project': 'a', 'dataset': 'b'}})));
     });
   });
 });

--- a/src/scripts/modules/wr-google-bigquery/adapters/targetTable.spec.js
+++ b/src/scripts/modules/wr-google-bigquery/adapters/targetTable.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './targetTable';
 import { cases } from './targetTable.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './targetTable.spec.def';
 describe('targetTable', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default configuration with the table details filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration('in.c-bucket.test').toJS(), adapter.createConfiguration(Immutable.fromJS({destination: 'test', source: 'in.c-bucket.test'})).toJS());
+      expect(adapter.createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({destination: 'test', source: 'in.c-bucket.test'})).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-google-bigquery/helpers/makeColumnDefinition.spec.js
+++ b/src/scripts/modules/wr-google-bigquery/helpers/makeColumnDefinition.spec.js
@@ -1,6 +1,5 @@
 import makeColumnDefinition from './makeColumnDefinition';
 import {Types} from './constants';
-import assert from 'assert';
 
 describe('makeColumnDefinition', () => {
   it('test type STRING setup', () => {
@@ -9,11 +8,11 @@ describe('makeColumnDefinition', () => {
       dbName: 'id',
       type: Types.STRING
     });
-    assert.deepEqual(definition.fields.dbName, {
+    expect(definition.fields.dbName).toEqual({
       show: true,
       defaultValue: 'id'
     });
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       defaultValue: Types.IGNORE
     });
@@ -25,11 +24,11 @@ describe('makeColumnDefinition', () => {
       dbName: 'id',
       type: Types.IGNORE
     });
-    assert.deepEqual(definition.fields.dbName, {
+    expect(definition.fields.dbName).toEqual({
       show: false,
       defaultValue: 'id'
     });
-    assert.deepEqual(definition.fields.type, {
+    expect(definition.fields.type).toEqual({
       show: true,
       defaultValue: Types.IGNORE
     });

--- a/src/scripts/modules/wr-storage/adapters/actions.spec.js
+++ b/src/scripts/modules/wr-storage/adapters/actions.spec.js
@@ -1,11 +1,10 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import actions from './actions';
 
 describe('actions', function() {
   describe('info()', function() {
     it('should return false for an empty input', function() {
-      assert.equal(false, actions.info(Immutable.fromJS({})));
+      expect(false).toEqual(actions.info(Immutable.fromJS({})));
     });
     it('should return valid payload for a valid input', function() {
       const expected = {
@@ -22,7 +21,7 @@ describe('actions', function() {
           url: 'abc'
         }
       };
-      assert.deepEqual(expected, actions.info(Immutable.fromJS(configuration)).toJS());
+      expect(expected).toEqual(actions.info(Immutable.fromJS(configuration)).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-storage/adapters/conform.spec.js
+++ b/src/scripts/modules/wr-storage/adapters/conform.spec.js
@@ -1,19 +1,18 @@
-import assert from 'assert';
 import { fromJS } from 'immutable';
 import { conform, configDraft } from './conform';
 import * as cases from './conform.spec.def';
 
 describe('conform()', function() {
   it('should return default config for empty configuration', function() {
-    assert.deepEqual(conform(fromJS({})), configDraft);
+    expect(configDraft).toEqual(conform(fromJS({})));
   });
 
   it('should return valid config for valid configuration', function() {
-    assert.deepEqual(conform(cases.validSimple), cases.validSimple);
+    expect(cases.validSimple).toEqual(conform(cases.validSimple));
   });
 
   it('should return valid config for old configuration format with incremental parameter', function() {
-    assert.deepEqual(conform(cases.incrementalFalse), cases.incrementalFalseExpected);
-    assert.deepEqual(conform(cases.incrementalTrue), cases.incrementalTrueExpected);
+    expect(cases.incrementalFalseExpected).toEqual(conform(cases.incrementalFalse));
+    expect(cases.incrementalTrueExpected).toEqual(conform(cases.incrementalTrue));
   });
 });

--- a/src/scripts/modules/wr-storage/adapters/destination.spec.js
+++ b/src/scripts/modules/wr-storage/adapters/destination.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './destination';
 import { cases } from './destination.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './destination.spec.def';
 describe('destination', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default configuration with the table details filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration('in.c-bucket.test').toJS(), adapter.createConfiguration(Immutable.fromJS({destination: 'test'})).toJS());
+      expect(adapter.createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({destination: 'test'})).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-storage/adapters/inputMapping.spec.js
+++ b/src/scripts/modules/wr-storage/adapters/inputMapping.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './inputMapping';
 import { cases } from './inputMapping.spec.def';
@@ -6,29 +5,29 @@ import { cases } from './inputMapping.spec.def';
 describe('inputMapping', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('createEmptyConfiguration()', function() {
     it('should return a default configuration with the table details filled in', function() {
-      assert.deepEqual(adapter.createEmptyConfiguration('in.c-bucket.test').toJS(), adapter.createConfiguration(Immutable.fromJS({source: 'in.c-bucket.test'})).toJS());
+      expect(adapter.createEmptyConfiguration('in.c-bucket.test').toJS()).toEqual(adapter.createConfiguration(Immutable.fromJS({source: 'in.c-bucket.test'})).toJS());
     });
   });
 });

--- a/src/scripts/modules/wr-storage/adapters/targetProject.spec.js
+++ b/src/scripts/modules/wr-storage/adapters/targetProject.spec.js
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import Immutable from 'immutable';
 import adapter from './targetProject';
 import { cases } from './targetProject.spec.def';
@@ -6,32 +5,32 @@ import { cases } from './targetProject.spec.def';
 describe('credentials', function() {
   describe('createConfiguration()', function() {
     it('should return an empty config with defaults from an empty local state', function() {
-      assert.deepEqual(cases.emptyWithDefaults.configuration, adapter.createConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.configuration).toEqual(adapter.createConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a valid config for a local state with ' + key, function() {
-        assert.deepEqual(cases[key].configuration, adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
+        expect(cases[key].configuration).toEqual(adapter.createConfiguration(Immutable.fromJS(cases[key].localState)).toJS());
       });
     });
   });
 
   describe('parseConfiguration()', function() {
     it('should return empty localState with defaults from empty configuration', function() {
-      assert.deepEqual(cases.emptyWithDefaults.localState, adapter.parseConfiguration(Immutable.fromJS({})).toJS());
+      expect(cases.emptyWithDefaults.localState).toEqual(adapter.parseConfiguration(Immutable.fromJS({})).toJS());
     });
     Object.keys(cases).forEach(function(key) {
       it('should return a correct localState with ' + key + ' configuration', function() {
-        assert.deepEqual(cases[key].localState, adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
+        expect(cases[key].localState).toEqual(adapter.parseConfiguration(Immutable.fromJS(cases[key].configuration)).toJS());
       });
     });
   });
 
   describe('isComplete()', function() {
     it('should return false with empty configuration', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({})), false);
+      expect(false).toEqual(adapter.isComplete(Immutable.fromJS({})));
     });
     it('should return true when parameters are filled', function() {
-      assert.equal(adapter.isComplete(Immutable.fromJS({parameters: {'url': 'a', '#token': 'b', 'bucket': 'c'}})), true);
+      expect(true).toEqual(adapter.isComplete(Immutable.fromJS({parameters: {'url': 'a', '#token': 'b', 'bucket': 'c'}})));
     });
   });
 });

--- a/src/scripts/react/common/changedSinceOptionCreator.spec.js
+++ b/src/scripts/react/common/changedSinceOptionCreator.spec.js
@@ -1,85 +1,84 @@
-var assert = require('assert');
 var changedSinceOptionCreator = require('./changedSinceOptionCreator');
 
 describe('changedSinceOptionCreator', function() {
   describe('valid options', function() {
     it('1', function() {
-      assert.equal('1 hour', changedSinceOptionCreator('1'));
+      expect('1 hour').toEqual(changedSinceOptionCreator('1'));
     });
     it('2', function() {
-      assert.equal('2 hours', changedSinceOptionCreator('2'));
+      expect('2 hours').toEqual(changedSinceOptionCreator('2'));
     });
     it('1m', function() {
-      assert.equal('1 minute', changedSinceOptionCreator('1m'));
+      expect('1 minute').toEqual(changedSinceOptionCreator('1m'));
     });
     it('2m', function() {
-      assert.equal('2 minutes', changedSinceOptionCreator('2m'));
+      expect('2 minutes').toEqual(changedSinceOptionCreator('2m'));
     });
     it('1h', function() {
-      assert.equal('1 hour', changedSinceOptionCreator('1h'));
+      expect('1 hour').toEqual(changedSinceOptionCreator('1h'));
     });
     it('2h', function() {
-      assert.equal('2 hours', changedSinceOptionCreator('2h'));
+      expect('2 hours').toEqual(changedSinceOptionCreator('2h'));
     });
     it('1d', function() {
-      assert.equal('1 day', changedSinceOptionCreator('1d'));
+      expect('1 day').toEqual(changedSinceOptionCreator('1d'));
     });
     it('2d', function() {
-      assert.equal('2 days', changedSinceOptionCreator('2d'));
+      expect('2 days').toEqual(changedSinceOptionCreator('2d'));
     });
     it('1 m', function() {
-      assert.equal('1 minute', changedSinceOptionCreator('1 m'));
+      expect('1 minute').toEqual(changedSinceOptionCreator('1 m'));
     });
     it('1min', function() {
-      assert.equal('1 minute', changedSinceOptionCreator('1min'));
+      expect('1 minute').toEqual(changedSinceOptionCreator('1min'));
     });
     it('-1m', function() {
-      assert.equal('1 minute', changedSinceOptionCreator('-1m'));
+      expect('1 minute').toEqual(changedSinceOptionCreator('-1m'));
     });
   });
 
   describe('invalid options', function() {
     it('invalid', function() {
-      assert.equal(false, changedSinceOptionCreator('invalid'));
+      expect(false).toEqual(changedSinceOptionCreator('invalid'));
     });
     it('empty string', function() {
-      assert.equal(false, changedSinceOptionCreator(''));
+      expect(false).toEqual(changedSinceOptionCreator(''));
     });
     it('null', function() {
-      assert.equal(false, changedSinceOptionCreator(null));
+      expect(false).toEqual(changedSinceOptionCreator(null));
     });
     it('a b', function() {
-      assert.equal(false, changedSinceOptionCreator('a b'));
+      expect(false).toEqual(changedSinceOptionCreator('a b'));
     });
     it('1 2', function() {
-      assert.equal(false, changedSinceOptionCreator('1 2'));
+      expect(false).toEqual(changedSinceOptionCreator('1 2'));
     });
     it('number', function() {
-      assert.equal(false, changedSinceOptionCreator(10));
+      expect(false).toEqual(changedSinceOptionCreator(10));
     });
     it('object', function() {
-      assert.equal(false, changedSinceOptionCreator({a: 'b'}));
+      expect(false).toEqual(changedSinceOptionCreator({ a: 'b' }));
     });
     it('array', function() {
-      assert.equal(false, changedSinceOptionCreator([1, 'minutes']));
+      expect(false).toEqual(changedSinceOptionCreator([1, 'minutes']));
     });
     it('0 minutes', function() {
-      assert.equal(false, changedSinceOptionCreator('0 minutes'));
+      expect(false).toEqual(changedSinceOptionCreator('0 minutes'));
     });
     it('1 minutes', function() {
-      assert.equal(false, changedSinceOptionCreator('1 minutes'));
+      expect(false).toEqual(changedSinceOptionCreator('1 minutes'));
     });
     it('1 hours', function() {
-      assert.equal(false, changedSinceOptionCreator('1 hours'));
+      expect(false).toEqual(changedSinceOptionCreator('1 hours'));
     });
     it('1 days', function() {
-      assert.equal(false, changedSinceOptionCreator('1 days'));
+      expect(false).toEqual(changedSinceOptionCreator('1 days'));
     });
     it('1 seconds', function() {
-      assert.equal(false, changedSinceOptionCreator('1 seconds'));
+      expect(false).toEqual(changedSinceOptionCreator('1 seconds'));
     });
     it('0 seconds', function() {
-      assert.equal(false, changedSinceOptionCreator('0 seconds'));
+      expect(false).toEqual(changedSinceOptionCreator('0 seconds'));
     });
   });
 });

--- a/src/scripts/utils/duration.spec.js
+++ b/src/scripts/utils/duration.spec.js
@@ -1,82 +1,81 @@
-var assert = require('assert');
 var timeInWords = require('./duration').timeInWords;
 
 describe('duration', function() {
   describe('duration without round param - default', function() {
     it('0 seconds should return "0 sec"', function() {
-      assert.equal('0 sec', timeInWords(0));
+      expect('0 sec').toEqual(timeInWords(0));
     });
     it('1 second should return "1 sec"', function() {
-      assert.equal('1 sec', timeInWords(1));
+      expect('1 sec').toEqual(timeInWords(1));
     });
     it('59 seconds should return "59 sec"', function() {
-      assert.equal('59 sec', timeInWords(59));
+      expect('59 sec').toEqual(timeInWords(59));
     });
     it('60 seconds should return "1 min"', function() {
-      assert.equal('1 min', timeInWords(60));
+      expect('1 min').toEqual(timeInWords(60));
     });
     it('61 seconds should return "1 min 1 sec"', function() {
-      assert.equal('1 min 1 sec', timeInWords(61));
+      expect('1 min 1 sec').toEqual(timeInWords(61));
     });
     it('3599 seconds should return "59 min 59 sec"', function() {
-      assert.equal('59 min 59 sec', timeInWords(3599));
+      expect('59 min 59 sec').toEqual(timeInWords(3599));
     });
     it('3600 seconds should return "1 hr"', function() {
-      assert.equal('1 hr', timeInWords(3600));
+      expect('1 hr').toEqual(timeInWords(3600));
     });
     it('3601 seconds should return "1 hr 1 sec"', function() {
-      assert.equal('1 hr 1 sec', timeInWords(3601));
+      expect('1 hr 1 sec').toEqual(timeInWords(3601));
     });
     it('3660 seconds should return "1 hr 1 min"', function() {
-      assert.equal('1 hr 1 min', timeInWords(3660));
+      expect('1 hr 1 min').toEqual(timeInWords(3660));
     });
     it('3661 seconds should return "1 hr 1 min 1 sec"', function() {
-      assert.equal('1 hr 1 min 1 sec', timeInWords(3661));
+      expect('1 hr 1 min 1 sec').toEqual(timeInWords(3661));
     });
     it('86399 seconds should return "23 hr 59 min 59 sec"', function() {
-      assert.equal('23 hrs 59 min 59 sec', timeInWords(86399));
+      expect('23 hrs 59 min 59 sec').toEqual(timeInWords(86399));
     });
     it('86400 seconds should return "more than 24 hrs"', function() {
-      assert.equal('more than 24 hrs', timeInWords(86400));
+      expect('more than 24 hrs').toEqual(timeInWords(86400));
     });
   });
 
   describe('duration with round param (should trim seconds part)', function() {
     it('0 seconds should return "0 sec"', function() {
-      assert.equal('0 sec', timeInWords(0, true));
+      expect('0 sec').toEqual(timeInWords(0, true));
     });
     it('1 seconds should return "1 sec"', function() {
-      assert.equal('1 sec', timeInWords(1, true));
+      expect('1 sec').toEqual(timeInWords(1, true));
     });
     it('59 seconds should return "59 sec"', function() {
-      assert.equal('59 sec', timeInWords(59, true));
+      expect('59 sec').toEqual(timeInWords(59, true));
     });
     it('60 seconds should return "1 min"', function() {
-      assert.equal('1 min', timeInWords(60, true));
+      expect('1 min').toEqual(timeInWords(60, true));
     });
     it('61 seconds should return "1 min 1 sec"', function() {
-      assert.equal('1 min 1 sec', timeInWords(61, true));
+      expect('1 min 1 sec').toEqual(timeInWords(61, true));
     });
     it('3599 seconds should return "59 min 59 sec"', function() {
-      assert.equal('59 min 59 sec', timeInWords(3599, true));
+      expect('59 min 59 sec').toEqual(timeInWords(3599, true));
     });
     it('3600 seconds should return "1 hr"', function() {
-      assert.equal('1 hr', timeInWords(3600, true));
+      expect('1 hr').toEqual(timeInWords(3600, true));
     });
     it('3601 seconds should return "1 hr"', function() {
-      assert.equal('1 hr', timeInWords(3601, true));
+      expect('1 hr').toEqual(timeInWords(3601, true));
     });
     it('3660 seconds should return "1 hr 1 min"', function() {
-      assert.equal('1 hr 1 min', timeInWords(3660, true));
+      expect('1 hr 1 min').toEqual(timeInWords(3660, true));
     });
     it('3661 seconds should return "1 hr 1 min"', function() {
-      assert.equal('1 hr 1 min', timeInWords(3661, true));
+      expect('1 hr 1 min').toEqual(timeInWords(3661, true));
     });
     it('86399 seconds should return "23 hr 59 min"', function() {
-      assert.equal('23 hrs 59 min', timeInWords(86399, true));
+      expect('23 hrs 59 min').toEqual(timeInWords(86399, true));
     });
     it('86400 seconds should return "more than 24 hrs"', function() {
-      assert.equal('more than 24 hrs', timeInWords(86400, true));
+      expect('more than 24 hrs').toEqual(timeInWords(86400, true));
     });
   });
 });

--- a/src/scripts/utils/formatCardinalNumber.spec.js
+++ b/src/scripts/utils/formatCardinalNumber.spec.js
@@ -1,26 +1,51 @@
-import assert from 'assert';
 import formatCardinalNumber from './formatCardinalNumber';
 
 describe('formatCardinalNumber', () =>{
   describe('invalid input', () => {
-    it('null should return N/A', () => assert.equal(formatCardinalNumber(null), 'N/A'));
-    it('empty string should return N/A', () => assert.equal(formatCardinalNumber(''), 'N/A'));
-    it('invalid number should return N/A', () => assert.equal(formatCardinalNumber('asdafa'), 'N/A'));
+    it('null should return N/A', () => {
+      expect('N/A').toEqual(formatCardinalNumber(null));
+    });
+    it('empty string should return N/A', () => {
+      expect('N/A').toEqual(formatCardinalNumber(''));
+    });
+    it('invalid number should return N/A', () => {
+      expect('N/A').toEqual(formatCardinalNumber('asdafa'));
+    });
   });
 
   describe('valid string input', () => {
-    it('0 should return 0', () => assert.equal(formatCardinalNumber('0'), '0'));
-    it('1 should return 1', () => assert.equal(formatCardinalNumber('1'), '1'));
-    it('100 should return 100', () => assert.equal(formatCardinalNumber('100'), '100'));
-    it('1234 should return 1,234', () => assert.equal(formatCardinalNumber('1234'), '1,234'));
-    it('1234567 should return 1,234,567', () => assert.equal(formatCardinalNumber('1234567'), '1,234,567'));
+    it('0 should return 0', () => {
+      expect('0').toEqual(formatCardinalNumber('0'));
+    });
+    it('1 should return 1', () => {
+      expect('1').toEqual(formatCardinalNumber('1'));
+    });
+    it('100 should return 100', () => {
+      expect('100').toEqual(formatCardinalNumber('100'));
+    });
+    it('1234 should return 1,234', () => {
+      expect('1,234').toEqual(formatCardinalNumber('1234'));
+    });
+    it('1234567 should return 1,234,567', () => {
+      expect('1,234,567').toEqual(formatCardinalNumber('1234567'));
+    });
   });
 
   describe('valid integer input', () => {
-    it('0 should return 0', () => assert.equal(formatCardinalNumber(0), '0'));
-    it('1 should return 1', () => assert.equal(formatCardinalNumber(1), '1'));
-    it('100 should return 100', () => assert.equal(formatCardinalNumber(100), '100'));
-    it('1234 should return 1,234', () => assert.equal(formatCardinalNumber(1234), '1,234'));
-    it('1234567 should return 1,234,567', () => assert.equal(formatCardinalNumber(1234567), '1,234,567'));
+    it('0 should return 0', () => {
+      expect('0').toEqual(formatCardinalNumber(0));
+    });
+    it('1 should return 1', () => {
+      expect('1').toEqual(formatCardinalNumber(1));
+    });
+    it('100 should return 100', () => {
+      expect('100').toEqual(formatCardinalNumber(100));
+    });
+    it('1234 should return 1,234', () => {
+      expect('1,234').toEqual(formatCardinalNumber(1234));
+    });
+    it('1234567 should return 1,234,567', () => {
+      expect('1,234,567').toEqual(formatCardinalNumber(1234567));
+    });
   });
 });

--- a/src/scripts/utils/jobsQueryBuilder.spec.js
+++ b/src/scripts/utils/jobsQueryBuilder.spec.js
@@ -1,28 +1,27 @@
-import assert from 'assert';
 import { getQuery, getLegacyComponentQuery } from './jobsQueryBuilder';
 
 describe('getQuery', () => {
   it('should return a valid query', () => {
-    assert.strictEqual('+params.component:component +params.config:config', getQuery('component', 'config'));
+    expect('+params.component:component +params.config:config').toEqual(getQuery('component', 'config'));
   });
   it('should return a valid query with rowId', () => {
-    assert.strictEqual('+params.component:component +params.config:config +(params.row:row OR (NOT _exists_: params.row))', getQuery('component', 'config', 'row'));
+    expect('+params.component:component +params.config:config +(params.row:row OR (NOT _exists_: params.row))').toEqual(getQuery('component', 'config', 'row'));
   });
 });
 
 describe('getLegacyComponentQuery', () => {
   it('should return a valid query', () => {
-    assert.strictEqual('+component:component +params.config:config', getLegacyComponentQuery('component', 'config'));
+    expect('+component:component +params.config:config').toEqual(getLegacyComponentQuery('component', 'config'));
   });
   it('should return a valid query with rowId for transformations', () => {
-    assert.strictEqual('+component:transformation +params.config:config +(params.transformations:row OR (NOT _exists_: params.transformations))', getLegacyComponentQuery('transformation', 'config', 'row'));
+    expect('+component:transformation +params.config:config +(params.transformations:row OR (NOT _exists_: params.transformations))').toEqual(getLegacyComponentQuery('transformation', 'config', 'row'));
   });
   it('should return fail for query with rowId for another component', () => {
     try {
       getLegacyComponentQuery('component', 'config', 'row');
-      assert.fail('Should have failed');
+      expect.fail('Should have failed');
     } catch (exception) {
-      assert.strictEqual('Component component does not support rows', exception.message);
+      expect('Component component does not support rows').toEqual(exception.message);
     }
   });
 });

--- a/src/scripts/utils/matchByWords.spec.js
+++ b/src/scripts/utils/matchByWords.spec.js
@@ -1,57 +1,54 @@
-import assert from 'assert';
 import matchByWords from './matchByWords';
-
 
 describe('test matchByWords', () => {
   it('should match empty query', () => {
-    assert.strictEqual(matchByWords(' some input string with spaces  ', ''), true);
-    assert.strictEqual(matchByWords('someinputstringwithoutspace', ''), true);
-    assert.strictEqual(matchByWords('', ''), true);
+    expect(true).toEqual(matchByWords(' some input string with spaces  ', ''));
+    expect(true).toEqual(matchByWords('someinputstringwithoutspace', ''));
+    expect(true).toEqual(matchByWords('', ''));
   });
 
   it('should strict match one word query', () => {
-    assert.strictEqual(matchByWords('some input param string', 'param'), true);
-    assert.strictEqual(matchByWords('some input param string', 'param  '), true);
-    assert.strictEqual(matchByWords('some input param string', ' param  '), true);
+    expect(true).toEqual(matchByWords('some input param string', 'param'));
+    expect(true).toEqual(matchByWords('some input param string', 'param  '));
+    expect(true).toEqual(matchByWords('some input param string', ' param  '));
   });
 
   it('should not fuzzy match word', () => {
-    assert.strictEqual(matchByWords('some input param string', 'taram'), false);
-    assert.strictEqual(matchByWords('some input param string', 'taram  '), false);
-    assert.strictEqual(matchByWords('some input param string', ' taram  '), false);
-    assert.strictEqual(matchByWords('some input param string', ' mara  '), false);
+    expect(false).toEqual(matchByWords('some input param string', 'taram'));
+    expect(false).toEqual(matchByWords('some input param string', 'taram  '));
+    expect(false).toEqual(matchByWords('some input param string', ' taram  '));
+    expect(false).toEqual(matchByWords('some input param string', ' mara  '));
   });
 
   it('should match words in order', () => {
-    assert.strictEqual(matchByWords('some input param string', 'some param'), true);
-    assert.strictEqual(matchByWords('some input param string', ' string param'), true);
-    assert.strictEqual(matchByWords('some input param string', '  some   param  '), true);
-    assert.strictEqual(matchByWords('some input param string', ' some  string   '), true);
+    expect(true).toEqual(matchByWords('some input param string', 'some param'));
+    expect(true).toEqual(matchByWords('some input param string', ' string param'));
+    expect(true).toEqual(matchByWords('some input param string', '  some   param  '));
+    expect(true).toEqual(matchByWords('some input param string', ' some  string   '));
   });
 
   it('should not match more words', () => {
-    assert.strictEqual(matchByWords('some input param string', '  blabla   param  '), false);
-    assert.strictEqual(matchByWords('some input param string', ' some  blablag   '), false);
-    assert.strictEqual(matchByWords('some input param string', ' total  blablag   '), false);
+    expect(false).toEqual(matchByWords('some input param string', '  blabla   param  '));
+    expect(false).toEqual(matchByWords('some input param string', ' some  blablag   '));
+    expect(false).toEqual(matchByWords('some input param string', ' total  blablag   '));
   });
 
   it('should not fuzzy match more words', () => {
-    assert.strictEqual(matchByWords('some input param string', ' prm str'), false);
-    assert.strictEqual(matchByWords('some input param string', '  param   sti  '), false);
-    assert.strictEqual(matchByWords('some input param string', ' sm  st '), false);
+    expect(false).toEqual(matchByWords('some input param string', ' prm str'));
+    expect(false).toEqual(matchByWords('some input param string', '  param   sti  '));
+    expect(false).toEqual(matchByWords('some input param string', ' sm  st '));
   });
 
   it('should fuzzy match by single characters', () => {
-    assert.strictEqual(matchByWords('some input param string', ' string p r m str'), true);
-    assert.strictEqual(matchByWords('some input param string', ' p r m str'), true);
-    assert.strictEqual(matchByWords('some input param string', '  param   st i  '), true);
-    assert.strictEqual(matchByWords('some input param string', ' som  s g '), true);
-    assert.strictEqual(matchByWords('some input param string', ' i g put'), true);
-
-    assert.strictEqual(matchByWords('some input param string', ' input  e'), true);
+    expect(true).toEqual(matchByWords('some input param string', ' string p r m str'));
+    expect(true).toEqual(matchByWords('some input param string', ' p r m str'));
+    expect(true).toEqual(matchByWords('some input param string', '  param   st i  '));
+    expect(true).toEqual(matchByWords('some input param string', ' som  s g '));
+    expect(true).toEqual(matchByWords('some input param string', ' i g put'));
+    expect(true).toEqual(matchByWords('some input param string', ' input  e'));
   });
 
   it('should not fuzzy match by single characters', () => {
-    assert.strictEqual(matchByWords('some input param string', ' igput  s'), false);
+    expect(false).toEqual(matchByWords('some input param string', ' igput  s'));
   });
 });

--- a/src/scripts/utils/string.spec.js
+++ b/src/scripts/utils/string.spec.js
@@ -1,32 +1,31 @@
-import assert from 'assert';
 import stringUtils from './string';
 const {webalize} = stringUtils;
 
 describe('string utils tests', function() {
   describe('webalize', function() {
     it('jeden dva tri styri pat -> jeden-dva-tri-styri-pat', function() {
-      assert.equal(webalize('jeden dva tri styri pat'), 'jeden-dva-tri-styri-pat');
+      expect('jeden-dva-tri-styri-pat').toEqual(webalize('jeden dva tri styri pat'));
     });
     it('jeden dva  Tri -> jeden-dva-tri', function() {
-      assert.equal(webalize('jeden dva  Tri'), 'jeden-dva-tri');
+      expect('jeden-dva-tri').toEqual(webalize('jeden dva  Tri'));
     });
     it('jeden DVA  Tri -> jeden-DVA-Tri', function() {
-      assert.equal(webalize('jeden DVA  Tri', {caseSensitive: true}), 'jeden-DVA-Tri');
+      expect('jeden-DVA-Tri').toEqual(webalize('jeden DVA  Tri', {caseSensitive: true}));
     });
     it('Háčky a čárky NEdělají problémyô->hacky-a-carky-nedelaji-problemyo', function() {
-      assert.equal(webalize('Háčky a čárky NEdělají problémyô'), 'hacky-a-carky-nedelaji-problemyo');
+      expect('hacky-a-carky-nedelaji-problemyo').toEqual(webalize('Háčky a čárky NEdělají problémyô'));
     });
     it('LaLaLa123->lalala123', function() {
-      assert.equal(webalize('LaLaLa123'), 'lalala123');
+      expect('lalala123').toEqual(webalize('LaLaLa123'));
     });
     it('a_b->a_b', function() {
-      assert.equal(webalize('a_b'), 'a_b');
+      expect('a_b').toEqual(webalize('a_b'));
     });
     it('__a__b___c->a_b_c', function() {
-      assert.equal(webalize('__a__b___c'), 'a_b_c');
+      expect('a_b_c').toEqual(webalize('__a__b___c'));
     });
     it('_a_b_->a_b', function() {
-      assert.equal(webalize('_a_b_'), 'a_b');
+      expect('a_b').toEqual(webalize('_a_b_'));
     });
   });
 });

--- a/src/scripts/utils/tableIdParser.spec.js
+++ b/src/scripts/utils/tableIdParser.spec.js
@@ -1,74 +1,73 @@
-import assert from 'assert';
 import {parse} from './tableIdParser';
 
 describe('tableIdParser', () => {
   it('should parse null input', function() {
     const parsed = parse(null);
-    assert.equal('..', parsed.tableId);
+    expect('..').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('', stage);
-    assert.equal('', bucket);
-    assert.equal('', table);
+    expect('').toEqual(stage);
+    expect('').toEqual(bucket);
+    expect('').toEqual(table);
   });
   it('should parse null input with default stage', function() {
     const parsed = parse(null, {defaultStage: 'out'});
-    assert.equal('out..', parsed.tableId);
+    expect('out..').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('out', stage);
-    assert.equal('', bucket);
-    assert.equal('', table);
+    expect('out').toEqual(stage);
+    expect('').toEqual(bucket);
+    expect('').toEqual(table);
   });
 
   it('should parse table with missing bucket', function() {
     const parsed = parse('in..table', {defaultStage: 'out'});
-    assert.equal('in..table', parsed.tableId);
+    expect('in..table').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('in', stage);
-    assert.equal('', bucket);
-    assert.equal('table', table);
+    expect('in').toEqual(stage);
+    expect('').toEqual(bucket);
+    expect('table').toEqual(table);
   });
 
   it('should parse bucket with missing table', function() {
     const parsed = parse('in.bucket.', {defaultStage: 'out'});
-    assert.equal('in.bucket.', parsed.tableId);
+    expect('in.bucket.').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('in', stage);
-    assert.equal('bucket', bucket);
-    assert.equal('', table);
+    expect('in').toEqual(stage);
+    expect('bucket').toEqual(bucket);
+    expect('').toEqual(table);
   });
 
   it('should parse whole tableId', function() {
     const parsed = parse('in.bucket.table');
-    assert.equal('in.bucket.table', parsed.tableId);
+    expect('in.bucket.table').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('in', stage);
-    assert.equal('bucket', bucket);
-    assert.equal('table', table);
+    expect('in').toEqual(stage);
+    expect('bucket').toEqual(bucket);
+    expect('table').toEqual(table);
   });
 
   it('should parse null input with default stage and bucket', function() {
     const parsed = parse(null, {defaultStage: 'out', defaultBucket: 'bucket'});
-    assert.equal('out.bucket.', parsed.tableId);
+    expect('out.bucket.').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('out', stage);
-    assert.equal('bucket', bucket);
-    assert.equal('', table);
+    expect('out').toEqual(stage);
+    expect('bucket').toEqual(bucket);
+    expect('').toEqual(table);
   });
 
   it('should parse input with default stage and bucket', function() {
     const parsed = parse('in.other.table', {defaultStage: 'out', defaultBucket: 'bucket'});
-    assert.equal('in.other.table', parsed.tableId);
+    expect('in.other.table').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('in', stage);
-    assert.equal('other', bucket);
-    assert.equal('table', table);
+    expect('in').toEqual(stage);
+    expect('other').toEqual(bucket);
+    expect('table').toEqual(table);
   });
   it('should parse input filling defaultbucket', function() {
     const parsed = parse('in..table', {defaultStage: 'out', defaultBucket: 'bucket'});
-    assert.equal('in.bucket.table', parsed.tableId);
+    expect('in.bucket.table').toEqual(parsed.tableId);
     const {stage, bucket, table} = parsed.parts;
-    assert.equal('in', stage);
-    assert.equal('bucket', bucket);
-    assert.equal('table', table);
+    expect('in').toEqual(stage);
+    expect('bucket').toEqual(bucket);
+    expect('table').toEqual(table);
   });
 });

--- a/src/scripts/utils/validateStorageTableId.spec.js
+++ b/src/scripts/utils/validateStorageTableId.spec.js
@@ -1,29 +1,27 @@
-var assert = require('assert');
 var validateStorageTableId = require('./validateStorageTableId');
-
 
 describe('validateStorageTableId', function() {
   describe('#validateStorageTableId()', function() {
     it('should return false on empty string', function() {
-      assert.equal(false, validateStorageTableId(''));
+      expect(false).toEqual(validateStorageTableId(''));
     });
     it('should return false on sys bucket', function() {
-      assert.equal(false, validateStorageTableId('sys.c-whatever.table'));
+      expect(false).toEqual(validateStorageTableId('sys.c-whatever.table'));
     });
     it('should return false on missing table part', function() {
-      assert.equal(false, validateStorageTableId('in.c-data.'));
+      expect(false).toEqual(validateStorageTableId('in.c-data.'));
     });
     it('should return false on invalid character in table part', function() {
-      assert.equal(false, validateStorageTableId('in.c-data.#'));
+      expect(false).toEqual(validateStorageTableId('in.c-data.#'));
     });
     it('should return false on invalid prefix', function() {
-      assert.equal(false, validateStorageTableId('in.x-data.abc'));
+      expect(false).toEqual(validateStorageTableId('in.x-data.abc'));
     });
     it('should return true on valid in bucket table', function() {
-      assert.equal(true, validateStorageTableId('in.c-data.abc'));
+      expect(true).toEqual(validateStorageTableId('in.c-data.abc'));
     });
     it('should return true on valid out bucket table', function() {
-      assert.equal(true, validateStorageTableId('out.c-data.abc'));
+      expect(true).toEqual(validateStorageTableId('out.c-data.abc'));
     });
   });
 });


### PR DESCRIPTION
Fixes #2693

Kompletně jsem nahradil `assert` za `expect`.

Po přepsání pouze jeden test neprošel (což je dobré, pokud to netestovalo teda na sto procent dříve). Divné ale objekt vracel v jedné property "" a porovnávalo se to s "false" (nebo naopak už nevím přesně) a prošlo to. Po přepsání na `expect` už to končilo chybou tak jsem to upravil.