### PR TITLE
Jobs - fixes

### DIFF
--- a/src/scripts/modules/jobs/ActionCreators.js
+++ b/src/scripts/modules/jobs/ActionCreators.js
@@ -30,7 +30,7 @@ export default {
   },
 
   // poll for not finished jobs
-  reloadNotFinishedJobs(self) {
+  reloadNotFinishedJobs() {
     const allJobs = JobsStore.getAll()
       .filter(job => !job.get('isFinished'))
       .map(j => j.get('id'))
@@ -39,12 +39,14 @@ export default {
       return Promise.resolve();
     }
     const query = `(id:${allJobs.join(' OR id:')})`;
-    return self.loadJobsForce(0, false, true, query);
+    return this.loadJobsForce(0, false, true, query);
   },
 
   reloadJobs() {
     if (JobsStore.loadJobsErrorCount() < 10) {
-      return this.loadJobsForce(0, false, true).then(this.reloadNotFinishedJobs(this));
+      return this.loadJobsForce(0, false, true).then(() => {
+        this.reloadNotFinishedJobs();
+      });
     }
   },
 

--- a/src/scripts/modules/jobs/ActionCreators.js
+++ b/src/scripts/modules/jobs/ActionCreators.js
@@ -32,7 +32,7 @@ export default {
   // poll for not finished jobs
   reloadNotFinishedJobs() {
     const allJobs = JobsStore.getAll()
-      .filter(job => job.has('isFinished') && !job.get('isFinished'))
+      .filter(job => !job.get('isFinished'))
       .map(j => j.get('id'))
       .toArray();
     if (allJobs.length === 0) {

--- a/src/scripts/modules/jobs/ActionCreators.js
+++ b/src/scripts/modules/jobs/ActionCreators.js
@@ -32,7 +32,7 @@ export default {
   // poll for not finished jobs
   reloadNotFinishedJobs() {
     const allJobs = JobsStore.getAll()
-      .filter(job => !job.get('isFinished'))
+      .filter(job => job.has('isFinished') && !job.get('isFinished'))
       .map(j => j.get('id'))
       .toArray();
     if (allJobs.length === 0) {
@@ -45,7 +45,7 @@ export default {
   reloadJobs() {
     if (JobsStore.loadJobsErrorCount() < 10) {
       return this.loadJobsForce(0, false, true).then(() => {
-        this.reloadNotFinishedJobs();
+        return this.reloadNotFinishedJobs();
       });
     }
   },

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Button } from 'react-bootstrap';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import JobsStore from '../../../stores/JobsStore';
 import ActionCreators from '../../../ActionCreators';
@@ -16,25 +17,17 @@ export default React.createClass({
     };
   },
 
-  _search(query) {
-    return ActionCreators.filterJobs(query);
-  },
-
-  _loadMore() {
-    return ActionCreators.loadMoreJobs();
-  },
-
   render() {
     return (
       <div className="container-fluid">
         <div className="kbc-main-content">
-          <QueryRow onSearch={this._search} query={this.state.query} />
-          {this._renderTable()}
+          <QueryRow onSearch={this.handleSearch} query={this.state.query} />
+          {this.renderTable()}
           {this.state.isLoadMore && (
             <div className="kbc-block-with-padding">
-              <button onClick={this._loadMore} className="btn btn-default btn-large text-center">
+              <Button bsSize="large" onClick={this.handleLoadMore} className="text-center">
                 More...
-              </button>
+              </Button>
             </div>
           )}
         </div>
@@ -42,7 +35,18 @@ export default React.createClass({
     );
   },
 
-  _renderTableHeader() {
+  renderTable() {
+    return (
+      <div className="table table-striped table-hover">
+        {this.renderTableHeader()}
+        <div className="tbody">
+          {this.state.jobs.map(this.renderJob).toArray()}
+        </div>
+      </div>
+    );
+  },
+
+  renderTableHeader() {
     return (
       <div className="thead">
         <div className="tr">
@@ -69,18 +73,15 @@ export default React.createClass({
     );
   },
 
-  _renderTable() {
-    return (
-      <div className="table table-striped table-hover">
-        {this._renderTableHeader()}
-        <div className="tbody">
-          {this.state.jobs
-            .map(job => {
-              return <JobRow job={job} key={job.get('id')} query={this.state.query} />;
-            })
-            .toArray()}
-        </div>
-      </div>
-    );
+  renderJob(job) {
+    return <JobRow job={job} key={job.get('id')} query={this.state.query} />;
+  },
+
+  handleSearch(query) {
+    return ActionCreators.filterJobs(query);
+  },
+
+  handleLoadMore() {
+    return ActionCreators.loadMoreJobs();
   }
 });

--- a/src/scripts/modules/jobs/stores/JobsStore.js
+++ b/src/scripts/modules/jobs/stores/JobsStore.js
@@ -12,7 +12,7 @@ let _store = Map({
   isLoaded: false,
   isLoadMore: true,
   loadJobsErrorCnt: 0,
-  limit: 5,
+  limit: 50,
   offset: 0
 });
 

--- a/src/scripts/modules/jobs/stores/JobsStore.js
+++ b/src/scripts/modules/jobs/stores/JobsStore.js
@@ -12,7 +12,7 @@ let _store = Map({
   isLoaded: false,
   isLoadMore: true,
   loadJobsErrorCnt: 0,
-  limit: 50,
+  limit: 5,
   offset: 0
 });
 
@@ -130,11 +130,11 @@ JobsStore.dispatchToken = Dispatcher.register(payload => {
 
     case constants.ActionTypes.JOB_LOAD_SUCCESS:
       _store = _store.withMutations(store => {
-        const job = fromJS(action.job);
-        job.set('id', parseInt(job.get('id'), 10));
+        const jobId = parseInt(action.job.id, 10);
+        const job = fromJS(action.job).set('id', jobId);
         store
-          .setIn(['jobsById', action.job.id], job)
-          .update('loadingJobs', loadingJobs => loadingJobs.remove(loadingJobs.indexOf(action.job.id)));
+          .setIn(['jobsById', jobId], job)
+          .update('loadingJobs', loadingJobs => loadingJobs.remove(loadingJobs.indexOf(jobId)));
       });
 
       return JobsStore.emitChange();


### PR DESCRIPTION
Upravil jsem pár věcí:

- bluebird hlásil že v `then` musí být funkce a že tam posíláme objekt, asi jak tam je `.bind(this)` tak to vrací objekt, upravil jsme to na klasikou funkci
- `JobsIndex` jsem pouze přidal bootstrap komponenty a nějaký drobnosti - žádné opravy
- oprava `JOB_LOAD_SUCCESS` tam bylo:
```js
const job = fromJS(action.job);
job.set('id', parseInt(job.get('id'), 10));
```
kde chybí `job = ..` takže se to nedostalo do storu. To jsem upravil aby tam všude bylo number místo stringu. Dělalo to problémy i u načítání jobů občas, neseděli tam počty (používá se tam mergeIn a díky tomu jak byly dva různé ID tak to tam bylo dvakrát, zvedlo to i počet nad limit, takže se to pak neresetovalo kdy mělo asi atd) a načítalo se to někdy dvakrát, dále tam byly 2 záznamy se stejným ID jakoby takže React psal varování že nemůže vypsat obojí apod.

Reprodukce:
- reload na stránce nějaké extraktoru třeba (snowflake u mě)
- pustit "Run Extraction"
- hned přejít na stránku "Jobs" (pak to blbne, ale ne vždy, asi podle toho jak dopadnou nějaký requesty časově)

V konzoli to začne házet: `Warning: flattenChildren(...): Encountered two children with the same key, `.$479929283`. Child keys must be unique; when two children share a key, only the first child will be used.`
Začtou se pouštět dva requesty na JOBY zároveň a pokračují ikdyž už tam není žádný job co není dokončený.