### PR TITLE
Remove jest --forceExit on CI

### DIFF
--- a/environment/scripts/jest.js
+++ b/environment/scripts/jest.js
@@ -4,11 +4,6 @@ process.env.TZ = 'UTC';
 const jest = require('jest');
 const argv = process.argv.slice(2);
 
-// NOTE: temporary fix for enable console.log on localhost.
-if (process.env.CI === 'true') {
-  argv.push('--forceExit');
-}
-
 if (process.env.DEV_CACHE !== 'true') {
   argv.push('--no-cache');
 }


### PR DESCRIPTION
Probably no longer needed

Related to: #2622 