### PR TITLE
Transformations - Fix rollback bug after a transformation was edited

### DIFF
--- a/src/scripts/modules/transformations/react/pages/transformation-detail/Queries.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/Queries.jsx
@@ -1,11 +1,12 @@
 import React, { PropTypes } from 'react';
-import PureRenderMixin from 'react-addons-pure-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import Edit from './QueriesEdit';
 import Clipboard from '../../../../../react/common/Clipboard';
 import SaveButton from '../../components/SaveButton';
 
 export default React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [ImmutableRenderMixin],
+
   propTypes: {
     bucketId: PropTypes.string.isRequired,
     transformation: PropTypes.object.isRequired,

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -533,6 +533,11 @@ export default React.createClass({
           TransformationsActionCreators.cancelTransformationEditingField(
             this.props.bucketId,
             this.props.transformationId,
+            'splitQueries'
+          );
+          TransformationsActionCreators.cancelTransformationEditingField(
+            this.props.bucketId,
+            this.props.transformationId,
             'queriesString'
           );
           return TransformationsActionCreators.cancelTransformationEditingField(

--- a/src/scripts/modules/transformations/stores/TransformationsStore.js
+++ b/src/scripts/modules/transformations/stores/TransformationsStore.js
@@ -230,25 +230,12 @@ Dispatcher.register(payload => {
           store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, action.editingId]);
 
           if (action.editingId === 'queries') {
-            store.deleteIn([
-              'editingTransformationsFields',
-              action.bucketId,
-              action.transformationId,
-              'queriesChanged'
-            ]);
-            store.deleteIn([
-              'editingTransformationsFields',
-              action.bucketId,
-              action.transformationId,
-              'description'
-            ]);
+            store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'splitQueries']);
+            store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'queriesString']);
+            store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'queriesChanged']);
+            store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'description']);
           } else if (action.editingId === 'packages') {
-            store.deleteIn([
-              'editingTransformationsFields',
-              action.bucketId,
-              action.transformationId,
-              'packagesChanged'
-            ]);
+            store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'packagesChanged']);
           } else if (action.editingId === 'tags') {
             store.deleteIn(['editingTransformationsFields', action.bucketId, action.transformationId, 'tagsChanged']);
           }


### PR DESCRIPTION
Doufám že to jsou správné opravy.

Pokud jsem editovat `queries` v transformaci a následně dal `Reset`. Neresetovalo to všechny položky co tam jsou ohledně `queries`. To pak dělalo problémy třeba po rollbacku. Ukazovalo to jiný `queries` než ve skutečnosti bylo apod.

Po uložení `queries` to také nemazalo všechny položky `queries` v editaci a dělalo to stejný bug. Po rollbacku to ukazovalo jiné `queries` než byla realita. Přitom `Save` button byl disabled, protože `queriesChanged` bylo jako jediné smazáno.

Do Queries komponenty chodí immutable props objekt jako `transformation`, tak jsem upravil ten mixin. To nevím zda má nějaký vliv na něco ale asi se to tam hodí lépe.

BTW: Myslím, že by stálo za uváženo chytat `ROW_VERSIONS_ROLLBACK_SUCCESS` (možná také `VERSIONS_ROLLBACK_SUCCESS`) ve `TransformationsStore` a v takovém případě celou rozdělanou editaci smazat. Aby při návratu na detail byla transformace v tom stavu z rollbacku. Je to blbost nebo to dává smysl? :) Ono to po této opravě funguje tak, že když mám rozdělanou `queries` třeba, neuložím. Jdu dát rollback. Hotovo a vrátím se, tak mám stále rozdělanou `queries`. S těmi fixy tu aspoň vidím že můžu Save neb Reset. Po Resetu dostanu ty správné `queries` po rollbacku. Ale i tak bych to spíše prostě resetnul hned sám.