### PR TITLE
use lowercase when checking datatypes

### DIFF
--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -149,7 +149,7 @@ export function createActions(componentId) {
     const allowedTypes = incrementalFetchingTypes.get(componentId, List());
     return sourceTables.reduce((memo, table) => {
       const qualifyingColumns = table.get('columns', List()).filter((column) => {
-        if (allowedTypes.includes(column.get('type'))) {
+        if (allowedTypes.includes(column.get('type').toLowerCase())) {
           return column;
         }
       });

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -149,9 +149,7 @@ export function createActions(componentId) {
     const allowedTypes = incrementalFetchingTypes.get(componentId, List());
     return sourceTables.reduce((memo, table) => {
       const qualifyingColumns = table.get('columns', List()).filter((column) => {
-        if (column.get('type') && allowedTypes.includes(column.get('type').toLowerCase())) {
-          return column;
-        }
+        return column.get('type') && allowedTypes.includes(column.get('type').toLowerCase());
       });
       if (qualifyingColumns.count() > 0) {
         return memo.push(Map({

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -149,7 +149,7 @@ export function createActions(componentId) {
     const allowedTypes = incrementalFetchingTypes.get(componentId, List());
     return sourceTables.reduce((memo, table) => {
       const qualifyingColumns = table.get('columns', List()).filter((column) => {
-        if (allowedTypes.includes(column.get('type').toLowerCase())) {
+        if (column.get('type') && allowedTypes.includes(column.get('type').toLowerCase())) {
           return column;
         }
       });

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -167,7 +167,7 @@ export default React.createClass({
           value: candidate.get('name'),
           label: candidate.get('name')
         };
-      }).toJS();
+      }).toList().toJS();
     } else {
       return [];
     }


### PR DESCRIPTION
Fixes #2732 

Proposed changes:

- use lowercase compare for datatypes when finding candidate columns
