### PR TITLE
Remove recieveJobDetail call from "run component"

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -543,8 +543,6 @@ module.exports = {
         loadJobDataPromise = JobsActionCreators.reloadJobs().then(function() {
           return runJobResult;
         });
-      } else {
-        JobsActionCreators.recieveJobDetail(runJobResult);
       }
       return loadJobDataPromise.then(function(job) {
         if (paramsProcessed.notify) {


### PR DESCRIPTION
Fixes #2778

Proposed changes:

- do not call recieveJobDetail on "component run", so incomplete job parameters will not end up in store
