### PR TITLE
Extend request timeout

### DIFF
--- a/src/scripts/modules/sapi-events/EventsApi.js
+++ b/src/scripts/modules/sapi-events/EventsApi.js
@@ -12,7 +12,7 @@ export default {
   listEvents(params) {
     return createRequest('GET', 'events')
       .query(params)
-      .timeout(4000)
+      .timeout(10000)
       .promise()
       .then(response => response.body);
   },
@@ -20,7 +20,7 @@ export default {
   listTableEvents(tableId, params) {
     return createRequest('GET', 'tables/' + tableId + '/events')
       .query(params)
-      .timeout(4000)
+      .timeout(10000)
       .promise()
       .then(response => response.body);
   },
@@ -34,7 +34,7 @@ export default {
   listBucketEvents(buckedId, params) {
     return createRequest('GET', 'buckets/' + buckedId + '/events')
       .query(params)
-      .timeout(4000)
+      .timeout(10000)
       .promise()
       .then(response => response.body);
   }

--- a/src/scripts/modules/tokens/TokenEventsApi.js
+++ b/src/scripts/modules/tokens/TokenEventsApi.js
@@ -12,7 +12,7 @@ export default (tokenId) => {
     listEvents(params) {
       return createRequest('GET', 'events')
         .query(params)
-        .timeout(4000)
+        .timeout(10000)
         .promise()
         .then(response => response.body);
     },


### PR DESCRIPTION
Related #2774 (možná i FIX ale určo ne stopro)

Aby se nezapomnělo na to issue tak nahodím nějakou úpravu a může se to vyladit, nebo celé vyhodit pokud se dohodne, že "nepodporujme" pomalé připojení.

Obecně je na request timeout 60 sekund. Další timeouty jsou jen tyto 4 a jsou nastavený docela agresivně na 4 sekundy. Zvýšil jsem to na 10 sekund. Konkrétní důvod není ale nemyslím že by to měl být problém.

BTW: Obecně bych nebyl proti zvýšit i pool na detailu jobu - současný 2 sekundy jsou docela agresivní :) ale chápu že na tom detailu je lepší vidět updaty často, ale i 3 sekundy by za mě bylo lepší. 