### PR TITLE
Checking detail of IM breaks adding new IM

### DIFF
--- a/src/scripts/modules/components/react/components/generic/AddFileInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/AddFileInputMapping.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import FileInputMappingModal from './FileInputMappingModal';
 import actionCreators from '../../../InstalledComponentsActionCreators';
+import FileInputMappingModal from './FileInputMappingModal';
 
 export default React.createClass({
   propTypes: {
@@ -10,16 +10,17 @@ export default React.createClass({
   },
 
   render() {
-    return React.createElement(FileInputMappingModal, {
-      mode: 'create',
-      mapping: this.props.mapping,
-      onChange: this.handleChange,
-      onCancel: this.handleCancel,
-      onSave: this.handleSave
-    });
+    return (
+      <FileInputMappingModal
+        mode="create"
+        mapping={this.props.mapping}
+        onChange={this.handleChange}
+        onCancel={this.handleCancel}
+        onSave={this.handleSave}
+      />
+    );
   },
 
-  /* eslint camelcase: 0 */
   handleChange(newMapping) {
     actionCreators.changeEditingMapping(this.props.componentId,
       this.props.configId,
@@ -40,7 +41,6 @@ export default React.createClass({
   },
 
   handleSave() {
-    // returns promise
     return actionCreators.saveEditingMapping(this.props.componentId,
       this.props.configId,
       'input',
@@ -49,5 +49,4 @@ export default React.createClass({
       'Add input file'
     );
   }
-
 });

--- a/src/scripts/modules/components/react/components/generic/AddFileOutputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/AddFileOutputMapping.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import FileOutputMappingModal from './FileOutputMappingModal';
 import actionCreators from '../../../InstalledComponentsActionCreators';
+import FileOutputMappingModal from './FileOutputMappingModal';
 
 export default React.createClass({
   propTypes: {
@@ -10,16 +10,17 @@ export default React.createClass({
   },
 
   render() {
-    return React.createElement(FileOutputMappingModal, {
-      mode: 'create',
-      mapping: this.props.mapping,
-      onChange: this.handleChange,
-      onCancel: this.handleCancel,
-      onSave: this.handleSave
-    });
+    return (
+      <FileOutputMappingModal
+        mode="create"
+        mapping={this.props.mapping}
+        onChange={this.handleChange}
+        onCancel={this.handleCancel}
+        onSave={this.handleSave}
+      />
+    );
   },
 
-  /* eslint camelcase: 0 */
   handleChange(newMapping) {
     actionCreators.changeEditingMapping(this.props.componentId,
       this.props.configId,
@@ -40,7 +41,6 @@ export default React.createClass({
   },
 
   handleSave() {
-    // returns promise
     return actionCreators.saveEditingMapping(this.props.componentId,
       this.props.configId,
       'output',
@@ -49,5 +49,4 @@ export default React.createClass({
       'Add file output'
     );
   }
-
 });

--- a/src/scripts/modules/components/react/components/generic/AddTableInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/AddTableInputMapping.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import Modal from './TableInputMappingModal';
 import actionCreators from '../../../InstalledComponentsActionCreators';
+import Modal from './TableInputMappingModal';
 
 export default React.createClass({
   propTypes: {
@@ -12,18 +12,19 @@ export default React.createClass({
   },
 
   render() {
-    return React.createElement(Modal, {
-      mode: 'create',
-      mapping: this.props.mapping,
-      tables: this.props.tables,
-      onChange: this.handleChange,
-      onCancel: this.handleCancel,
-      onSave: this.handleSave,
-      otherDestinations: this.props.otherDestinations
-    });
+    return (
+      <Modal
+        mode="create"
+        mapping={this.props.mapping}
+        tables={this.props.tables}
+        onChange={this.handleChange}
+        onCancel={this.handleCancel}
+        onSave={this.handleSave}
+        otherDestinations={this.props.otherDestinations}
+      />
+    );
   },
 
-  /* eslint camelcase: 0 */
   handleChange(newMapping) {
     actionCreators.changeEditingMapping(this.props.componentId,
       this.props.configId,
@@ -45,7 +46,7 @@ export default React.createClass({
 
   handleSave() {
     const newTableId = this.props.mapping.get('source');
-    // returns promise
+
     return actionCreators.saveEditingMapping(this.props.componentId,
       this.props.configId,
       'input',
@@ -54,5 +55,4 @@ export default React.createClass({
       `Add input table ${newTableId}`
     );
   }
-
 });

--- a/src/scripts/modules/components/react/components/generic/AddTableOutputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/AddTableOutputMapping.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import TableOutputMappingModal from './TableOutputMappingModal';
 import actionCreators from '../../../InstalledComponentsActionCreators';
+import TableOutputMappingModal from './TableOutputMappingModal';
 
 export default React.createClass({
   propTypes: {
@@ -12,18 +12,19 @@ export default React.createClass({
   },
 
   render() {
-    return React.createElement(TableOutputMappingModal, {
-      mode: 'create',
-      mapping: this.props.mapping,
-      tables: this.props.tables,
-      buckets: this.props.buckets,
-      onChange: this.handleChange,
-      onCancel: this.handleCancel,
-      onSave: this.handleSave
-    });
+    return (
+      <TableOutputMappingModal
+        mode="create"
+        mapping={this.props.mapping}
+        tables={this.props.tables}
+        buckets={this.props.buckets}
+        onChange={this.handleChange}
+        onCancel={this.handleCancel}
+        onSave={this.handleSave}
+      />
+    );
   },
 
-  /* eslint camelcase: 0 */
   handleChange(newMapping) {
     actionCreators.changeEditingMapping(this.props.componentId,
       this.props.configId,
@@ -45,7 +46,6 @@ export default React.createClass({
 
   handleSave() {
     const newTableId = this.props.mapping.get('destination');
-    // returns promise
     return actionCreators.saveEditingMapping(this.props.componentId,
       this.props.configId,
       'output',
@@ -54,5 +54,4 @@ export default React.createClass({
       `Add output table ${newTableId}`
     );
   }
-
 });

--- a/src/scripts/modules/components/react/components/generic/FileInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileInputMapping.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
         <Add
           componentId={this.props.componentId}
           configId={this.props.configId}
-          mapping={this.props.editingValue.toMap().get('new-mapping', Map())}
+          mapping={this.props.editingValue.get('new-mapping', Map())}
         />
       </span>
     );
@@ -63,7 +63,7 @@ export default React.createClass({
         <Add
           componentId={this.props.componentId}
           configId={this.props.configId}
-          mapping={this.props.editingValue.toMap().get('new-mapping', Map())}
+          mapping={this.props.editingValue.get('new-mapping', Map())}
         />
       </div>
     );

--- a/src/scripts/modules/components/react/components/generic/FileOutputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileOutputMapping.jsx
@@ -24,7 +24,7 @@ export default React.createClass({
           <Add
             componentId={this.props.componentId}
             configId={this.props.configId}
-            mapping={this.props.editingValue.toMap().get('new-mapping', Immutable.Map())}
+            mapping={this.props.editingValue.get('new-mapping', Immutable.Map())}
           />
         </span>
       );
@@ -123,7 +123,7 @@ export default React.createClass({
           <Add
             componentId={this.props.componentId}
             configId={this.props.configId}
-            mapping={this.props.editingValue.toMap().get('new-mapping', Immutable.Map())}
+            mapping={this.props.editingValue.get('new-mapping', Immutable.Map())}
           />
         </div>
       );

--- a/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
           tables={this.props.tables}
           componentId={this.props.componentId}
           configId={this.props.configId}
-          mapping={this.props.editingValue.toMap().get('new-mapping', Map())}
+          mapping={this.props.editingValue.get('new-mapping', Map())}
           otherDestinations={this.inputMappingDestinations()}
         />
       </span>
@@ -71,7 +71,7 @@ export default React.createClass({
           tables={this.props.tables}
           componentId={this.props.componentId}
           configId={this.props.configId}
-          mapping={this.props.editingValue.toMap().get('new-mapping', Map())}
+          mapping={this.props.editingValue.get('new-mapping', Map())}
           otherDestinations={this.inputMappingDestinations()}
         />
       </div>

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
@@ -1,13 +1,10 @@
 import React from 'react';
-import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { Map } from 'immutable';
 import DeleteButton from '../../../../../react/common/DeleteButton';
 import TableSizeLabel from '../../../../transformations/react/components/TableSizeLabel';
 import TableInputMappingModal from './TableInputMappingModal';
 
 export default React.createClass({
-  mixins: [ImmutableRenderMixin],
-
   propTypes: {
     value: React.PropTypes.object.isRequired,
     editingValue: React.PropTypes.object.isRequired,

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
@@ -1,10 +1,10 @@
 import React, {PropTypes} from 'react';
+import { Map } from 'immutable';
 import {Modal, Button} from 'react-bootstrap';
 import Tooltip from './../../../../../react/common/Tooltip';
 import ConfirmButtons from '../../../../../react/common/ConfirmButtons';
+import { resolveTableInputShowDetails } from './resolveInputShowDetails';
 import Editor from './TableInputMappingEditor';
-import {resolveTableInputShowDetails} from './resolveInputShowDetails';
-import { Map } from 'immutable';
 
 const MODE_CREATE = 'create', MODE_EDIT = 'edit';
 
@@ -16,12 +16,10 @@ export default React.createClass({
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
-    onEditStart: PropTypes.func,
-    title: PropTypes.string,
     otherDestinations: PropTypes.object.isRequired,
-    showFileHint: PropTypes.bool,
+    onEditStart: PropTypes.func,
     definition: PropTypes.object,
-
+    showFileHint: PropTypes.bool,
     buttonBsStyle: PropTypes.string,
     buttonLabel: PropTypes.string,
     tooltipText: PropTypes.string
@@ -30,7 +28,10 @@ export default React.createClass({
   getDefaultProps() {
     return {
       showFileHint: true,
-      definition: Map()
+      definition: Map(),
+      buttonBsStyle: 'success',
+      buttonLabel: 'New Table Input',
+      tooltipText: 'Edit Input'
     };
   },
 
@@ -68,17 +69,13 @@ export default React.createClass({
   },
 
   render() {
-    let title = 'Input Mapping';
-    if (this.props.definition.get('label')) {
-      title = this.props.definition.get('label');
-    }
     return (
       <span>
         { this.renderOpenButton() }
         <Modal onHide={this.handleCancel} show={this.state.showModal} bsSize="large">
-          <Modal.Header closeButton={true}>
+          <Modal.Header closeButton>
             <Modal.Title>
-              {title}
+              {this.props.definition.get('label') || 'Input Mapping'}
             </Modal.Title>
           </Modal.Header>
           <Modal.Body>
@@ -100,23 +97,20 @@ export default React.createClass({
 
   renderOpenButton() {
     if (this.props.mode === MODE_EDIT) {
-      const tooltipText = this.props.tooltipText ? this.props.tooltipText : 'Edit Input';
       return (
-        <Tooltip tooltip={tooltipText} placement="top">
+        <Tooltip tooltip={this.props.tooltipText} placement="top">
           <Button bsStyle="link" onClick={this.handleEditButtonClick}>
             <span className="fa fa-pencil" />
           </Button>
         </Tooltip>
       );
-    } else {
-      let buttonBsStyle = this.props.buttonBsStyle ? this.props.buttonBsStyle : 'success';
-      let buttonLabel = this.props.buttonLabel ? this.props.buttonLabel : 'New Table Input';
-      return (
-        <Button bsStyle={buttonBsStyle} onClick={this.open}>
-          <i className="kbc-icon-plus" />{buttonLabel}
-        </Button>
-      );
     }
+
+    return (
+      <Button bsStyle={this.props.buttonBsStyle} onClick={this.open}>
+        <i className="kbc-icon-plus" />{this.props.buttonLabel}
+      </Button>
+    );
   },
 
   handleEditButtonClick(e) {
@@ -173,5 +167,4 @@ export default React.createClass({
         throw e;
       });
   }
-
 });

--- a/src/scripts/modules/components/react/components/generic/TableOutputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMapping.jsx
@@ -36,7 +36,7 @@ export default React.createClass({
             buckets={this.props.buckets}
             componentId={this.props.componentId}
             configId={this.props.configId}
-            mapping={this.props.editingValue.toMap().get('new-mapping', Immutable.Map())}
+            mapping={this.props.editingValue.get('new-mapping', Immutable.Map())}
           />
         </span>
       );
@@ -149,7 +149,7 @@ export default React.createClass({
             buckets={this.props.buckets}
             componentId={this.props.componentId}
             configId={this.props.configId}
-            mapping={this.props.editingValue.toMap().get('new-mapping', Immutable.Map())}
+            mapping={this.props.editingValue.get('new-mapping', Immutable.Map())}
           />
         </div>
       );

--- a/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
@@ -99,7 +99,7 @@ export default React.createClass({
           componentId={this.state.componentId}
           configId={this.state.config.get('id')}
           value={this.state.configData.getIn(['storage', 'input', 'tables'], List())}
-          editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'tables'], List())}
+          editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'tables'], Map())}
           tables={this.state.tables}
           pendingActions={this.state.pendingActions}
           openMappings={this.state.openMappings}
@@ -117,7 +117,7 @@ export default React.createClass({
           componentId={this.state.componentId}
           configId={this.state.config.get('id')}
           value={this.state.configData.getIn(['storage', 'input', 'files'], List())}
-          editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'files'], List())}
+          editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'files'], Map())}
           pendingActions={this.state.pendingActions}
           openMappings={this.state.openMappings}
         />
@@ -134,7 +134,7 @@ export default React.createClass({
           componentId={this.state.componentId}
           configId={this.state.config.get('id')}
           value={this.state.configData.getIn(['storage', 'output', 'tables'], List())}
-          editingValue={this.state.editingConfigData.getIn(['storage', 'output', 'tables'], List())}
+          editingValue={this.state.editingConfigData.getIn(['storage', 'output', 'tables'], Map())}
           tables={this.state.tables}
           buckets={this.state.buckets}
           pendingActions={this.state.pendingActions}
@@ -153,7 +153,7 @@ export default React.createClass({
           componentId={this.state.componentId}
           configId={this.state.config.get('id')}
           value={this.state.configData.getIn(['storage', 'output', 'files'], List())}
-          editingValue={this.state.editingConfigData.getIn(['storage', 'output', 'files'], List())}
+          editingValue={this.state.editingConfigData.getIn(['storage', 'output', 'files'], Map())}
           pendingActions={this.state.pendingActions}
           openMappings={this.state.openMappings}
         />

--- a/src/scripts/modules/components/stores/InstalledComponentsStore.js
+++ b/src/scripts/modules/components/stores/InstalledComponentsStore.js
@@ -1,6 +1,6 @@
 import Dispatcher from '../../../Dispatcher';
 import * as constants from '../Constants';
-import { Map, List, fromJS } from 'immutable';
+import { Map, fromJS } from 'immutable';
 import TemplatesStore from './TemplatesStore';
 import ComponentsStore from './ComponentsStore';
 import StoreUtils from '../../../utils/StoreUtils';
@@ -819,24 +819,7 @@ Dispatcher.register(function(payload) {
         action.storage,
         action.index
       ];
-      var pathList = [
-        'configDataEditingObject',
-        action.componentId,
-        action.configId,
-        'storage',
-        action.mappingType,
-        action.storage
-      ];
-
-      if (!_store.hasIn(pathList)) {
-        _store = _store.setIn(pathList, List());
-      }
       _store = _store.setIn(path, currentMapping);
-
-      // editing mappings List may contain undefined values, make sure it contains empty Maps at least
-      // https://github.com/keboola/kbc-ui/pull/1623#issuecomment-381090091
-      var mappingsList = _store.getIn(pathList, List()).map(m => m || Map());
-      _store = _store.setIn(pathList, mappingsList);
       return InstalledComponentsStore.emitChange();
 
     case constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_EDITING_CANCEL:

--- a/src/scripts/modules/components/utils/mappingDefinitions.js
+++ b/src/scripts/modules/components/utils/mappingDefinitions.js
@@ -1,4 +1,4 @@
-var  Immutable = require('immutable');
+var Immutable = require('immutable');
 
 var mergeValueAndDefinition = function(compareKey, definitions, value) {
   if (definitions.size > 0) {
@@ -26,7 +26,7 @@ var mergeValueAndDefinition = function(compareKey, definitions, value) {
 var findDefinition = function(compareKey, definitions, value) {
   return definitions.find(function(definition) {
     return definition.get(compareKey) === value.get(compareKey);
-  }) || new Immutable.Map();
+  }, null, Immutable.Map());
 };
 
 module.exports = {

--- a/src/scripts/modules/custom-science/react/Index.jsx
+++ b/src/scripts/modules/custom-science/react/Index.jsx
@@ -70,7 +70,7 @@ export default React.createClass({
               tables={this.state.tables}
               pendingActions={this.state.pendingActions}
               openMappings={this.state.openMappings}
-              editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'tables'], List())}
+              editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'tables'], Map())}
               configId={this.state.configId}
               value={this.state.configData.getIn(['storage', 'input', 'tables'], List())}/>
           </div>


### PR DESCRIPTION
Fixes #2761

Jsou tu dva commity, první jsem hledal chybu na špatným místě, tak jsem upravit nějaký komponenty. Omezit použití `createElement`. Použít `react-immutable-render-mixin` protože jinak se v modalech i vlastně celá ta sekce třeba "Input mapping" překreslovala každých pár sekund co se aktualizovaly joby.

Pak už jsem nalezl chybu samotného bugu.

Pokud na detailu transformace otevřu modal na přidání tabulky třeba. Tak se do `configDataEditingObject ->componentId -> configId -> storage -> input -> tables` uloží 'new-mapping'. Tables je tak `Map`.

Pokud ale nejdřív jdu na detail tabulky. Tak u startu editace je podmínka:
```js
if (!_store.hasIn(pathList)) {
  _store = _store.setIn(pathList, List());
}
```
`pathList` je cesta právě k tables. A místo Map se tam vloží List. Pak se tam vloží nějaký hodnota a ještě protože to je List tak se to tam nějak upravuje víc. Je tam koment i na github issue.

No a pak už mám teda List, a když najednou otevřu přidání tabulky tak to chce uložit pod kličem 'new-mapping' ale to v Listu nejde tak se nic nestane.

Moje řešení teda bylo používat rovnou všude Map. Myslím že by to mělo být ok, protože se tam nepoužívají někde nějaký funkce co by s tím pracovaly jako s polem. Aspoň co jsem dohledal.