### PR TITLE
Config rows - configuration is not parsable after authorization reset 

### DIFF
--- a/src/scripts/modules/configurations/adapters/oauth.js
+++ b/src/scripts/modules/configurations/adapters/oauth.js
@@ -1,24 +1,22 @@
-import Immutable from 'immutable';
+import { Map, fromJS } from 'immutable';
 import { Constants } from '../../oauth-v2/Constants';
 
 const createConfiguration = function(localState) {
-  const config = Immutable.fromJS({
-    authorization: {
-      oauth_api: {
-        id: localState.get('oauthId', '')
-      }
-    }
-  });
+  let config = Map();
+
+  if (localState.get('oauthId')) {
+    config = config.setIn(['authorization', 'oauth_api', 'id'], localState.get('oauthId'));
+  }
 
   if (localState.get('oauthVersion') === Constants.OAUTH_VERSION_3) {
-    return config.setIn(['authorization', 'oauth_api', 'version'], Constants.OAUTH_VERSION_3);
+    config = config.setIn(['authorization', 'oauth_api', 'version'], Constants.OAUTH_VERSION_3);
   }
 
   return config;
 };
 
 const parseConfiguration = function(configuration, context) {
-  return Immutable.fromJS({
+  return fromJS({
     oauthId: configuration.getIn(['authorization', 'oauth_api', 'id'], ''),
     oauthVersion: configuration.getIn(['authorization', 'oauth_api', 'version'], Constants.OAUTH_VERSION_FALLBACK),
     componentId: context.get('componentId', ''),

--- a/src/scripts/modules/configurations/adapters/oauth.spec.def.js
+++ b/src/scripts/modules/configurations/adapters/oauth.spec.def.js
@@ -6,13 +6,7 @@ export const cases = {
       componentId: '',
       configurationId: ''
     },
-    configuration: {
-      authorization: {
-        oauth_api: {
-          id: ''
-        }
-      }
-    },
+    configuration: {},
     context: {
       componentId: '',
       configurationId: ''

--- a/src/scripts/modules/oauth-v2/OauthUtils.js
+++ b/src/scripts/modules/oauth-v2/OauthUtils.js
@@ -115,8 +115,11 @@ export function deleteCredentialsAndConfigAuth(componentId, configId) {
     .then(() => {
       // delete the whole authorization object part of the configuration
       const newConfigData = configData.deleteIn([].concat(configOauthPath[0]));
-      const saveFn = installedComponentsActions.saveComponentConfigData;
-      return saveFn(componentId, configId, newConfigData, `Reset authorization of ${authorizedFor}`);
+      const description = `Reset authorization of ${authorizedFor}`;
+      return installedComponentsActions.saveComponentConfigData(componentId, configId, newConfigData, description);
+    })
+    .then(() => {
+      return installedComponentsActions.loadComponentConfigDataForce(componentId, configId);
     });
 }
 


### PR DESCRIPTION
Fixes #2821

Je tam ten fix co byl popsán v issue.

Koukal jsem do toho více protože, jsem se v tom chtěl více zorientovat, ale je to teda docela peklo pro mě zatím.

Když uložím třeba v tom "wr-google-bigquery` nějaký jiný data v tom projects, tak to hned pak vidím v tom Editoru. Jakmile ale resetnu autorizaci, tak v tom editoru mám stále auth ID. Myslel jsem že by problém mohl být právě v tom že to nějak neúplně aktualizuje, když se to tam nepromítne hned. Ale nedokázal jsem se v tom zorientovat abych byl schopný to více prověřit.