### PR TITLE
wr-db: validate size of data type only if it should have size

### DIFF
--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -185,9 +185,10 @@ export default componentId => {
     _validateColumn(column) {
       const type = column.get('type');
       const size = column.get('size');
-      const valid = columnTypeValidation.validate(type, size);
+      const shouldHaveSize = this._getSizeParam(type);
+      const sizeValid = columnTypeValidation.validate(type, size);
 
-      return this._setValidateColumn(column.get('name'), valid);
+      return this._setValidateColumn(column.get('name'), !shouldHaveSize || sizeValid);
     },
 
     _showIncrementalSetupModal() {


### PR DESCRIPTION
Fixes #2803 

Proposed changes:
- Tyka sa validacie definicie stlpcov vsetkych db writerov
- ak je size definovany v default datovych stlpcoch ako `defaultSize` v https://github.com/keboola/kbc-ui/blob/master/src/scripts/modules/wr-db/templates/dataTypes.js tak zvaliduje size zadanu uzivatelom 
