### PR TITLE
Ex Google Analytics - Selected Profiles List - fix warnings

### DIFF
--- a/src/scripts/modules/ex-google-analytics-v4/react/Index/SelectedProfilesList.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/Index/SelectedProfilesList.jsx
@@ -1,9 +1,10 @@
 import React, {PropTypes} from 'react';
 import ProfileInfo from '../ProfileInfo';
+
 export default React.createClass({
   propTypes: {
     allProfiles: PropTypes.object.isRequired,
-    profileIds: PropTypes.object
+    profileIds: PropTypes.array
   },
 
   getProfile(profileId) {
@@ -24,18 +25,19 @@ export default React.createClass({
 
   renderProfile(profileId) {
     const profile = this.getProfile(profileId);
+
     if (!profile) {
       return (
-        <span>
+        <span key={profileId}>
           Unknown Profile({profileId})
         </span>
       );
-    } else {
-      return (
-        <small>
-          <ProfileInfo profile={profile} />
-        </small>
-      );
     }
+
+    return (
+      <small key={profileId}>
+        <ProfileInfo profile={profile} />
+      </small>
+    );
   }
 });


### PR DESCRIPTION
Drobný fix na úpravu varování. Chybí `key` v `map` a  `profileIds` je pole.