### PR TITLE
Ex AWS S3 - Configuration

### DIFF
--- a/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
+++ b/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
@@ -168,7 +168,6 @@ export default React.createClass({
           onChange={function(e) {
             props.onChange({enclosure: e.target.value});
           }}
-          placeholder={'"'}
           disabled={this.props.disabled}
           help={(<span>Field enclosure used in CSV file. Default value is <code>"</code>.</span>)}
         />

--- a/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
+++ b/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
@@ -169,7 +169,7 @@ export default React.createClass({
             props.onChange({enclosure: e.target.value});
           }}
           disabled={this.props.disabled}
-          help={(<span>Field enclosure used in CSV file. Default value is <code>"</code>.</span>)}
+          help={<span>Field enclosure used in CSV file.</span>}
         />
         <div className="form-group">
           <div className="col-xs-4 control-label">Header</div>

--- a/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
+++ b/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
@@ -158,6 +158,7 @@ export default React.createClass({
             props.onChange({delimiter: value});
           }}
           disabled={this.props.disabled}
+          help={<span>Field delimiter used in CSV file. Use <code>\t</code> for tabulator.</span>}
         />
         <Input
           type="text"


### PR DESCRIPTION
Fixes #2797

Vymazán placeholder u `enclosure` protože je validní taky prázdný string.
Upraven text aby to sedělo že tam nemusí být nic.

Upraven taky text `delimeter` kde se vyhodila informace o default hodnotě, protože ta není žádná. Také tam může být prázdný string.

Adapters jsem neměnil, protože furt platí, že pro nové tabulky se doplní ty hodnoty co byly psané jako default v textu. 