### PR TITLE
Remove isMounted check

### DIFF
--- a/src/scripts/modules/components/react/components/RunComponentButton.jsx
+++ b/src/scripts/modules/components/react/components/RunComponentButton.jsx
@@ -49,36 +49,35 @@ module.exports = React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromise && this.cancellablePromise.cancel();
+  },
+
   _handleRunStart: function() {
-    var params;
     this.setState({
       isLoading: true
     });
-    params = {
+    const params = {
       method: this.props.method,
       component: this.props.component,
       data: this.props.runParams(),
       notify: !this.props.redirect
     };
 
-    return InstalledComponentsActionCreators.runComponent(params)
+    this.cancellablePromise = InstalledComponentsActionCreators.runComponent(params)
       .then(this._handleStarted)
-      .catch((function(_this) {
-        return function(error) {
-          _this.setState({
-            isLoading: false
-          });
-          throw error;
-        };
-      })(this));
+      .catch((error) => {
+        this.setState({
+          isLoading: false
+        });
+        throw error;
+      });
   },
 
   _handleStarted: function(response) {
-    if (this.isMounted()) {
-      this.setState({
-        isLoading: false
-      });
-    }
+    this.setState({
+      isLoading: false
+    });
     if (this.props.redirect) {
       return RoutesStore.getRouter().transitionTo('jobDetail', {
         jobId: response.id

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
@@ -52,23 +52,23 @@ export default React.createClass({
     if (this.timeout) {
       this.timeout.clear();
     }
+    if (this.cancellablePromise) {
+      this.cancellablePromise.cancel();
+    }
   },
 
   collectStats(runId) {
     this.setState({
       isLoading: true
     });
-    getRunIdStats(runId)
-      .then(this.receiveStats);
+    this.cancellablePromise = getRunIdStats(runId).then(this.receiveStats);
   },
 
   receiveStats(stats) {
-    if (this.isMounted()) {
-      this.setState({
-        stats: Immutable.fromJS(stats),
-        isLoading: false
-      });
-    }
+    this.setState({
+      stats: Immutable.fromJS(stats),
+      isLoading: false
+    });
   },
 
   getInitialState() {

--- a/src/scripts/modules/orchestrations/react/components/OrchestrationRunButton.jsx
+++ b/src/scripts/modules/orchestrations/react/components/OrchestrationRunButton.jsx
@@ -24,6 +24,10 @@ export default React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromise && this.cancellablePromise.cancel();
+  },
+
   render() {
     return (
       <RunOrchestrationModal
@@ -63,19 +67,15 @@ export default React.createClass({
   },
 
   handleRunStart() {
-    this.setState({
-      isLoading: true
-    });
+    this.setState({ isLoading: true });
 
-    ActionCreators.runOrchestration(
+    this.cancellablePromise = ActionCreators.runOrchestration(
       this.props.orchestration.get('id'),
       this.props.tasks ? this.props.tasks : null,
       this.props.notify
     ).finally(() => {
-      if (this.isMounted()) {
-        this.setState({
-          isLoading: false
-        });
+      if (!this.cancellablePromise.isCancelled()) {
+        this.setState({ isLoading: false });
       }
     });
   }

--- a/src/scripts/modules/orchestrations/react/components/OrchestrationTaskRunButton.jsx
+++ b/src/scripts/modules/orchestrations/react/components/OrchestrationTaskRunButton.jsx
@@ -23,6 +23,10 @@ export default React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromise && this.cancellablePromise.cancel();
+  },
+
   render() {
     return (
       <RunOrchestrationModal
@@ -36,15 +40,10 @@ export default React.createClass({
   },
 
   handleRunStart() {
-    this.setState({
-      isLoading: true
-    });
-
-    return this.props.onRun(this.props.task).finally(() => {
-      if (this.isMounted()) {
-        this.setState({
-          isLoading: false
-        });
+    this.setState({ isLoading: true });
+    this.cancellablePromise = this.props.onRun(this.props.task).finally(() => {
+      if (!this.cancellablePromise.isCancelled()) {
+        this.setState({ isLoading: false });
       }
     });
   }

--- a/src/scripts/modules/sapi-events/react/Events.jsx
+++ b/src/scripts/modules/sapi-events/react/Events.jsx
@@ -22,19 +22,17 @@ export default React.createClass({
   _handleChange() {
     const currentEventId = RoutesStore.getRouterState().getIn(['query', 'eventId']);
 
-    if (this.isMounted()) {
-      return this.setState({
-        searchQuery: this._events.getQuery(),
-        events: this._events.getEvents(),
-        currentEventId,
-        currentEvent: this._events.getEvent(currentEventId),
-        isLoadingCurrentEvent: this._events.getIsLoadingEvent(currentEventId),
-        isLoading: this._events.getIsLoading(),
-        isLoadingOlder: this._events.getIsLoadingOlder(),
-        hasMore: this._events.getHasMore(),
-        errorMessage: this._events.getErrorMessage()
-      });
-    }
+    return this.setState({
+      searchQuery: this._events.getQuery(),
+      events: this._events.getEvents(),
+      currentEventId,
+      currentEvent: this._events.getEvent(currentEventId),
+      isLoadingCurrentEvent: this._events.getIsLoadingEvent(currentEventId),
+      isLoading: this._events.getIsLoading(),
+      isLoadingOlder: this._events.getIsLoadingOlder(),
+      hasMore: this._events.getHasMore(),
+      errorMessage: this._events.getErrorMessage()
+    });
   },
 
   getInitialState() {

--- a/src/scripts/modules/sapi-events/sliced-files-downloader/ModalHandler.jsx
+++ b/src/scripts/modules/sapi-events/sliced-files-downloader/ModalHandler.jsx
@@ -24,6 +24,11 @@ export default React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromiseRunComponent && this.cancellablePromiseRunComponent.cancel();
+    this.cancellablePromiseJobDetail && this.cancellablePromiseJobDetail.cancel();
+  },
+
   render() {
     const {file, children} = this.props;
     return (
@@ -50,7 +55,8 @@ export default React.createClass({
       progress: 'Waiting for start...',
       progressStatus: null
     });
-    actionCreators.runComponent({
+
+    this.cancellablePromiseRunComponent = actionCreators.runComponent({
       component: SLICED_FILES_DOWNLOADER_COMPONENT,
       notify: false,
       data: {
@@ -75,9 +81,6 @@ export default React.createClass({
   },
 
   handleJobReceive(job) {
-    if (!this.isMounted()) {
-      return;
-    }
     if (job.isFinished) {
       if (job.status === 'success') {
         setTimeout(
@@ -126,7 +129,8 @@ export default React.createClass({
     if (!this.state.jobId) {
       return;
     }
-    jobsApi
+
+    this.cancellablePromiseJobDetail = jobsApi
       .getJobDetail(this.state.jobId)
       .then(this.handleJobReceive)
       .catch((e) => {
@@ -148,5 +152,4 @@ export default React.createClass({
       isModalOpen: false
     });
   }
-
 });

--- a/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
+++ b/src/scripts/modules/transformations/react/modals/ConfigureSandbox.js
@@ -45,6 +45,11 @@ export default React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromiseRunComponent && this.cancellablePromiseRunComponent.cancel();
+    this.cancellablePromiseJobDetail && this.cancellablePromiseJobDetail.cancel();
+  },
+
   render() {
     return (
       <ConfigureSandboxModal
@@ -120,7 +125,8 @@ export default React.createClass({
       progress: 'Waiting for load to start.',
       progressStatus: null
     });
-    actionCreators.runComponent({
+
+    this.cancellablePromiseRunComponent = actionCreators.runComponent({
       component: 'transformation',
       notify: false,
       data: this.props.runParams.set('mode', this.state.mode).toJS()
@@ -133,9 +139,6 @@ export default React.createClass({
   },
 
   handleJobReceive(job) {
-    if (!this.isMounted()) {
-      return;
-    }
     if (job.isFinished) {
       if (job.status === 'success') {
         this.setState({
@@ -167,7 +170,8 @@ export default React.createClass({
     if (!this.state.jobId) {
       return;
     }
-    jobsApi
+
+    this.cancellablePromiseJobDetail = jobsApi
       .getJobDetail(this.state.jobId)
       .then(this.handleJobReceive)
       .catch((e) => {

--- a/src/scripts/react/mixins/createStoreMixin.js
+++ b/src/scripts/react/mixins/createStoreMixin.js
@@ -17,9 +17,7 @@ const createStoreMixin = (...stores) => {
     },
 
     _handleStoreChanged() {
-      if (this.isMounted()) {
-        return this.setState(this.getStateFromStores(this.props));
-      }
+      return this.setState(this.getStateFromStores(this.props));
     }
   };
 


### PR DESCRIPTION
Toto by měly být poslední výskyty v aplikaci. 

Použil jsem tam to samé co máme třeba ve Storage -> `cancellablePromise`. Pokud je v komponentě více api requestů pak už to pojmenovávám podrobněji, třeba `cancellablePromiseRunComponent`.

Tímto se určitě nezbavíme varování že voláme `setState` na umnouted komponentě, těch výskytů tam je ještě asi dost. Ale tam nebyla ta kontrola `isMounted`, takže to jsem neřešil.