### PR TITLE
Configuration Row Link - more components with queries

### DIFF
--- a/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
+++ b/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
@@ -1,7 +1,7 @@
 import React, { PropTypes } from 'react';
 import { Link } from 'react-router';
 
-const COMPONENTS_WITH_QUERIES = [
+const ExDbGenericComponents = [
   'keboola.ex-db-pgsql',
   'keboola.ex-db-redshift',
   'keboola.ex-db-redshift-cursors',
@@ -14,9 +14,14 @@ const COMPONENTS_WITH_QUERIES = [
   'keboola.ex-db-oracle',
   'keboola.ex-db-snowflake',
   'keboola.ex-db-impala',
-  'ex-mongodb',
   'keboola.ex-google-bigquery',
   'keboola.ex-teradata'
+];
+
+const ExAnalyticsComponents = [
+  'ex-google-analytics',
+  'ex-google-analytics-v4',
+  'ex-google-analytics-v5'
 ];
 
 export default React.createClass({
@@ -32,61 +37,61 @@ export default React.createClass({
 
   render() {
     if (this.props.componentId === 'transformation') {
-      return this.renderTransformationLink();
-    }
-
-    if (COMPONENTS_WITH_QUERIES.includes(this.props.componentId)) {
-      return this.renderQueryLink();
-    }
-
-    return this.renderRowLink();
-  },
-
-  renderTransformationLink() {
-    return (
-      <Link
-        className={this.props.className}
-        to="transformationDetail"
-        params={{
+      return this.renderLink({
+        to: 'transformationDetail',
+        params: {
           config: this.props.configId,
           row: this.props.rowId
-        }}
-        query={this.props.query}
-        onClick={this.props.onClick}
-      >
-        {this.props.children}
-      </Link>
-    );
-  },
+        }
+      });
+    }
 
-  renderQueryLink() {
-    return (
-      <Link
-        className={this.props.className}
-        to={'ex-db-generic-' + this.props.componentId + '-query'}
-        params={{
+    if (ExAnalyticsComponents.includes(this.props.componentId)) {
+      return this.renderLink({
+        to: this.props.componentId + '-query-detail',
+        params: {
+          config: this.props.configId,
+          queryId: this.props.rowId
+        }
+      });
+    }
+
+    if (ExDbGenericComponents.includes(this.props.componentId)) {
+      return this.renderLink({
+        to: 'ex-db-generic-' + this.props.componentId + '-query',
+        params: {
           config: this.props.configId,
           query: this.props.rowId
-        }}
-        query={this.props.query}
-        onClick={this.props.onClick}
-      >
-        {this.props.children}
-      </Link>
-    );
+        }
+      });
+    }
+
+    if (this.props.componentId === 'ex-mongodb') {
+      return this.renderLink({
+        to: this.props.componentId + '-query',
+        params: {
+          config: this.props.configId,
+          query: this.props.rowId
+        }
+      });
+    }
+
+    return this.renderLink({
+      to: this.props.componentId + '-row',
+      params: {
+        config: this.props.configId,
+        row: this.props.rowId
+      }
+    });
   },
 
-  renderRowLink() {
+  renderLink(props) {
     return (
       <Link
         className={this.props.className}
-        to={this.props.componentId + '-row'}
-        params={{
-          config: this.props.configId,
-          row: this.props.rowId
-        }}
         query={this.props.query}
         onClick={this.props.onClick}
+        {...props}
       >
         {this.props.children}
       </Link>

--- a/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
+++ b/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
@@ -37,61 +37,47 @@ export default React.createClass({
 
   render() {
     if (this.props.componentId === 'transformation') {
-      return this.renderLink({
-        to: 'transformationDetail',
-        params: {
-          config: this.props.configId,
-          row: this.props.rowId
-        }
+      return this.renderLink('transformationDetail', {
+        config: this.props.configId,
+        row: this.props.rowId
       });
     }
 
     if (ExAnalyticsComponents.includes(this.props.componentId)) {
-      return this.renderLink({
-        to: this.props.componentId + '-query-detail',
-        params: {
-          config: this.props.configId,
-          queryId: this.props.rowId
-        }
+      return this.renderLink(this.props.componentId + '-query-detail', {
+        config: this.props.configId,
+        queryId: this.props.rowId
       });
     }
 
     if (ExDbGenericComponents.includes(this.props.componentId)) {
-      return this.renderLink({
-        to: 'ex-db-generic-' + this.props.componentId + '-query',
-        params: {
-          config: this.props.configId,
-          query: this.props.rowId
-        }
+      return this.renderLink('ex-db-generic-' + this.props.componentId + '-query', {
+        config: this.props.configId,
+        query: this.props.rowId
       });
     }
 
     if (this.props.componentId === 'ex-mongodb') {
-      return this.renderLink({
-        to: this.props.componentId + '-query',
-        params: {
-          config: this.props.configId,
-          query: this.props.rowId
-        }
+      return this.renderLink(this.props.componentId + '-query', {
+        config: this.props.configId,
+        query: this.props.rowId
       });
     }
 
-    return this.renderLink({
-      to: this.props.componentId + '-row',
-      params: {
-        config: this.props.configId,
-        row: this.props.rowId
-      }
+    return this.renderLink(this.props.componentId + '-row', {
+      config: this.props.configId,
+      row: this.props.rowId
     });
   },
 
-  renderLink(props) {
+  renderLink(to, params) {
     return (
       <Link
         className={this.props.className}
         query={this.props.query}
         onClick={this.props.onClick}
-        {...props}
+        to={to}
+        params={params}
       >
         {this.props.children}
       </Link>

--- a/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
+++ b/src/scripts/modules/components/react/components/ComponentConfigurationRowLink.jsx
@@ -1,21 +1,50 @@
-import React from 'react';
-import {Link} from 'react-router';
+import React, { PropTypes } from 'react';
+import { Link } from 'react-router';
 
-module.exports = React.createClass({
-  displayName: 'ComponentConfigurationRowLink',
+const COMPONENTS_WITH_QUERIES = [
+  'keboola.ex-db-pgsql',
+  'keboola.ex-db-redshift',
+  'keboola.ex-db-redshift-cursors',
+  'keboola.ex-db-firebird',
+  'keboola.ex-db-db2',
+  'keboola.ex-db-db2-bata',
+  'keboola.ex-db-mssql',
+  'keboola.ex-db-mysql',
+  'keboola.ex-db-mysql-custom',
+  'keboola.ex-db-oracle',
+  'keboola.ex-db-snowflake',
+  'keboola.ex-db-impala',
+  'ex-mongodb',
+  'keboola.ex-google-bigquery',
+  'keboola.ex-teradata'
+];
+
+export default React.createClass({
   propTypes: {
-    componentId: React.PropTypes.string.isRequired,
-    configId: React.PropTypes.string.isRequired,
-    rowId: React.PropTypes.string.isRequired,
-    className: React.PropTypes.string,
-    query: React.PropTypes.object,
-    children: React.PropTypes.node.isRequired,
-    onClick: React.PropTypes.func
+    componentId: PropTypes.string.isRequired,
+    configId: PropTypes.string.isRequired,
+    rowId: PropTypes.string.isRequired,
+    className: PropTypes.string,
+    query: PropTypes.object,
+    children: PropTypes.node.isRequired,
+    onClick: PropTypes.func
   },
 
-  render: function() {
+  render() {
     if (this.props.componentId === 'transformation') {
-      return (<Link
+      return this.renderTransformationLink();
+    }
+
+    if (COMPONENTS_WITH_QUERIES.includes(this.props.componentId)) {
+      return this.renderQueryLink();
+    }
+
+    return this.renderRowLink();
+  },
+
+  renderTransformationLink() {
+    return (
+      <Link
         className={this.props.className}
         to="transformationDetail"
         params={{
@@ -24,9 +53,15 @@ module.exports = React.createClass({
         }}
         query={this.props.query}
         onClick={this.props.onClick}
-      >{this.props.children}</Link>);
-    } else if (this.props.componentId === 'keboola.ex-db-mysql' || this.props.componentId === 'keboola.ex-teradata') {
-      return (<Link
+      >
+        {this.props.children}
+      </Link>
+    );
+  },
+
+  renderQueryLink() {
+    return (
+      <Link
         className={this.props.className}
         to={'ex-db-generic-' + this.props.componentId + '-query'}
         params={{
@@ -35,17 +70,26 @@ module.exports = React.createClass({
         }}
         query={this.props.query}
         onClick={this.props.onClick}
-      >{this.props.children}</Link>);
-    }
-    return (<Link
-      className={this.props.className}
-      to={this.props.componentId + '-row'}
-      params={{
-        config: this.props.configId,
-        row: this.props.rowId
-      }}
-      query={this.props.query}
-      onClick={this.props.onClick}
-    >{this.props.children}</Link>);
+      >
+        {this.props.children}
+      </Link>
+    );
+  },
+
+  renderRowLink() {
+    return (
+      <Link
+        className={this.props.className}
+        to={this.props.componentId + '-row'}
+        params={{
+          config: this.props.configId,
+          row: this.props.rowId
+        }}
+        query={this.props.query}
+        onClick={this.props.onClick}
+      >
+        {this.props.children}
+      </Link>
+    );
   }
 });


### PR DESCRIPTION
Fixes #2763

Byly tam 2 komponenty kde místo `-row` se mělo použít `-query`, co jsem ale koukal tak těch komponent co mají `query` místo `row` je daleko více, všechny jsem tam přidal, ale nevím zda to je kompletní.. ani zda to je správě..

Jsou tam pro mě nějaké nesrovnalosti.
- když pustím třeba jednu Query třeba ve `ex-db-pgsql`, tak pak v jobs mám právě odkaz na tu jednu query (row) a label partial
- když ale pustím jednu query třeba ve `ex-db-snowflake` tak mám odkaz pouze na celou konfiguraci a label partial tam nemám

Ta chyba v issue právě byla že třeba `ex-db-pgsql` nebyla v tom seznamu komponent co mají query a tak místo odkazu na query se měl udělat odkaz na row který neexistovala a skončilo to jako `render error`. Nevím zda v aplikaci není někde seznam komponent co mají query místo row, abych to nemusel mít vyjmenované přímo v této komponentě. Já nic nenašel, tak jsem to hodil přímo tu.

Ještě vidím (v routes snapshot @ujovlado - dobrá věc), že komponenty `ex-google-analytics`, `ex-google-analytics-v4` a `ex-google-analytics-v5` nemají ani row, ani query, ale `query-detail`. 
Tak jsem ještě přidal novou podmínku a přidal také to. Ono když pustím pouze jednu `query` z Google Analytics, tak to taky nevypisuje jako partial s odkazem přímo na query, ale pouze na celou konfiguraci. Ale i tak to je lepší mít asi nachystané.

Poslední věc že `ex-mongodb` má taky query ale není to `db-generic` takže tam jsem přidal taky speciální odkaz.