### PR TITLE
HttpError: undefined

### DIFF
--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -69,16 +69,8 @@ const startApp = appOptions => {
   Promise.onPossiblyUnhandledRejection(e => {
     const error = Error.create(e);
 
-    const notification = React.createClass({
-      render() {
-        return (
-          <ErrorNotification error={error} />
-        );
-      }
-    });
-
     ApplicationActionCreators.sendNotification({
-      message: notification,
+      message: () => <ErrorNotification error={error} />,
       type: 'error',
       id: error.id
     });

--- a/src/scripts/utils/HttpError.js
+++ b/src/scripts/utils/HttpError.js
@@ -6,6 +6,9 @@ class HttpError extends Error {
     if (this.response.body) {
       this.message = this.response.body.error || this.response.body.message || this.response.body.errorMessage;
     }
+    if (this.response.serverError) {
+      this.message = 'Server error';
+    }
   }
 }
 

--- a/src/scripts/utils/HttpError.js
+++ b/src/scripts/utils/HttpError.js
@@ -2,8 +2,9 @@ class HttpError extends Error {
   constructor(response) {
     super();
     this.response = response;
+
     if (this.response.body) {
-      this.message = this.response.body.error;
+      this.message = this.response.body.error || this.response.body.message || this.response.body.errorMessage;
     }
   }
 }


### PR DESCRIPTION
Koukal jsem na nějaké issue, něco jako #2501 (možná fixed, aspoň to je psané v sentry).

Kde chodí `Error: undefined`. Nejdřív jsem chtěl nějak ty chyby ošetřit (z toho issue výše), ale pak jsem si uvědomil, že není smyslem chyby mimo (400, 401, 403, 404 - tento seznam je v kódu) ošetřovat, protože potřebuje aby právě došli do Sentry a my mohli zjistit o co šlo a opravit to.

Přímo ale ve `createFromXhrError` se hledá message na více místech (error, errorMessage a message).
Pokud se ale pak zjistí že nejde o "userError" `isUserError`, vyhodí se pouze klasický zachycený error `throw e`, v případě že jde o HttpError a ta error message byla někde jinde než v message, tak tam je undefined, což je škoda. Pak to právě dopadne jako třeba `HttpError: undefined`.

Nevím jak moc je to BC break, kdy tam message teď bude mít častěji nějakou hodnotu. 