### PR TITLE
New Transformation Bucket - fix call setState on unmounted component

### DIFF
--- a/src/scripts/modules/transformations/react/modals/NewTransformationBucket.jsx
+++ b/src/scripts/modules/transformations/react/modals/NewTransformationBucket.jsx
@@ -17,6 +17,10 @@ export default React.createClass({
     };
   },
 
+  componentWillUnmount() {
+    this.cancellablePromise && this.cancellablePromise.cancel();
+  },
+
   render() {
     return (
       <span>
@@ -106,7 +110,7 @@ export default React.createClass({
       isLoading: true
     });
 
-    return TransformationActionCreators.createTransformationBucket({
+    this.cancellablePromise = TransformationActionCreators.createTransformationBucket({
       name: this.state.name,
       description: this.state.description
     }).then(this._close);


### PR DESCRIPTION
Když kouknu co dělá `createTransformationBucket` tak tam je pak "redirect" na ten detail. Díky tomu pak dojde k tomu varování protože ten modal je již unmouted.

Tak nevím zda je lepší tam ten `than` vynechat, protože vím že tam je to přesměrování. Nebo se nestarat co to dělá, ale prostě to pohlídat tím `cancellablePromise`. Zvolil jsem prozatím to druhé, přijde mi to čistší. Ale nechám si poradit.