### PR TITLE
google analytics ex: prevent infinite loop in date picker date validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-bootstrap": "^0.31.5",
     "react-clipboard.js": "^0.1.5",
     "react-code-mirror": "~3.0.4",
-    "react-datetime": "2.10.2",
+    "react-datetime": "git+https://git@github.com/keboola/react-datetime.git#v2.10.3-fix",
     "react-dnd": "~2.2.0",
     "react-dnd-html5-backend": "~2.2.0",
     "react-document-title": "~1.0.2",

--- a/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/DateRangeModal.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/DateRangeModal.jsx
@@ -110,8 +110,6 @@ export default React.createClass({
   },
 
   renderAbsolute() {
-    const isStartValid = moment(this.state.absoluteStart).isValid();
-    const isEndValid = moment(this.state.absoluteEnd).isValid();
 
     return (
       <Form horizontal>
@@ -126,7 +124,7 @@ export default React.createClass({
               timeFormat={false}
               value={this.state.absoluteStart}
               onChange={val => this.setState({ absoluteStart: val })}
-              isValidDate={current => !isEndValid || current.isBefore(this.state.absoluteEnd)}
+              isValidDate={current => !moment(this.state.absoluteEnd, 'YYYY-MM-DD', true).isValid() || (current.isBefore(this.state.absoluteEnd))}
             />
           </Col>
         </FormGroup>
@@ -141,7 +139,7 @@ export default React.createClass({
               timeFormat={false}
               value={this.state.absoluteEnd}
               onChange={val => this.setState({ absoluteEnd: val })}
-              isValidDate={current => !isStartValid || current.isAfter(this.state.absoluteStart)}
+              isValidDate={current => !moment(this.state.absoluteStart, 'YYYY-MM-DD', true).isValid() || (current.isAfter(this.state.absoluteStart))}
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/DateRangeModal.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/components/QueryEditor/DateRangeModal.jsx
@@ -110,7 +110,6 @@ export default React.createClass({
   },
 
   renderAbsolute() {
-
     return (
       <Form horizontal>
         <FormGroup>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6686,10 +6686,9 @@ react-code-mirror@~3.0.4:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/react-code-mirror/-/react-code-mirror-3.0.6.tgz#65e95abb479165e1678e3ee9837fb4d0438868f1"
 
-react-datetime@2.10.2:
-  version "2.10.2"
-  resolved "https://registry.yarnpkg.com/react-datetime/-/react-datetime-2.10.2.tgz#0a91819c8068f6f3f24bbc687c0039820145a43e"
-  integrity sha512-tErw6Yp6fGRX6BQ1vTgSqDabWLpCovxLoMaohWB41yv5K1umf8JrxAZLt1JjKVDYdU0aBC+nH1/K9x4CLEq7rA==
+"react-datetime@git+https://git@github.com/keboola/react-datetime.git#v2.10.3-fix":
+  version "2.10.3-fix"
+  resolved "git+https://git@github.com/keboola/react-datetime.git#04bd1d24c94c3f3b31220d6fe67f206cd5daef11"
   dependencies:
     create-react-class "^15.5.2"
     object-assign "^3.0.0"


### PR DESCRIPTION
Fixes #2751 

Proposed changes:
- enforce strict date parsing on date validation
- ~update react-datetime lib to prevent infinite loop when isValidDate returns always false~

~viac je to popisane v https://github.com/YouCanBookMe/react-datetime/issues/ 
issue cislo 414 (nechcem im to tam referencovat)~

Jedine co nakoniec zabralo bolo striktne parsovanie date a parsovat ich priamo vo funkcii `isValidDate` toho pickeru. 