### PR TITLE
Use ES6 module system

### DIFF
--- a/src/scripts/Dispatcher.js
+++ b/src/scripts/Dispatcher.js
@@ -16,4 +16,4 @@ class KbcDispatcher extends Dispatcher {
   }
 }
 
-module.exports = new KbcDispatcher();
+export default new KbcDispatcher();

--- a/src/scripts/app.js
+++ b/src/scripts/app.js
@@ -141,7 +141,7 @@ const startApp = appOptions => {
   });
 };
 
-module.exports = {
+export default {
   start: startApp,
   helpers
 };

--- a/src/scripts/modules/billing/react/datesForMonthlyUsage.test.js
+++ b/src/scripts/modules/billing/react/datesForMonthlyUsage.test.js
@@ -1,10 +1,10 @@
-var computeDatesForMonthlyUsage = require('./datesForMonthlyUsage').compute;
-var moment = require('moment');
+import { compute } from './datesForMonthlyUsage';
+import moment from 'moment';
 
 describe('computeDatesForMonthlyUsage', function() {
   describe('#computeDatesForMonthlyUsage()', function() {
     it('it should return previous day for both dates', function() {
-      expect(computeDatesForMonthlyUsage(
+      expect(compute(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2017-05-17') // projectCreation
@@ -15,7 +15,7 @@ describe('computeDatesForMonthlyUsage', function() {
     });
 
     it('it should return computation start date and previous day', function() {
-      expect(computeDatesForMonthlyUsage(
+      expect(compute(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment(null) // projectCreation not set
@@ -26,7 +26,7 @@ describe('computeDatesForMonthlyUsage', function() {
     });
 
     it('it should return computation start date and previous day', function() {
-      expect(computeDatesForMonthlyUsage(
+      expect(compute(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2016-08-01') // projectCreation before computation
@@ -37,7 +37,7 @@ describe('computeDatesForMonthlyUsage', function() {
     });
 
     it('it should return previous day for both dates', function() {
-      expect(computeDatesForMonthlyUsage(
+      expect(compute(
         moment('2017-01-01'), // computation start
         moment('2017-05-17'), // now
         moment('2017-05-30') // projectCreation in future

--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -44,7 +44,7 @@ const storeEncodedConfigRow = function(componentId, configId, rowId, dataToSave,
   });
 };
 
-module.exports = {
+export default {
   loadComponentsForce: function() {
     var promises;
     promises = [];

--- a/src/scripts/modules/components/InstalledComponentsApi.js
+++ b/src/scripts/modules/components/InstalledComponentsApi.js
@@ -186,4 +186,4 @@ const installedComponentsApi = {
   }
 };
 
-module.exports = installedComponentsApi;
+export default installedComponentsApi;

--- a/src/scripts/modules/components/MetadataActionCreators.js
+++ b/src/scripts/modules/components/MetadataActionCreators.js
@@ -7,8 +7,7 @@ import Immutable from 'immutable';
 
 var Map = Immutable.Map;
 
-module.exports = {
-
+export default {
   startMetadataEdit: function(objectType, objectId, metadataKey) {
     dispatcher.handleViewAction({
       type: Constants.ActionTypes.METADATA_EDIT_START,

--- a/src/scripts/modules/components/MetadataConstants.js
+++ b/src/scripts/modules/components/MetadataConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
 
     METADATA_EDIT_START: null,

--- a/src/scripts/modules/components/OAuthActionCreators.js
+++ b/src/scripts/modules/components/OAuthActionCreators.js
@@ -5,7 +5,7 @@ import oauthApi from './OAuthApi';
 import Constants from './OAuthConstants';
 import Immutable from 'immutable';
 
-module.exports = {
+export default {
   loadCredentials: function(componentId, configId) {
     if (oauthStore.hasCredentials(componentId, configId)) {
       return Promise.resolve();

--- a/src/scripts/modules/components/OAuthApi.js
+++ b/src/scripts/modules/components/OAuthApi.js
@@ -10,7 +10,7 @@ var createRequest = function(method, path) {
   return request(method, createUrl(path)).set('X-StorageApi-Token', ApplicationStore.getSapiTokenString());
 };
 
-module.exports = {
+export default {
   getCredentials: function(componentId, configId) {
     return createRequest('GET', 'credentials/' + componentId + '/' + configId).promise().then(function(response) {
       return response.body;

--- a/src/scripts/modules/components/OAuthConstants.js
+++ b/src/scripts/modules/components/OAuthConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
     OAUTH_DELETE_CREDENTIALS_SUCCESS: null,
     OAUTH_DELETE_CREDENTIALS_START: null,

--- a/src/scripts/modules/components/Routes.js
+++ b/src/scripts/modules/components/Routes.js
@@ -43,138 +43,144 @@ const extractor = injectProps({ type: 'extractor' });
 const writer = injectProps({ type: 'writer' });
 const application = injectProps({ type: 'application' });
 
-export default {
-  applications: {
-    name: 'applications',
-    title: 'Applications',
-    requireData: function() {
-      return InstalledComponentsActionsCreators.loadComponents();
-    },
-    defaultRouteHandler: application(ComponentsIndex),
-    headerButtonsHandler: injectProps({
-      addRoute: 'new-application',
-      type: 'application'
-    })(ComponentsHeaderButtons),
-    reloaderHandler: ComponentReloaderButton,
-    childRoutes: [
-      {
-        name: 'new-application',
-        title: 'New Application',
-        defaultRouteHandler: application(NewComponent)
-      },
-      createComponentRoute('geneea-nlp-analysis', [geneeaGeneralRoutes]),
-      createComponentRoute('geneea.nlp-analysis-v2', [geneeaV2Routes]),
-      createComponentRoute('custom-science', [customScienceRoutes]),
-      createComponentRoute('keboola.app-snowflake-dwh-manager', [appSnowflakeDwhManagerRoutes]),
-      createGenericDetailRoute('application')
-    ]
+const applications = {
+  name: 'applications',
+  title: 'Applications',
+  requireData: function() {
+    return InstalledComponentsActionsCreators.loadComponents();
   },
-  extractors: {
-    name: 'extractors',
-    title: 'Extractors',
-    requireData: function() {
-      return InstalledComponentsActionsCreators.loadComponents();
+  defaultRouteHandler: application(ComponentsIndex),
+  headerButtonsHandler: injectProps({
+    addRoute: 'new-application',
+    type: 'application'
+  })(ComponentsHeaderButtons),
+  reloaderHandler: ComponentReloaderButton,
+  childRoutes: [
+    {
+      name: 'new-application',
+      title: 'New Application',
+      defaultRouteHandler: application(NewComponent)
     },
-    defaultRouteHandler: extractor(ComponentsIndex),
-    headerButtonsHandler: injectProps({
-      addRoute: 'new-extractor',
-      type: 'extractor'
-    })(ComponentsHeaderButtons),
-    reloaderHandler: ComponentReloaderButton,
-    childRoutes: [
-      {
-        name: 'new-extractor',
-        title: 'New Extractor',
-        defaultRouteHandler: extractor(NewComponent)
-      },
-      createComponentRoute('keboola.ex-google-analytics-v5', [exGaV4Routes('keboola.ex-google-analytics-v5')]),
-      createComponentRoute('keboola.ex-google-analytics-v4', [exGaV4Routes('keboola.ex-google-analytics-v4')]),
-      createComponentRoute('keboola.ex-google-analytics', [exGaV4Routes('keboola.ex-google-analytics')]),
-      createComponentRoute('keboola.ex-facebook', [exFacebookRoutes('keboola.ex-facebook')]),
-      createComponentRoute('keboola.ex-facebook-ads', [exFacebookRoutes('keboola.ex-facebook-ads')]),
-      createComponentRoute('keboola.ex-instagram', [exFacebookRoutes('keboola.ex-instagram')]),
-      createComponentRoute('keboola.ex-google-drive', [exGdriveNewRoutes]),
-      createComponentRoute('ex-adform', [adformRoutes]),
-      createComponentRoute('keboola.ex-twitter', [twitterRoutes]),
-      createComponentRoute('ex-dropbox', [dropoxExtractorRoutes]),
-      createComponentRoute('radektomasek.ex-dropbox-v2', [dropoxExtractorRoutesV2]),
-      createComponentRoute('keboola.ex-db-pgsql', [exDbGenericRoutes('keboola.ex-db-pgsql')]),
-      createComponentRoute('keboola.ex-db-redshift', [exDbGenericRoutes('keboola.ex-db-redshift')]),
-      createComponentRoute('keboola.ex-db-redshift-cursors', [exDbGenericRoutes('keboola.ex-db-redshift-cursors')]),
-      createComponentRoute('keboola.ex-db-firebird', [exDbGenericRoutes('keboola.ex-db-firebird')]),
-      createComponentRoute('keboola.ex-db-db2', [exDbGenericRoutes('keboola.ex-db-db2')]),
-      createComponentRoute('keboola.ex-db-db2-bata', [exDbGenericRoutes('keboola.ex-db-db2-bata')]),
-      createComponentRoute('keboola.ex-db-mssql', [exDbGenericRoutes('keboola.ex-db-mssql')]),
-      createComponentRoute('keboola.ex-db-mysql', [exDbGenericRoutes('keboola.ex-db-mysql')]),
-      createComponentRoute('keboola.ex-db-mysql-custom', [exDbGenericRoutes('keboola.ex-db-mysql-custom')]),
-      createComponentRoute('keboola.ex-db-oracle', [exDbGenericRoutes('keboola.ex-db-oracle')]),
-      createComponentRoute('keboola.ex-db-snowflake', [exDbGenericRoutes('keboola.ex-db-snowflake')]),
-      createComponentRoute('keboola.ex-db-impala', [exDbGenericRoutes('keboola.ex-db-impala')]),
-      createComponentRoute('keboola.ex-mongodb', [exMongoDbRoutes]),
-      createComponentRoute('keboola.ex-google-bigquery', [exGoogleBigqueryRoutes]),
-      createComponentRoute('keboola.ex-teradata', [exDbGenericRoutes('keboola.ex-teradata')]),
-      createComponentRoute('keboola.csv-import', [csvImportRoutes]),
-      createComponentRoute('keboola.ex-s3', [exS3Routes]),
-      createComponentRoute('apify.apify', [exApifyRoutes]),
-      createComponentRoute('keboola.ex-aws-s3', [exAwsS3Routes]),
-      createComponentRoute('keboola.ex-email-attachments', [emailAttachmentsExtractorRoutes]),
-      createComponentRoute('keboola.ex-http', [exHttpRoutes]),
-      createComponentRoute('keboola.ex-storage', [exStorageRoutes]),
-      createComponentRoute('htns.ex-salesforce', [htnsExSalesforceRoutes]),
-      createComponentRoute('keboola.ex-ftp', [exFtpRoutes]),
-      createGenericDetailRoute('extractor')
-    ]
+    createComponentRoute('geneea-nlp-analysis', [geneeaGeneralRoutes]),
+    createComponentRoute('geneea.nlp-analysis-v2', [geneeaV2Routes]),
+    createComponentRoute('custom-science', [customScienceRoutes]),
+    createComponentRoute('keboola.app-snowflake-dwh-manager', [appSnowflakeDwhManagerRoutes]),
+    createGenericDetailRoute('application')
+  ]
+};
+
+const extractors = {
+  name: 'extractors',
+  title: 'Extractors',
+  requireData: function() {
+    return InstalledComponentsActionsCreators.loadComponents();
   },
-  writers: {
-    name: 'writers',
-    title: 'Writers',
-    requireData: function() {
-      return InstalledComponentsActionsCreators.loadComponents();
+  defaultRouteHandler: extractor(ComponentsIndex),
+  headerButtonsHandler: injectProps({
+    addRoute: 'new-extractor',
+    type: 'extractor'
+  })(ComponentsHeaderButtons),
+  reloaderHandler: ComponentReloaderButton,
+  childRoutes: [
+    {
+      name: 'new-extractor',
+      title: 'New Extractor',
+      defaultRouteHandler: extractor(NewComponent)
     },
-    defaultRouteHandler: writer(ComponentsIndex),
-    headerButtonsHandler: injectProps({
-      addRoute: 'new-writer',
-      type: 'writer'
-    })(ComponentsHeaderButtons),
-    reloaderHandler: ComponentReloaderButton,
-    childRoutes: [
-      {
-        name: 'new-writer',
-        title: 'New Writer',
-        defaultRouteHandler: writer(NewComponent)
-      },
-      createComponentRoute('gooddata-writer', [goodDataWriterRoutes]),
-      createComponentRoute('tde-exporter', [tdeRoutes]),
-      createComponentRoute('keboola.wr-google-sheets', [googleSheetsWriterRoutes]),
-      createComponentRoute('keboola.wr-google-drive', [googleDriveWriterNewRoutes]),
-      createComponentRoute('wr-db', [createDbWriterRoutes('wr-db', 'mysql', false)]),
-      createComponentRoute('wr-db-mysql', [createDbWriterRoutes('wr-db-mysql', 'mysql', false)]),
-      createComponentRoute('wr-db-oracle', [createDbWriterRoutes('wr-db-oracle', 'oracle', false)]),
-      createComponentRoute('wr-db-redshift', [createDbWriterRoutes('wr-db-redshift', 'redshift', true)]),
-      createComponentRoute('keboola.wr-looker', [createDbWriterRoutes('keboola.wr-looker', 'redshift', true)]),
-      createComponentRoute('keboola.wr-qlik', [createDbWriterRoutes('keboola.wr-qlik', 'redshift', true)]),
-      createComponentRoute('wr-tableau', [createDbWriterRoutes('wr-tableau', 'mysql', false)]),
-      createComponentRoute('wr-db-mssql', [createDbWriterRoutes('wr-db-mssql', 'mssql', false)]),
-      createComponentRoute('keboola.wr-db-mssql-v2', [createDbWriterRoutes('keboola.wr-db-mssql-v2', 'mssql', false)]),
-      createComponentRoute('keboola.wr-redshift-v2', [
-        createDbWriterRoutes('keboola.wr-redshift-v2', 'redshift', true)
-      ]),
-      createComponentRoute('keboola.wr-db-impala', [createDbWriterRoutes('keboola.wr-db-impala', 'impala', false)]),
-      createComponentRoute('keboola.wr-db-mysql', [createDbWriterRoutes('keboola.wr-db-mysql', 'mysql', false)]),
-      createComponentRoute('keboola.wr-db-oracle', [createDbWriterRoutes('keboola.wr-db-oracle', 'oracle', false)]),
-      createComponentRoute('keboola.wr-db-pgsql', [createDbWriterRoutes('keboola.wr-db-pgsql', 'pgsql', false)]),
-      createComponentRoute('keboola.wr-db-snowflake', [
-        createDbWriterRoutes('keboola.wr-db-snowflake', 'snowflake', true)
-      ]),
-      createComponentRoute('keboola.wr-thoughtspot', [
-        createDbWriterRoutes('keboola.wr-thoughtspot', 'thoughtspot', false)
-      ]),
-      createComponentRoute('keboola.gooddata-writer', [gooddataWriterV3Routes]),
-      createComponentRoute('keboola.wr-storage', [wrStorageRoutes]),
-      createComponentRoute('keboola.wr-aws-s3', [wrAwsS3Routes]),
-      createComponentRoute('keboola.wr-google-bigquery', [wrGoogleBigQueryRoutes]),
-      createComponentRoute('keboola.wr-google-bigquery-v2', [wrGoogleBigQueryV2Routes]),
-      createGenericDetailRoute('writer')
-    ]
-  }
+    createComponentRoute('keboola.ex-google-analytics-v5', [exGaV4Routes('keboola.ex-google-analytics-v5')]),
+    createComponentRoute('keboola.ex-google-analytics-v4', [exGaV4Routes('keboola.ex-google-analytics-v4')]),
+    createComponentRoute('keboola.ex-google-analytics', [exGaV4Routes('keboola.ex-google-analytics')]),
+    createComponentRoute('keboola.ex-facebook', [exFacebookRoutes('keboola.ex-facebook')]),
+    createComponentRoute('keboola.ex-facebook-ads', [exFacebookRoutes('keboola.ex-facebook-ads')]),
+    createComponentRoute('keboola.ex-instagram', [exFacebookRoutes('keboola.ex-instagram')]),
+    createComponentRoute('keboola.ex-google-drive', [exGdriveNewRoutes]),
+    createComponentRoute('ex-adform', [adformRoutes]),
+    createComponentRoute('keboola.ex-twitter', [twitterRoutes]),
+    createComponentRoute('ex-dropbox', [dropoxExtractorRoutes]),
+    createComponentRoute('radektomasek.ex-dropbox-v2', [dropoxExtractorRoutesV2]),
+    createComponentRoute('keboola.ex-db-pgsql', [exDbGenericRoutes('keboola.ex-db-pgsql')]),
+    createComponentRoute('keboola.ex-db-redshift', [exDbGenericRoutes('keboola.ex-db-redshift')]),
+    createComponentRoute('keboola.ex-db-redshift-cursors', [exDbGenericRoutes('keboola.ex-db-redshift-cursors')]),
+    createComponentRoute('keboola.ex-db-firebird', [exDbGenericRoutes('keboola.ex-db-firebird')]),
+    createComponentRoute('keboola.ex-db-db2', [exDbGenericRoutes('keboola.ex-db-db2')]),
+    createComponentRoute('keboola.ex-db-db2-bata', [exDbGenericRoutes('keboola.ex-db-db2-bata')]),
+    createComponentRoute('keboola.ex-db-mssql', [exDbGenericRoutes('keboola.ex-db-mssql')]),
+    createComponentRoute('keboola.ex-db-mysql', [exDbGenericRoutes('keboola.ex-db-mysql')]),
+    createComponentRoute('keboola.ex-db-mysql-custom', [exDbGenericRoutes('keboola.ex-db-mysql-custom')]),
+    createComponentRoute('keboola.ex-db-oracle', [exDbGenericRoutes('keboola.ex-db-oracle')]),
+    createComponentRoute('keboola.ex-db-snowflake', [exDbGenericRoutes('keboola.ex-db-snowflake')]),
+    createComponentRoute('keboola.ex-db-impala', [exDbGenericRoutes('keboola.ex-db-impala')]),
+    createComponentRoute('keboola.ex-mongodb', [exMongoDbRoutes]),
+    createComponentRoute('keboola.ex-google-bigquery', [exGoogleBigqueryRoutes]),
+    createComponentRoute('keboola.ex-teradata', [exDbGenericRoutes('keboola.ex-teradata')]),
+    createComponentRoute('keboola.csv-import', [csvImportRoutes]),
+    createComponentRoute('keboola.ex-s3', [exS3Routes]),
+    createComponentRoute('apify.apify', [exApifyRoutes]),
+    createComponentRoute('keboola.ex-aws-s3', [exAwsS3Routes]),
+    createComponentRoute('keboola.ex-email-attachments', [emailAttachmentsExtractorRoutes]),
+    createComponentRoute('keboola.ex-http', [exHttpRoutes]),
+    createComponentRoute('keboola.ex-storage', [exStorageRoutes]),
+    createComponentRoute('htns.ex-salesforce', [htnsExSalesforceRoutes]),
+    createComponentRoute('keboola.ex-ftp', [exFtpRoutes]),
+    createGenericDetailRoute('extractor')
+  ]
+};
+
+const writers = {
+  name: 'writers',
+  title: 'Writers',
+  requireData: function() {
+    return InstalledComponentsActionsCreators.loadComponents();
+  },
+  defaultRouteHandler: writer(ComponentsIndex),
+  headerButtonsHandler: injectProps({
+    addRoute: 'new-writer',
+    type: 'writer'
+  })(ComponentsHeaderButtons),
+  reloaderHandler: ComponentReloaderButton,
+  childRoutes: [
+    {
+      name: 'new-writer',
+      title: 'New Writer',
+      defaultRouteHandler: writer(NewComponent)
+    },
+    createComponentRoute('gooddata-writer', [goodDataWriterRoutes]),
+    createComponentRoute('tde-exporter', [tdeRoutes]),
+    createComponentRoute('keboola.wr-google-sheets', [googleSheetsWriterRoutes]),
+    createComponentRoute('keboola.wr-google-drive', [googleDriveWriterNewRoutes]),
+    createComponentRoute('wr-db', [createDbWriterRoutes('wr-db', 'mysql', false)]),
+    createComponentRoute('wr-db-mysql', [createDbWriterRoutes('wr-db-mysql', 'mysql', false)]),
+    createComponentRoute('wr-db-oracle', [createDbWriterRoutes('wr-db-oracle', 'oracle', false)]),
+    createComponentRoute('wr-db-redshift', [createDbWriterRoutes('wr-db-redshift', 'redshift', true)]),
+    createComponentRoute('keboola.wr-looker', [createDbWriterRoutes('keboola.wr-looker', 'redshift', true)]),
+    createComponentRoute('keboola.wr-qlik', [createDbWriterRoutes('keboola.wr-qlik', 'redshift', true)]),
+    createComponentRoute('wr-tableau', [createDbWriterRoutes('wr-tableau', 'mysql', false)]),
+    createComponentRoute('wr-db-mssql', [createDbWriterRoutes('wr-db-mssql', 'mssql', false)]),
+    createComponentRoute('keboola.wr-db-mssql-v2', [createDbWriterRoutes('keboola.wr-db-mssql-v2', 'mssql', false)]),
+    createComponentRoute('keboola.wr-redshift-v2', [
+      createDbWriterRoutes('keboola.wr-redshift-v2', 'redshift', true)
+    ]),
+    createComponentRoute('keboola.wr-db-impala', [createDbWriterRoutes('keboola.wr-db-impala', 'impala', false)]),
+    createComponentRoute('keboola.wr-db-mysql', [createDbWriterRoutes('keboola.wr-db-mysql', 'mysql', false)]),
+    createComponentRoute('keboola.wr-db-oracle', [createDbWriterRoutes('keboola.wr-db-oracle', 'oracle', false)]),
+    createComponentRoute('keboola.wr-db-pgsql', [createDbWriterRoutes('keboola.wr-db-pgsql', 'pgsql', false)]),
+    createComponentRoute('keboola.wr-db-snowflake', [
+      createDbWriterRoutes('keboola.wr-db-snowflake', 'snowflake', true)
+    ]),
+    createComponentRoute('keboola.wr-thoughtspot', [
+      createDbWriterRoutes('keboola.wr-thoughtspot', 'thoughtspot', false)
+    ]),
+    createComponentRoute('keboola.gooddata-writer', [gooddataWriterV3Routes]),
+    createComponentRoute('keboola.wr-storage', [wrStorageRoutes]),
+    createComponentRoute('keboola.wr-aws-s3', [wrAwsS3Routes]),
+    createComponentRoute('keboola.wr-google-bigquery', [wrGoogleBigQueryRoutes]),
+    createComponentRoute('keboola.wr-google-bigquery-v2', [wrGoogleBigQueryV2Routes]),
+    createGenericDetailRoute('writer')
+  ]
+};
+
+export {
+  applications,
+  extractors,
+  writers
 };

--- a/src/scripts/modules/components/Routes.js
+++ b/src/scripts/modules/components/Routes.js
@@ -43,7 +43,7 @@ const extractor = injectProps({ type: 'extractor' });
 const writer = injectProps({ type: 'writer' });
 const application = injectProps({ type: 'application' });
 
-module.exports = {
+export default {
   applications: {
     name: 'applications',
     title: 'Applications',

--- a/src/scripts/modules/components/StorageActionCreators.js
+++ b/src/scripts/modules/components/StorageActionCreators.js
@@ -16,8 +16,7 @@ import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 import 'aws-sdk/dist/aws-sdk';
 const AWS = window.AWS;
 
-module.exports = {
-
+export default {
   tokenVerify: function() {
     return storageApi.verifyToken().then((sapiToken) => {
       return dispatcher.handleViewAction({

--- a/src/scripts/modules/components/StorageApi.js
+++ b/src/scripts/modules/components/StorageApi.js
@@ -11,7 +11,7 @@ var createRequest = function(method, path) {
   return request(method, createUrl(path)).set('X-StorageApi-Token', ApplicationStore.getSapiTokenString());
 };
 
-var storageApi = {
+export default {
 
   verifyToken: function() {
     return createRequest('GET', 'tokens/verify').promise().then(function(response) {
@@ -336,5 +336,3 @@ var storageApi = {
     };
   }
 };
-
-module.exports = storageApi;

--- a/src/scripts/modules/components/VersionsActionCreators.js
+++ b/src/scripts/modules/components/VersionsActionCreators.js
@@ -7,7 +7,7 @@ import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 import React from 'react';
 import ConfigurationCopiedNotification from './react/components/ConfigurationCopiedNotification';
 
-module.exports = {
+export default {
   loadVersions: function(componentId, configId) {
     if (Store.hasVersions(componentId, configId)) {
       this.loadVersionsForce(componentId, configId);

--- a/src/scripts/modules/components/VersionsConstants.js
+++ b/src/scripts/modules/components/VersionsConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
 
     VERSIONS_LOAD_START: null,

--- a/src/scripts/modules/components/react/components/ComponentsReloaderButton.jsx
+++ b/src/scripts/modules/components/react/components/ComponentsReloaderButton.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import InstalledComponentsActionCreators from '../../InstalledComponentsActionCreators';
 import { RefreshIcon } from '@keboola/indigo-ui';
-const createStoreMixin = require('../../../../react/mixins/createStoreMixin').default;
-const InstalledComponentsStore = require('../../stores/InstalledComponentsStore').default;
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import InstalledComponentsStore from '../../stores/InstalledComponentsStore';
 
 export default React.createClass({
   mixins: [createStoreMixin(InstalledComponentsStore)],

--- a/src/scripts/modules/components/react/components/RunComponentButton.jsx
+++ b/src/scripts/modules/components/react/components/RunComponentButton.jsx
@@ -7,9 +7,7 @@ import RoutesStore from '../../../../stores/RoutesStore';
 import classnames from 'classnames';
 import RunModal from './RunComponentButtonModal';
 
-module.exports = React.createClass({
-  displayName: 'RunComponentButton',
-
+export default React.createClass({
   propTypes: {
     title: React.PropTypes.string.isRequired,
     mode: React.PropTypes.oneOf(['button', 'link']),

--- a/src/scripts/modules/components/react/components/RunComponentButtonModal.jsx
+++ b/src/scripts/modules/components/react/components/RunComponentButtonModal.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import {Modal, ButtonToolbar, Button} from 'react-bootstrap';
 
-module.exports = React.createClass({
-  displayName: 'RunComponentButtonModal',
+export default React.createClass({
   propTypes: {
     onHide: React.PropTypes.func.isRequired,
     onRequestRun: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/components/react/components/SapiTableSelector.jsx
+++ b/src/scripts/modules/components/react/components/SapiTableSelector.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import Select from 'react-select';
 import storageActionCreators from '../../StorageActionCreators';
-const createStoreMixin = require('../../../../react/mixins/createStoreMixin').default;
-const storageTablesStore = require('../../stores/StorageTablesStore').default;
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import storageTablesStore from '../../stores/StorageTablesStore';
 
 export default React.createClass({
   mixins: [createStoreMixin(storageTablesStore)],

--- a/src/scripts/modules/components/react/components/SidebarVersions.jsx
+++ b/src/scripts/modules/components/react/components/SidebarVersions.jsx
@@ -5,9 +5,10 @@ import SidebarVersionsRow from './SidebarVersionsRow';
 import {Link} from 'react-router';
 import {getPreviousVersion} from '../../../../utils/VersionsDiffUtils';
 import DiffVersionButton from '../../../../react/common/DiffVersionButton';
-module.exports = React.createClass({
-  displayName: 'SidebarVersions',
+
+export default React.createClass({
   mixins: [PureRenderMixin],
+
   propTypes: {
     versions: React.PropTypes.object.isRequired,
     versionsConfigs: React.PropTypes.object.isRequired,
@@ -21,6 +22,7 @@ module.exports = React.createClass({
     isPending: React.PropTypes.bool,
     prepareVersionsDiffData: React.PropTypes.func
   },
+
   getDefaultProps: function() {
     return {
       limit: 5

--- a/src/scripts/modules/components/react/components/SidebarVersionsRow.jsx
+++ b/src/scripts/modules/components/react/components/SidebarVersionsRow.jsx
@@ -3,13 +3,14 @@ import CreatedWithIcon from '../../../../react/common/CreatedWithIcon';
 import ImmutableRendererMixin from 'react-immutable-render-mixin';
 import VersionIcon from './VersionIcon';
 
-module.exports = React.createClass({
-  displayName: 'SidebarVersionsRow',
+export default React.createClass({
   mixins: [ImmutableRendererMixin],
+
   propTypes: {
     version: React.PropTypes.object.isRequired,
     isLast: React.PropTypes.bool
   },
+
   getDefaultProps: function() {
     return {
       isLast: false

--- a/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
@@ -2,7 +2,7 @@ import React, {PropTypes} from 'react';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import {Map, List} from 'immutable';
 import {Panel} from 'react-bootstrap';
-import {getInputMappingValue, findInputMappingDefinition} from '../../../utils/mappingDefinitions';
+import mappingDefinitions from '../../../utils/mappingDefinitions';
 import InstalledComponentsActions from '../../../InstalledComponentsActionCreators';
 import Detail from './TableInputMappingDetail';
 import Header from './TableInputMappingHeader';
@@ -94,7 +94,7 @@ export default React.createClass({
   },
 
   renderHeader(input, key) {
-    const definition = findInputMappingDefinition(this.props.definitions, input);
+    const definition = mappingDefinitions.findInputMappingDefinition(this.props.definitions, input);
 
     return (
       <div onClick={() => this.toggleMapping(key)}>
@@ -157,6 +157,6 @@ export default React.createClass({
   },
 
   getValue() {
-    return getInputMappingValue(this.props.definitions, this.props.value);
+    return mappingDefinitions.getInputMappingValue(this.props.definitions, this.props.value);
   }
 });

--- a/src/scripts/modules/components/react/components/generic/TableOutputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMapping.jsx
@@ -5,7 +5,7 @@ import {Panel} from 'react-bootstrap';
 import Immutable from 'immutable';
 import InstalledComponentsActions from '../../../InstalledComponentsActionCreators';
 import Add from './AddTableOutputMapping';
-import {getOutputMappingValue, findOutputMappingDefinition} from '../../../utils/mappingDefinitions';
+import mappingDefinitions from '../../../utils/mappingDefinitions';
 
 export default React.createClass({
   propTypes: {
@@ -78,7 +78,7 @@ export default React.createClass({
   },
 
   getValue() {
-    return getOutputMappingValue(this.props.definitions, this.props.value);
+    return mappingDefinitions.getOutputMappingValue(this.props.definitions, this.props.value);
   },
 
   content() {
@@ -120,7 +120,7 @@ export default React.createClass({
   },
 
   renderHeader(output, key) {
-    const definition = findOutputMappingDefinition(this.props.definitions, output);
+    const definition = mappingDefinitions.findOutputMappingDefinition(this.props.definitions, output);
 
     return (
       <div onClick={() => this.toggleMapping(key)}>

--- a/src/scripts/modules/components/stores/MetadataStore.js
+++ b/src/scripts/modules/components/stores/MetadataStore.js
@@ -190,4 +190,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = MetadataStore;
+export default MetadataStore;

--- a/src/scripts/modules/components/stores/OAuthStore.js
+++ b/src/scripts/modules/components/stores/OAuthStore.js
@@ -47,4 +47,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = OAuthStore;
+export default OAuthStore;

--- a/src/scripts/modules/components/stores/VersionsStore.js
+++ b/src/scripts/modules/components/stores/VersionsStore.js
@@ -138,4 +138,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = VersionsStore;
+export default VersionsStore;

--- a/src/scripts/modules/components/utils/mappingDefinitions.js
+++ b/src/scripts/modules/components/utils/mappingDefinitions.js
@@ -1,4 +1,4 @@
-var Immutable = require('immutable');
+import Immutable from 'immutable';
 
 var mergeValueAndDefinition = function(compareKey, definitions, value) {
   if (definitions.size > 0) {
@@ -29,7 +29,7 @@ var findDefinition = function(compareKey, definitions, value) {
   }, null, Immutable.Map());
 };
 
-module.exports = {
+export default {
   getInputMappingValue: function(definitions, value) {
     return mergeValueAndDefinition('destination', definitions, value);
   },

--- a/src/scripts/modules/components/utils/mappingDefinitions.spec.js
+++ b/src/scripts/modules/components/utils/mappingDefinitions.spec.js
@@ -1,5 +1,5 @@
-var mappingDefinitions = require('./mappingDefinitions');
-var Immutable = require('immutable');
+import Immutable from 'immutable';
+import mappingDefinitions from './mappingDefinitions';
 
 const inputMappingDefinition =  Immutable.fromJS({
   'label': 'Load data from table',

--- a/src/scripts/modules/components/utils/preferEncryptedAttributes.js
+++ b/src/scripts/modules/components/utils/preferEncryptedAttributes.js
@@ -42,11 +42,11 @@ var preferEncryptedAttributesFromArray = function(data) {
   });
 };
 
-module.exports = function(configuration) {
+export default function(configuration) {
   if (isObject(configuration)) {
     preferEncryptedAttributesFromObject(configuration);
   } else if (Array.isArray(configuration)) {
     preferEncryptedAttributesFromArray(configuration);
   }
   return configuration;
-};
+}

--- a/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
+++ b/src/scripts/modules/components/utils/preferEncryptedAttributes.spec.js
@@ -1,4 +1,4 @@
-var preferEncryptedAttributes = require('./preferEncryptedAttributes');
+import preferEncryptedAttributes from './preferEncryptedAttributes';
 
 describe('preferEncryptedAttributes', function() {
   describe('#preferEncryptedAttributes()', function() {

--- a/src/scripts/modules/components/utils/templateFinder.js
+++ b/src/scripts/modules/components/utils/templateFinder.js
@@ -1,6 +1,6 @@
-var deepEqual = require('deep-equal');
+import deepEqual from 'deep-equal';
 
-module.exports = function(templates, configuration) {
+export default function(templates, configuration) {
   return templates.filter(function(template) {
     var templateKeys, valid;
 
@@ -48,4 +48,4 @@ module.exports = function(templates, configuration) {
     });
     return valid;
   });
-};
+}

--- a/src/scripts/modules/components/utils/templateFinder.spec.js
+++ b/src/scripts/modules/components/utils/templateFinder.spec.js
@@ -1,5 +1,5 @@
-var Immutable = require('immutable');
-var templateFinder = require('./templateFinder');
+import Immutable from 'immutable';
+import templateFinder from './templateFinder';
 
 var templates = Immutable.fromJS([
   {

--- a/src/scripts/modules/configurations/ConfigurationRowsActionCreators.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsActionCreators.js
@@ -27,7 +27,7 @@ const storeEncodedConfigurationRow = function(componentId, configurationId, rowI
   });
 };
 
-module.exports = {
+export default {
   create: function(componentId, configurationId, name, friendlyName, description, emptyConfigFn, createCallback, changeDescription) {
     Dispatcher.handleViewAction({
       type: Constants.ActionTypes.CONFIGURATION_ROWS_CREATE_START,

--- a/src/scripts/modules/configurations/ConfigurationRowsConstants.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
     CONFIGURATION_ROWS_CREATE_START: null,
     CONFIGURATION_ROWS_CREATE_SUCCESS: null,

--- a/src/scripts/modules/configurations/ConfigurationRowsStore.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsStore.js
@@ -291,4 +291,4 @@ Dispatcher.register(function(payload) {
   }
 });
 
-module.exports = ConfigurationRowsStore;
+export default ConfigurationRowsStore;

--- a/src/scripts/modules/configurations/ConfigurationsActionCreators.js
+++ b/src/scripts/modules/configurations/ConfigurationsActionCreators.js
@@ -21,7 +21,7 @@ const storeEncodedConfiguration = function(componentId, configurationId, configu
   });
 };
 
-module.exports = {
+export default {
   updateConfiguration: function(componentId, configurationId, value) {
     Dispatcher.handleViewAction({
       type: Constants.ActionTypes.CONFIGURATIONS_UPDATE_CONFIGURATION,

--- a/src/scripts/modules/configurations/ConfigurationsConstants.js
+++ b/src/scripts/modules/configurations/ConfigurationsConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
     CONFIGURATIONS_UPDATE_CONFIGURATION: null,
     CONFIGURATIONS_RESET_CONFIGURATION: null,

--- a/src/scripts/modules/configurations/ConfigurationsStore.js
+++ b/src/scripts/modules/configurations/ConfigurationsStore.js
@@ -215,4 +215,4 @@ Dispatcher.register(function(payload) {
   }
 });
 
-module.exports = ConfigurationsStore;
+export default ConfigurationsStore;

--- a/src/scripts/modules/configurations/DockerActionsActionCreators.js
+++ b/src/scripts/modules/configurations/DockerActionsActionCreators.js
@@ -7,7 +7,7 @@ import ConfigurationsStore from './ConfigurationsStore';
 import ConfigurationRowsStore from './ConfigurationRowsStore';
 import Immutable from 'immutable';
 
-module.exports = {
+export default {
   callAction: function(componentId, actionName, body, cache) {
     dispatcher.handleViewAction({
       type: Constants.ActionTypes.DOCKER_RUNNER_SYNC_ACTION_RUN,

--- a/src/scripts/modules/configurations/DockerActionsStore.js
+++ b/src/scripts/modules/configurations/DockerActionsStore.js
@@ -75,4 +75,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = DockerActionsStore;
+export default DockerActionsStore;

--- a/src/scripts/modules/configurations/RowVersionsActionCreators.js
+++ b/src/scripts/modules/configurations/RowVersionsActionCreators.js
@@ -5,7 +5,7 @@ import Api from '../components/InstalledComponentsApi';
 import Constants from './RowVersionsConstants';
 import ApplicationActionCreators from '../../actions/ApplicationActionCreators';
 
-module.exports = {
+export default {
   loadVersions: function(componentId, configId, rowId) {
     if (Store.hasVersions(componentId, configId, rowId)) {
       this.loadVersionsForce(componentId, configId, rowId);

--- a/src/scripts/modules/configurations/RowVersionsConstants.js
+++ b/src/scripts/modules/configurations/RowVersionsConstants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
 
     ROW_VERSIONS_LOAD_START: null,

--- a/src/scripts/modules/configurations/RowVersionsStore.js
+++ b/src/scripts/modules/configurations/RowVersionsStore.js
@@ -126,4 +126,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = RowVersionsStore;
+export default RowVersionsStore;

--- a/src/scripts/modules/configurations/react/components/ClearStateButtonModal.jsx
+++ b/src/scripts/modules/configurations/react/components/ClearStateButtonModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, ButtonToolbar, Button} from 'react-bootstrap';
 
-module.exports = React.createClass({
+export default React.createClass({
   propTypes: {
     onHide: React.PropTypes.func.isRequired,
     onRequestRun: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -4,7 +4,7 @@ import {fromJS} from 'immutable';
 import classnames from 'classnames';
 import storageApi from '../../../components/StorageApi';
 import ColumnDataPreview from '../../../components/react/components/ColumnDataPreview';
-require('./StorageTableColumnsEditor.less');
+import './StorageTableColumnsEditor.less';
 
 export default React.createClass({
   propTypes: {

--- a/src/scripts/modules/configurations/utils/isParsableConfiguration.js
+++ b/src/scripts/modules/configurations/utils/isParsableConfiguration.js
@@ -1,4 +1,4 @@
-var Immutable = require('immutable');
+import Immutable from 'immutable';
 
 export default function(configuration, parseFunction, createFunction) {
   if (configuration.isEmpty()) {

--- a/src/scripts/modules/csv-import/utils.js
+++ b/src/scripts/modules/csv-import/utils.js
@@ -36,7 +36,7 @@ const createConfiguration = function(settings, configId) {
   return config;
 };
 
-module.exports = {
+export default {
   getDefaultTable: getDefaultTable,
   createConfiguration: createConfiguration
 };

--- a/src/scripts/modules/csv-import/utils.js
+++ b/src/scripts/modules/csv-import/utils.js
@@ -1,11 +1,10 @@
 import {Map, List} from 'immutable';
 
-const getDefaultTable = function(configId) {
+export const getDefaultTable = function(configId) {
   return 'in.c-csv-import.' + configId;
 };
 
-
-const createConfiguration = function(settings, configId) {
+export const createConfiguration = function(settings, configId) {
   let config = Map();
 
   if (settings.get('destination') && settings.get('destination') !== '') {

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test1.test.js
@@ -1,3 +1,5 @@
+import { createStore } from '../../storeProvisioning';
+
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -18,7 +20,7 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
   };
 });
 
-const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+const store = createStore('keboola.ex-db-mysql', '333289236222');
 
 describe('shouldDestinationHaveOldFormat test 1', function() {
   describe('shouldDestinationHaveOldFormat', function() {

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test2.test.js
@@ -1,3 +1,5 @@
+import { createStore } from '../../storeProvisioning';
+
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -32,7 +34,7 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
   };
 });
 
-const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+const store = createStore('keboola.ex-db-mysql', '333289236222');
 
 describe('shouldDestinationHaveOldFormat test 2', function() {
   describe('shouldDestinationHaveOldFormat', function() {

--- a/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
+++ b/src/scripts/modules/ex-db-generic/tests/shouldDestinationHaveOldFormat/test3.test.js
@@ -1,3 +1,5 @@
+import { createStore } from '../../storeProvisioning';
+
 jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () => {
   const Immutable = require('immutable');
   const data = Immutable.fromJS({
@@ -26,7 +28,7 @@ jest.mock('../../../../modules/components/stores/InstalledComponentsStore', () =
   };
 });
 
-const store = require('../../storeProvisioning').createStore('keboola.ex-db-mysql', '333289236222');
+const store = createStore('keboola.ex-db-mysql', '333289236222');
 
 describe('shouldDestinationHaveOldFormat test 3', function() {
   describe('shouldDestinationHaveOldFormat', function() {

--- a/src/scripts/modules/ex-s3/utils.js
+++ b/src/scripts/modules/ex-s3/utils.js
@@ -1,18 +1,18 @@
 import Immutable from 'immutable';
 
-const getDefaultBucket = function(configId) {
+export const getDefaultBucket = function(configId) {
   return 'in.c-keboola-ex-s3-' + configId;
 };
 
-const getDefaultTable = function(configId) {
+export const getDefaultTable = function(configId) {
   return getDefaultBucket(configId) + '.data';
 };
 
-const hasWildcard = function(key) {
+export const hasWildcard = function(key) {
   return key.substring(key.length - 1, key.length) === '*';
 };
 
-const createConfiguration = function(localState, configId) {
+export const createConfiguration = function(localState, configId) {
   var mapping = {};
   var s3Key = localState.get('s3Key', '');
 
@@ -69,7 +69,7 @@ const createConfiguration = function(localState, configId) {
   return config;
 };
 
-const parseConfiguration = function(configuration, configId) {
+export const parseConfiguration = function(configuration, configId) {
   const configData = Immutable.fromJS(configuration);
   const s3Key = configData.getIn(['parameters', 'key'], '');
   return {
@@ -86,7 +86,7 @@ const parseConfiguration = function(configuration, configId) {
   };
 };
 
-export {
+export default {
   getDefaultTable,
   getDefaultBucket,
   hasWildcard,

--- a/src/scripts/modules/ex-s3/utils.js
+++ b/src/scripts/modules/ex-s3/utils.js
@@ -1,4 +1,4 @@
-var Immutable = require('immutable');
+import Immutable from 'immutable';
 
 const getDefaultBucket = function(configId) {
   return 'in.c-keboola-ex-s3-' + configId;
@@ -86,7 +86,7 @@ function parseConfiguration(configuration, configId) {
   };
 }
 
-module.exports = {
+export default {
   getDefaultTable: getDefaultTable,
   getDefaultBucket: getDefaultBucket,
   hasWildcard: hasWildcard,

--- a/src/scripts/modules/ex-s3/utils.js
+++ b/src/scripts/modules/ex-s3/utils.js
@@ -12,7 +12,7 @@ const hasWildcard = function(key) {
   return key.substring(key.length - 1, key.length) === '*';
 };
 
-function createConfiguration(localState, configId) {
+const createConfiguration = function(localState, configId) {
   var mapping = {};
   var s3Key = localState.get('s3Key', '');
 
@@ -67,9 +67,9 @@ function createConfiguration(localState, configId) {
     processors: processors
   };
   return config;
-}
+};
 
-function parseConfiguration(configuration, configId) {
+const parseConfiguration = function(configuration, configId) {
   const configData = Immutable.fromJS(configuration);
   const s3Key = configData.getIn(['parameters', 'key'], '');
   return {
@@ -84,12 +84,12 @@ function parseConfiguration(configuration, configId) {
     delimiter: configData.getIn(['storage', 'output', 'tables', 0, 'delimiter'], ','),
     enclosure: configData.getIn(['storage', 'output', 'tables', 0, 'enclosure'], '"')
   };
-}
+};
 
-export default {
-  getDefaultTable: getDefaultTable,
-  getDefaultBucket: getDefaultBucket,
-  hasWildcard: hasWildcard,
-  createConfiguration: createConfiguration,
-  parseConfiguration: parseConfiguration
+export {
+  getDefaultTable,
+  getDefaultBucket,
+  hasWildcard,
+  createConfiguration,
+  parseConfiguration
 };

--- a/src/scripts/modules/ex-s3/utils.spec.js
+++ b/src/scripts/modules/ex-s3/utils.spec.js
@@ -1,9 +1,8 @@
-var Immutable = require('immutable');
-var getDefaultTable = require('./utils').getDefaultTable;
-var hasWildcard = require('./utils').hasWildcard;
-var createConfiguration = require('./utils').createConfiguration;
-var parseConfiguration = require('./utils').parseConfiguration;
-var getDefaultBucket = require('./utils').getDefaultBucket;
+import Immutable from 'immutable';
+import { getDefaultTable, hasWildcard, createConfiguration, parseConfiguration, getDefaultBucket } from './utils';
+
+console.log(getDefaultTable); // eslint-disable-line
+console.log(hasWildcard); // eslint-disable-line
 
 const emptyLocalState = {};
 const emptyConfiguration = {};

--- a/src/scripts/modules/ex-s3/utils.spec.js
+++ b/src/scripts/modules/ex-s3/utils.spec.js
@@ -1,9 +1,6 @@
 import Immutable from 'immutable';
 import { getDefaultTable, hasWildcard, createConfiguration, parseConfiguration, getDefaultBucket } from './utils';
 
-console.log(getDefaultTable); // eslint-disable-line
-console.log(hasWildcard); // eslint-disable-line
-
 const emptyLocalState = {};
 const emptyConfiguration = {};
 

--- a/src/scripts/modules/gooddata-writer/react/notifications/projectScheduledToReset.js
+++ b/src/scripts/modules/gooddata-writer/react/notifications/projectScheduledToReset.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router/lib';
+import { Link } from 'react-router';
 
 export default (job) => {
   return React.createClass({

--- a/src/scripts/modules/home/react/Index.jsx
+++ b/src/scripts/modules/home/react/Index.jsx
@@ -11,7 +11,7 @@ import DeprecatedComponents from './DeprecatedComponents';
 import FileSize from '../../../react/common/FileSize';
 import TransformationParallelUnloads from './TransformationParallelUnloads';
 import createStoreMixin from '../../../react/mixins/createStoreMixin';
-import { showWizardModalFn } from '../../guide-mode/stores/ActionCreators.js';
+import { showWizardModalFn } from '../../guide-mode/stores/ActionCreators';
 import WizardStore from '../../guide-mode/stores/WizardStore';
 import Desk from '../../guide-mode/react/Desk';
 import lessons from '../../guide-mode/WizardLessons';

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobStatsContainer.jsx
@@ -3,7 +3,7 @@ import Immutable from 'immutable';
 import PureRenderMixin from 'react-addons-pure-render-mixin';
 import later from 'later';
 
-import {getRunIdStats} from '../../../../components/StorageApi';
+import StorageApi from '../../../../components/StorageApi';
 import JobStats from './JobStats';
 
 
@@ -61,7 +61,8 @@ export default React.createClass({
     this.setState({
       isLoading: true
     });
-    this.cancellablePromise = getRunIdStats(runId).then(this.receiveStats);
+    this.cancellablePromise = StorageApi.getRunIdStats(runId)
+      .then(this.receiveStats);
   },
 
   receiveStats(stats) {

--- a/src/scripts/modules/oauth-v2/Api.js
+++ b/src/scripts/modules/oauth-v2/Api.js
@@ -20,7 +20,7 @@ function createRequest(method, path, version) {
     .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString());
 }
 
-module.exports = {
+export default {
   getCredentials: function(componentId, id, version) {
     return createRequest('GET', 'credentials/' + componentId + '/' + id, version)
       .promise().then(function(response) {

--- a/src/scripts/modules/provisioning/ActionCreators.js
+++ b/src/scripts/modules/provisioning/ActionCreators.js
@@ -9,7 +9,7 @@ import WrDbCredentialsStore from './stores/WrDbCredentialsStore';
 import Promise from 'bluebird';
 import HttpError from '../../utils/HttpError';
 
-module.exports = {
+export default {
   getRedshiftBackend: function() {
     return 'redshift-workspace';
   },

--- a/src/scripts/modules/provisioning/Constants.js
+++ b/src/scripts/modules/provisioning/Constants.js
@@ -1,6 +1,6 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
-module.exports = {
+export default {
   ActionTypes: keyMirror({
     CREDENTIALS_REDSHIFT_SANDBOX_LOAD: null,
     CREDENTIALS_REDSHIFT_SANDBOX_LOAD_SUCCESS: null,

--- a/src/scripts/modules/provisioning/ProvisioningApi.js
+++ b/src/scripts/modules/provisioning/ProvisioningApi.js
@@ -99,4 +99,4 @@ const ProvisioningApi = {
   }
 };
 
-module.exports = ProvisioningApi;
+export default ProvisioningApi;

--- a/src/scripts/modules/provisioning/react/components/ExtendCredentialsButton.jsx
+++ b/src/scripts/modules/provisioning/react/components/ExtendCredentialsButton.jsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import {Loader} from '@keboola/indigo-ui';
 
-module.exports = React.createClass({
-  displayName: 'ExtendCredentials',
-
+export default React.createClass({
   propTypes: {
     isExtending: React.PropTypes.bool.isRequired,
     onExtend: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/provisioning/react/components/ExtendRStudioCredentials.jsx
+++ b/src/scripts/modules/provisioning/react/components/ExtendRStudioCredentials.jsx
@@ -4,9 +4,7 @@ import ActionCreators from '../../ActionCreators';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import ExtendCredentialsButton from './ExtendCredentialsButton';
 
-module.exports = React.createClass({
-  displayName: 'ExtendRStudioCredentials',
-
+export default React.createClass({
   mixins: [createStoreMixin(RStudioSandboxCredentialsStore)],
 
   getStateFromStores: function() {

--- a/src/scripts/modules/provisioning/stores/JupyterSandboxCredentialsStore.js
+++ b/src/scripts/modules/provisioning/stores/JupyterSandboxCredentialsStore.js
@@ -99,4 +99,4 @@ Dispatcher.register(function(payload) {
   }
 });
 
-module.exports = JupyterSandboxCredentialsStore;
+export default JupyterSandboxCredentialsStore;

--- a/src/scripts/modules/provisioning/stores/RStudioSandboxCredentialsStore.js
+++ b/src/scripts/modules/provisioning/stores/RStudioSandboxCredentialsStore.js
@@ -99,4 +99,4 @@ Dispatcher.register(function(payload) {
   }
 });
 
-module.exports = RStudioSandboxCredentialsStore;
+export default RStudioSandboxCredentialsStore;

--- a/src/scripts/modules/provisioning/stores/SnowflakeSandboxCredentialsStore.js
+++ b/src/scripts/modules/provisioning/stores/SnowflakeSandboxCredentialsStore.js
@@ -79,4 +79,4 @@ Dispatcher.register(function(payload) {
   }
 });
 
-module.exports = SnowflakeSandboxCredentialsStore;
+export default SnowflakeSandboxCredentialsStore;

--- a/src/scripts/modules/services/Store.js
+++ b/src/scripts/modules/services/Store.js
@@ -27,4 +27,4 @@ dispatcher.register(function(payload) {
   }
 });
 
-module.exports = ServicesStore;
+export default ServicesStore;

--- a/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
+++ b/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
@@ -5,11 +5,10 @@ import { fromJS, List, Map } from 'immutable';
 import * as tdeCommon from '../../tdeCommon';
 import InstalledComponentsActions from '../../../components/InstalledComponentsActionCreators';
 import EditButtons from '../../../../react/common/EditButtons';
-
-const createStoreMixin = require('../../../../react/mixins/createStoreMixin').default;
-const RoutesStore = require('../../../../stores/RoutesStore').default;
-const StorageTablesStore = require('../../../components/stores/StorageTablesStore').default;
-const InstalledComponentsStore = require('../../../components/stores/InstalledComponentsStore').default;
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import RoutesStore from '../../../../stores/RoutesStore';
+import StorageTablesStore from '../../../components/stores/StorageTablesStore';
+import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
 
 const componentId = 'tde-exporter';
 

--- a/src/scripts/modules/transformations/ActionCreators.js
+++ b/src/scripts/modules/transformations/ActionCreators.js
@@ -53,7 +53,7 @@ const reloadVersions = function(configId, rowId) {
   return Promise.all(promises);
 };
 
-module.exports = {
+export default {
   createTransformationBucket: function(data) {
     var changeDescription, newBucket;
     newBucket = {};

--- a/src/scripts/modules/transformations/TransformationsApiAdapter.js
+++ b/src/scripts/modules/transformations/TransformationsApiAdapter.js
@@ -82,4 +82,4 @@ var transformationsApi = {
   }
 };
 
-module.exports = transformationsApi;
+export default transformationsApi;

--- a/src/scripts/modules/transformations/react/components/CreateDockerSandboxForm.jsx
+++ b/src/scripts/modules/transformations/react/components/CreateDockerSandboxForm.jsx
@@ -3,8 +3,7 @@ import {Input} from './../../../../react/common/KbcBootstrap';
 import Immutable from 'immutable';
 import Select from 'react-select';
 
-module.exports = React.createClass({
-  displayName: 'CreateDockerSandboxForm',
+export default React.createClass({
   propTypes: {
     tables: React.PropTypes.object.isRequired,
     onChange: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
@@ -155,4 +155,4 @@ var JupyterSandbox = React.createClass({
   }
 });
 
-module.exports = JupyterSandbox;
+export default JupyterSandbox;

--- a/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
@@ -154,4 +154,4 @@ var RStudioSandbox = React.createClass({
   }
 });
 
-module.exports = RStudioSandbox;
+export default RStudioSandbox;

--- a/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
@@ -133,4 +133,4 @@ var SnowflakeSandbox = React.createClass({
   }
 });
 
-module.exports = SnowflakeSandbox;
+export default SnowflakeSandbox;

--- a/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.js
+++ b/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.js
@@ -1,6 +1,6 @@
-const { Map } = require('immutable');
+import { Map } from 'immutable';
 
-module.exports = function(datatype) {
+export default function(datatype) {
   var str;
   if (!Map.isMap(datatype)) {
     return datatype;
@@ -13,4 +13,4 @@ module.exports = function(datatype) {
     str += ' ENCODE ' + datatype.get('compression');
   }
   return str;
-};
+}

--- a/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.spec.js
+++ b/src/scripts/modules/transformations/react/components/mapping/input/getDatatypeLabel.spec.js
@@ -1,5 +1,5 @@
-var Immutable = require('immutable');
-var getDatatypeLabel = require('./getDatatypeLabel');
+import Immutable from 'immutable';
+import getDatatypeLabel from './getDatatypeLabel';
 
 describe('getDatatypeLabel', function() {
   describe('#getDatatypeLabel()', function() {

--- a/src/scripts/modules/transformations/react/modals/CreateDockerSandboxModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/CreateDockerSandboxModal.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import {Button, Modal} from 'react-bootstrap';
 import CreateDockerSandboxForm from '../components/CreateDockerSandboxForm';
 
-module.exports = React.createClass({
-  displayName: 'CreateDockerSandboxModal',
+export default React.createClass({
   propTypes: {
     show: React.PropTypes.bool.isRequired,
     close: React.PropTypes.func.isRequired,

--- a/src/scripts/modules/transformations/react/modals/NewTransformation.jsx
+++ b/src/scripts/modules/transformations/react/modals/NewTransformation.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Modal, Button } from 'react-bootstrap';
 import { Input } from './../../../../react/common/KbcBootstrap';
 import {Map} from 'immutable';
-import {createTransformation} from '../../ActionCreators';
+import ActionCreators from '../../ActionCreators';
 
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 
@@ -244,7 +244,7 @@ export default React.createClass({
     this.setState({
       data: this.state.data.set('isSaving', true)
     });
-    createTransformation(this.props.bucket.get('id'), prepareDataForCreate(this.state.data))
+    ActionCreators.createTransformation(this.props.bucket.get('id'), prepareDataForCreate(this.state.data))
       .then(this.close)
       .catch(() => {
         this.setState({

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/normalizeNewines.test.js
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/normalizeNewines.test.js
@@ -1,4 +1,4 @@
-var normalizeNewlines = require('./normalizeNewlines').default;
+import normalizeNewlines from './normalizeNewlines';
 
 describe('normalizeNewlines', function() {
   it('it should replace CRLF with LF', function() {

--- a/src/scripts/parts.js
+++ b/src/scripts/parts.js
@@ -9,7 +9,7 @@ import CurrentUser from './react/layout/CurrentUser';
 import ProjectsList from './react/layout/project-select/List';
 import NewProjectModal from './react/layout/NewProjectModal';
 
-module.exports = {
+export default {
   helpers,
   parts: {
     ProjectSelect,

--- a/src/scripts/projectsList.js
+++ b/src/scripts/projectsList.js
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import CurrentUser from './react/layout/CurrentUser';
 import ProjectsList from './react/layout/project-select/List';
+import helpers from './helpers';
 
 const App = React.createClass({
   propTypes: {
@@ -51,7 +52,7 @@ const App = React.createClass({
   }
 });
 
-module.exports = {
+export default {
   start: function(appOptions) {
     document.body.className = 'kbc-outer-page kbc-projects-list';
     ReactDOM.render(
@@ -69,5 +70,5 @@ module.exports = {
       document.body
     );
   },
-  helpers: require('./helpers')
+  helpers
 };

--- a/src/scripts/projectsList.js
+++ b/src/scripts/projectsList.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import Immutable from 'immutable';
 import CurrentUser from './react/layout/CurrentUser';
 import ProjectsList from './react/layout/project-select/List';
-import helpers from './helpers';
+import * as helpers from './helpers';
 
 const App = React.createClass({
   propTypes: {

--- a/src/scripts/react/common/SaveButtonsModal.jsx
+++ b/src/scripts/react/common/SaveButtonsModal.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Modal, ButtonToolbar, Button} from 'react-bootstrap';
 
-module.exports = React.createClass({
+export default React.createClass({
   propTypes: {
     onHide: React.PropTypes.func.isRequired,
     onSave: React.PropTypes.func.isRequired,

--- a/src/scripts/react/common/changedSinceOptionCreator.js
+++ b/src/scripts/react/common/changedSinceOptionCreator.js
@@ -10,7 +10,7 @@ const validTimeDimensionsPlural = [
   'days'
 ];
 
-module.exports = function(value) {
+export default function(value) {
   // has to be a string
   if (typeof value !== 'string') {
     return false;
@@ -61,5 +61,5 @@ module.exports = function(value) {
 
   // return absolute number + dimension
   return Math.abs(numberPart).toString() + ' ' + dimensionPartFull;
-};
+}
 

--- a/src/scripts/react/common/changedSinceOptionCreator.spec.js
+++ b/src/scripts/react/common/changedSinceOptionCreator.spec.js
@@ -1,4 +1,4 @@
-var changedSinceOptionCreator = require('./changedSinceOptionCreator');
+import changedSinceOptionCreator from './changedSinceOptionCreator';
 
 describe('changedSinceOptionCreator', function() {
   describe('valid options', function() {

--- a/src/scripts/settings-users.js
+++ b/src/scripts/settings-users.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {ExternalLink} from '@keboola/indigo-ui';
+import helpers from './helpers';
 
 const App = React.createClass({
   render() {
@@ -352,9 +353,9 @@ const App = React.createClass({
   }
 });
 
-module.exports = {
+export default {
   start: function() {
     ReactDOM.render(<App />, document.getElementById('react'));
   },
-  helpers: require('./helpers')
+  helpers
 };

--- a/src/scripts/settings-users.js
+++ b/src/scripts/settings-users.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import {ExternalLink} from '@keboola/indigo-ui';
-import helpers from './helpers';
+import * as helpers from './helpers';
 
 const App = React.createClass({
   render() {

--- a/src/scripts/utils/StoreUtils.js
+++ b/src/scripts/utils/StoreUtils.js
@@ -24,4 +24,4 @@ const StoreUtils = {
   }
 };
 
-module.exports = StoreUtils;
+export default StoreUtils;

--- a/src/scripts/utils/duration.spec.js
+++ b/src/scripts/utils/duration.spec.js
@@ -1,4 +1,4 @@
-var timeInWords = require('./duration').timeInWords;
+import { timeInWords } from './duration';
 
 describe('duration', function() {
   describe('duration without round param - default', function() {

--- a/src/scripts/utils/jobPoller.js
+++ b/src/scripts/utils/jobPoller.js
@@ -1,8 +1,9 @@
 import Promise from 'bluebird';
 import request from './request';
+
 const _pollStatuses = ['processing', 'waiting'];
 
-module.exports = {
+export default {
   poll: function(token, url, interval) {
     var timeOutInterval = 5000;
     if (parseInt(interval, 10) > 0) {

--- a/src/scripts/utils/react-shim.js
+++ b/src/scripts/utils/react-shim.js
@@ -1,6 +1,7 @@
 
 // keboola namespace for react components https://github.com/facebook/react/issues/1939
-const DOMProperty = require('react/lib/DOMProperty');
+import DOMProperty from 'react/lib/DOMProperty';
+
 if (process.env.NODE_ENV === 'production') {
   DOMProperty.ID_ATTRIBUTE_NAME = 'data-keboolaid';
 }

--- a/src/scripts/utils/request.js
+++ b/src/scripts/utils/request.js
@@ -26,6 +26,6 @@ Request.prototype.promise = function() {
   });
 };
 
-module.exports = (method, url) => {
+export default (method, url) => {
   return request(method, url).timeout(60000);
 };

--- a/src/scripts/utils/simpleMatch.js
+++ b/src/scripts/utils/simpleMatch.js
@@ -1,3 +1,3 @@
-module.exports = function(query, test) {
+export default function(query, test) {
   return test.toLocaleLowerCase().indexOf(query.toLocaleLowerCase()) >= 0;
-};
+}

--- a/src/scripts/utils/validateStorageTableId.js
+++ b/src/scripts/utils/validateStorageTableId.js
@@ -1,6 +1,6 @@
-module.exports = function(str) {
+export default function(str) {
   if (str.match(/^(in|out)\.c-[a-zA-z0-9_\-]+\.[a-zA-z0-9_\-]+$/)) {
     return true;
   }
   return false;
-};
+}

--- a/src/scripts/utils/validateStorageTableId.spec.js
+++ b/src/scripts/utils/validateStorageTableId.spec.js
@@ -1,4 +1,4 @@
-var validateStorageTableId = require('./validateStorageTableId');
+import validateStorageTableId from './validateStorageTableId';
 
 describe('validateStorageTableId', function() {
   describe('#validateStorageTableId()', function() {

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -58,6 +58,7 @@ module.exports = function(options) {
         path: path.resolve(__dirname, isDevelopment ? '../dist' : '../dist/' + process.env.KBC_REVISION),
         filename: isDevelopment ? '[name].js' : '[name].min.js',
         publicPath: isDevelopment ? '/scripts/' : '',
+        libraryExport: 'default',
         library: 'kbcApp'
       },
       isDevelopment ? { globalObject: 'this' } : {}


### PR DESCRIPTION
Všechny exporty různých utils atd jsem projel aby to fungovalo. Asi by bylo dobré to příště nějak sjednotit. Třeba že utils nebudou mít default export apod. Teď někde je jenom default, jinde named a default. A někde pouze named. To pak může dělat starosti při použivání.

Komponenty by měly být OK.

Různé store, actionCreators jsem také projel, tak snad vše.

Třeba `scripts/modules/components/Routes.js` jsem poupravil více, aby se zachovala funkčnost. Ale takovým úprav bylo minimum. Spíše se jen přepsal ten export, kouklo se jak se to používá a případně trošku upravilo nebo šlo dál.

Poslední co, tak jsem také upravil Webpack config, aby posílal do "library" objektu default export.  Abych mohl takto exportovat i přímo v tom "rootu" (scripts/app.js apod).

"require" v aplikaci furt zůstalo na pár místěch, kde se dělá třeba mock něčeho apod. Většina aplikace byla ale přepsána.