### PR TITLE
Fixes in ConfigurationsStore

### DIFF
--- a/src/scripts/modules/configurations/ConfigurationsStore.js
+++ b/src/scripts/modules/configurations/ConfigurationsStore.js
@@ -201,17 +201,13 @@ Dispatcher.register(function(payload) {
         .deleteIn(['jsonEditor', action.componentId, action.configurationId]);
       return ConfigurationsStore.emitChange();
 
-    case Constants.ActionTypes.CONFIGURATIONS_RESET_OAUTH_START:
+    case Constants.ActionTypes.CONFIGURATIONS_OAUTH_RESET_START:
       _store = _store.setIn(['pendingActions', action.componentId, action.configurationId, 'reset-oauth', action.rowId], true);
       return ConfigurationsStore.emitChange();
 
-    case Constants.ActionTypes.CONFIGURATIONS_RESET_OAUTH_ERROR:
+    case Constants.ActionTypes.CONFIGURATIONS_OAUTH_RESET_ERROR:
+    case Constants.ActionTypes.CONFIGURATIONS_OAUTH_RESET_SUCCESS:
       _store = _store.deleteIn(['pendingActions', action.componentId, action.configurationId, 'reset-oauth']);
-      return ConfigurationsStore.emitChange();
-
-    case Constants.ActionTypes.CONFIGURATIONS_RESET_OAUTH_SUCCESS:
-      _store = _store
-        .deleteIn(['pendingActions', action.componentId, action.configurationId, 'reset-oauth']);
       return ConfigurationsStore.emitChange();
 
     default:

--- a/src/scripts/modules/configurations/react/components/IndexSections.jsx
+++ b/src/scripts/modules/configurations/react/components/IndexSections.jsx
@@ -3,7 +3,6 @@ import Immutable from 'immutable';
 
 // stores
 import ComponentStore from '../../../components/stores/ComponentsStore';
-import ConfigurationsStore from '../../ConfigurationsStore';
 import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
 import RoutesStore from '../../../../stores/RoutesStore';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
@@ -29,7 +28,7 @@ export default React.createClass({
     const configurationId = RoutesStore.getCurrentRouteParam('config');
     const component = ComponentStore.getComponent(componentId);
     const isChanged = Store.isEditingConfiguration(componentId, configurationId);
-    const context = ConfigurationsStore.getConfigurationContext(componentId, configurationId);
+    const context = Store.getConfigurationContext(componentId, configurationId);
     const createBySectionsFn = sections.makeCreateFn(settings.getIn(['index', 'sections']));
     const conformFn = settings.getIn(['index', 'onConform'], (config) => config);
     const parseBySectionsFn = sections.makeParseFn(
@@ -54,7 +53,7 @@ export default React.createClass({
       settings: settings,
       component: component,
       configurationId: configurationId,
-      configuration: ConfigurationsStore.get(componentId, configurationId),
+      configuration: Store.get(componentId, configurationId),
       createBySectionsFn,
       parseBySectionsFn,
       jsonConfigurationValue: Store.getEditingJsonConfigurationString(componentId, configurationId),


### PR DESCRIPTION
Related #2836

Ve `IndexSections.jsx` se načítal jeden store dvakrát - malý fix.
Ve `ConfigurationsStore.js` byly špatné "konstatnty" (RESET_OAUTH místo OAUTH_RESET).

To druhé jsem doufal že mi opraví ten "bug" že se mi po resetu autorizace neprojeví ta změna v Json editoru. Ale to se nepotvrdilo.
Koukal jsem po tom více a tam se to maže úplně v jiném storu "InstalledComponents", vůbec nevím jak to že je to tam i tam, nebo jak to funguje. Radši jsem se nepouštěl to nějaké úpravy tam. Třeba v tom "wr-google-bigquery" se to tahá z `ConfigurationsStore` ale ten reset to teda maže z `InstalledComponentsStore`.

Poslední věc tak v `indexSections` nevidím žádné použití `InstalledComponentsStore` krom toho že to je v tom `createStoreMixin`. Asi to je záměr, aby se vyvolalo v nějakém případně nové načtení ze storů. Ale radši to sem píši. 