### PR TITLE
Wr-Db - PrepareColumnsType - return empty list instead of null

### DIFF
--- a/src/scripts/modules/wr-db/templates/columnsMetadata.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.js
@@ -4,7 +4,7 @@ import { SnowflakeDataTypesMapping } from '../../transformations/Constants';
 
 export function prepareColumnsTypes(componentId, table) {
   if (!DataTypes[componentId]) {
-    return null;
+    return List();
   }
 
   const defaultType = fromJS(DataTypes[componentId].default || {});

--- a/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
@@ -1,4 +1,4 @@
-import { fromJS } from 'immutable';
+import { fromJS, List } from 'immutable';
 import { prepareColumnsTypes } from './columnsMetadata';
 
 const SnowflakeComponentId = 'keboola.wr-db-snowflake';
@@ -31,8 +31,8 @@ function defaultMysqlType(column) {
 }
 
 describe('prepareColumnsTypes', function() {
-  it('it return null for unknown componentId', () => {
-    expect(null).toEqual(prepareColumnsTypes('keboola.wr-db-unknown', table));
+  it('it return empty list for unknown componentId', () => {
+    expect(List()).toEqual(prepareColumnsTypes('keboola.wr-db-unknown', table));
   });
 
   it('only table with snowflake backend can read metadata, default values is returned for others backend', () => {


### PR DESCRIPTION
Ve "updateTablesMapping" se volá `filter` nad `items`, ale asi často to mohlo být null a tak to chybovalo při tvorbě nové tabulky.

Toto jsem asi psal já (podle testů co mi jsou povědomí), tak jsem tam udělal chybu. Mělo by to spíš vracet prázdný list.