### PR TITLE
Use urlTemplates when linking to external project

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/ExternalProjectBucketLink.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/ExternalProjectBucketLink.jsx
@@ -1,21 +1,32 @@
 import React, { PropTypes } from 'react';
 import { ExternalLink } from '@keboola/indigo-ui';
+import _ from 'underscore';
 
 export default React.createClass({
   propTypes: {
-    bucket: PropTypes.object.isRequired
+    bucket: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired
   },
 
   render() {
-    const bucketId = this.props.bucket.get('id');
-    const projectId = this.props.bucket.getIn(['project', 'id']);
-    const projectName = this.props.bucket.getIn(['project', 'name']);
+    const { bucket, urlTemplates } = this.props;
+    const bucketId = bucket.get('id');
+    const projectId = bucket.getIn(['project', 'id']);
+    const projectName = bucket.getIn(['project', 'name']);
 
     return (
       <span>
-        <ExternalLink href={`/admin/projects/${projectId}`}>{projectName}</ExternalLink>
+        <ExternalLink
+          href={_.template(urlTemplates.get('project'))({ projectId })}
+        >
+          {projectName}
+        </ExternalLink>
         {' / '}
-        <ExternalLink href={`/admin/projects/${projectId}/storage#/buckets/${bucketId}`}>{bucketId}</ExternalLink>
+        <ExternalLink
+          href={`${_.template(urlTemplates.get('project'))({ projectId })}storage#/buckets/${bucketId}`}
+        >
+          {bucketId}
+        </ExternalLink>
       </span>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/components/ExternalProjectTableLink.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/ExternalProjectTableLink.jsx
@@ -1,21 +1,32 @@
 import React, { PropTypes } from 'react';
 import { ExternalLink } from '@keboola/indigo-ui';
+import _ from 'underscore';
 
 export default React.createClass({
   propTypes: {
-    table: PropTypes.object.isRequired
+    table: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired
   },
 
   render() {
-    const tableId = this.props.table.get('id');
-    const projectId = this.props.table.getIn(['project', 'id']);
-    const projectName = this.props.table.getIn(['project', 'name']);
+    const { table, urlTemplates } = this.props;
+    const tableId = table.get('id');
+    const projectId = table.getIn(['project', 'id']);
+    const projectName = table.getIn(['project', 'name']);
 
     return (
       <span>
-        <ExternalLink href={`/admin/projects/${projectId}`}>{projectName}</ExternalLink>
+        <ExternalLink
+          href={_.template(urlTemplates.get('project'))({ projectId })}
+        >
+          {projectName}
+        </ExternalLink>
         {' / '}
-        <ExternalLink href={`/admin/projects/${projectId}/storage#/tables/${tableId}`}>{tableId}</ExternalLink>
+        <ExternalLink
+          href={`${_.template(urlTemplates.get('project'))({ projectId })}storage#/tables/${tableId}`}
+        >
+          {tableId}
+        </ExternalLink>
       </span>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/components/ProjectAliasLink.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/ProjectAliasLink.jsx
@@ -5,6 +5,7 @@ import ExternalProjectBucketLink from './ExternalProjectBucketLink';
 export default React.createClass({
   propTypes: {
     sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired,
     alias: PropTypes.object.isRequired
   },
 
@@ -23,7 +24,12 @@ export default React.createClass({
     }
 
     if (this.props.sapiToken.getIn(['admin', 'isOrganizationMember'])) {
-      return <ExternalProjectBucketLink bucket={this.props.alias} />;
+      return (
+        <ExternalProjectBucketLink
+          bucket={this.props.alias}
+          urlTemplates={this.props.urlTemplates}
+        />
+      );
     }
 
     return (

--- a/src/scripts/modules/storage-explorer/react/components/TableAliasesAndLinks.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/TableAliasesAndLinks.jsx
@@ -9,6 +9,7 @@ export default React.createClass({
 
   propTypes: {
     sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired,
     tableAliases: PropTypes.array.isRequired,
     tableLinks: PropTypes.array.isRequired,
     onLinkClick: PropTypes.func.isRequired
@@ -45,7 +46,11 @@ export default React.createClass({
             {this.props.tableLinks.map(alias => (
               <tr key={`link-${alias.get('id')}`}>
                 <td>
-                  <ProjectAliasLink sapiToken={this.props.sapiToken} alias={alias} />
+                  <ProjectAliasLink
+                    sapiToken={this.props.sapiToken}
+                    urlTemplates={this.props.urlTemplates}
+                    alias={alias}
+                  />
                 </td>
               </tr>
             ))}

--- a/src/scripts/modules/storage-explorer/react/modals/DeleteColumnModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/DeleteColumnModal.jsx
@@ -15,7 +15,8 @@ export default React.createClass({
     tableLinks: PropTypes.array.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onHide: PropTypes.func.isRequired,
-    sapiToken: PropTypes.object.isRequired
+    sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -42,6 +43,7 @@ export default React.createClass({
 
                 <TableAliasesAndLinks
                   sapiToken={this.props.sapiToken}
+                  urlTemplates={this.props.urlTemplates}
                   tableAliases={this.props.tableAliases}
                   tableLinks={this.props.tableLinks}
                   onLinkClick={this.props.onHide}

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -26,6 +26,7 @@ export default React.createClass({
     return {
       bucket: BucketsStore.getAll().find(item => item.get('id') === bucketId),
       sapiToken: ApplicationStore.getSapiToken(),
+      urlTemplates: ApplicationStore.getUrlTemplates(),
       tables: TablesStore.getAll().filter(table => table.getIn(['bucket', 'id']) === bucketId),
       deletingBuckets: BucketsStore.deletingBuckets().has(bucketId),
       isSharing: BucketsStore.isSharing(bucketId),
@@ -87,6 +88,7 @@ export default React.createClass({
                 <BucketOverview
                   bucket={this.state.bucket}
                   sapiToken={this.state.sapiToken}
+                  urlTemplates={this.state.urlTemplates}
                   isSharing={this.state.isSharing}
                   isUnsharing={this.state.isUnsharing}
                   isChangingSharingType={this.state.isChangingSharingType}

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
@@ -130,7 +130,7 @@ export default React.createClass({
         <td>Source bucket</td>
         <td>
           {this.isOrganizationMember() ? (
-            this.renderSourceBucketLink(source)
+            this.renderBucketLink(source)
           ) : (
             <span>
               {source.getIn(['project', 'name'])} / {source.get('id')}
@@ -144,19 +144,19 @@ export default React.createClass({
     );
   },
 
-  renderSourceBucketLink(source) {
-    return this.props.sapiToken.getIn(['owner', 'id']) === source.getIn(['project', 'id']) ? (
+  renderBucketLink(bucket) {
+    return this.props.sapiToken.getIn(['owner', 'id']) === parseInt(bucket.getIn(['project', 'id']), 10) ? (
       <Link
         to="storage-explorer-bucket"
         params={{
-          bucketId: source.get('id')
+          bucketId: bucket.get('id')
         }}
       >
-        {source.get('id')}
+        {bucket.get('id')}
       </Link>
     ) : (
       <ExternalProjectBucketLink
-        bucket={source}
+        bucket={bucket}
         urlTemplates={this.props.urlTemplates}
       />
     );
@@ -167,10 +167,7 @@ export default React.createClass({
       <div key={index}>
         <CreatedWithIcon createdTime={linkedBucket.get('created')} relative={false} />{' '}
         {this.isOrganizationMember() ? (
-          <ExternalProjectBucketLink
-            bucket={linkedBucket}
-            urlTemplates={this.props.urlTemplates}
-          />
+          this.renderBucketLink(linkedBucket)
         ) : (
           <span>
             {linkedBucket.getIn(['project', 'name'])} / {linkedBucket.get('id')}

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import { Map } from 'immutable';
 import { Table, Button, Row } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
+import { Link } from 'react-router';
 
 import MetadataEditField from '../../../../components/react/components/MetadataEditField';
 import InlineEditArea from '../../../../../react/common/InlineEditArea';
@@ -129,18 +130,35 @@ export default React.createClass({
         <td>Source bucket</td>
         <td>
           {this.isOrganizationMember() ? (
-            <ExternalProjectBucketLink
-              bucket={source}
-              urlTemplates={this.props.urlTemplates}
-            />
+            this.renderSourceBucketLink(source)
           ) : (
             <span>
               {source.getIn(['project', 'name'])} / {source.get('id')}
             </span>
           )}{' '}
-          <Hint title="Source bucket">Bucket is linked from other project.</Hint>
+          {this.props.sapiToken.getIn(['owner', 'id']) !== source.getIn(['project', 'id']) && (
+            <Hint title="Source bucket">Bucket is linked from other project.</Hint>
+          )}
         </td>
       </tr>
+    );
+  },
+
+  renderSourceBucketLink(source) {
+    return this.props.sapiToken.getIn(['owner', 'id']) === source.getIn(['project', 'id']) ? (
+      <Link
+        to="storage-explorer-bucket"
+        params={{
+          bucketId: source.get('id')
+        }}
+      >
+        {source.get('id')}
+      </Link>
+    ) : (
+      <ExternalProjectBucketLink
+        bucket={source}
+        urlTemplates={this.props.urlTemplates}
+      />
     );
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
@@ -19,6 +19,7 @@ export default React.createClass({
   propTypes: {
     bucket: PropTypes.object.isRequired,
     sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired,
     isSharing: PropTypes.bool.isRequired,
     isUnsharing: PropTypes.bool.isRequired,
     isChangingSharingType: PropTypes.bool.isRequired
@@ -128,7 +129,10 @@ export default React.createClass({
         <td>Source bucket</td>
         <td>
           {this.isOrganizationMember() ? (
-            <ExternalProjectBucketLink bucket={source} />
+            <ExternalProjectBucketLink
+              bucket={source}
+              urlTemplates={this.props.urlTemplates}
+            />
           ) : (
             <span>
               {source.getIn(['project', 'name'])} / {source.get('id')}
@@ -145,7 +149,10 @@ export default React.createClass({
       <div key={index}>
         <CreatedWithIcon createdTime={linkedBucket.get('created')} relative={false} />{' '}
         {this.isOrganizationMember() ? (
-          <ExternalProjectBucketLink bucket={linkedBucket} />
+          <ExternalProjectBucketLink
+            bucket={linkedBucket}
+            urlTemplates={this.props.urlTemplates}
+          />
         ) : (
           <span>
             {linkedBucket.getIn(['project', 'name'])} / {linkedBucket.get('id')}

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
@@ -14,6 +14,7 @@ export default React.createClass({
     tableAliases: PropTypes.array.isRequired,
     tableLinks: PropTypes.array.isRequired,
     sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired,
     addingColumn: PropTypes.object.isRequired,
     deletingColumn: PropTypes.object.isRequired,
     canWriteTable: PropTypes.bool.isRequired
@@ -124,6 +125,7 @@ export default React.createClass({
         onConfirm={this.handleDeleteColumn}
         onHide={this.closeDeleteColumnModal}
         sapiToken={this.props.sapiToken}
+        urlTemplates={this.props.urlTemplates}
       />
     );
   },

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -39,6 +39,7 @@ export default React.createClass({
     return {
       table,
       sapiToken: ApplicationStore.getSapiToken(),
+      urlTemplates: ApplicationStore.getUrlTemplates(),
       tables: TablesStore.getAll(),
       buckets: BucketsStore.getAll(),
       bucket: BucketsStore.getAll().find(item => item.get('id') === bucketId),
@@ -150,6 +151,7 @@ export default React.createClass({
                   tableAliases={this.getTableAliases()}
                   tableLinks={this.getTableLinks()}
                   sapiToken={this.state.sapiToken}
+                  urlTemplates={this.state.urlTemplates}
                   creatingPrimaryKey={this.state.creatingPrimaryKey}
                   deletingPrimaryKey={this.state.deletingPrimaryKey}
                   settingAliasFilter={this.state.settingAliasFilter}
@@ -168,6 +170,7 @@ export default React.createClass({
                   tableAliases={this.getTableAliases()}
                   tableLinks={this.getTableLinks()}
                   sapiToken={this.state.sapiToken}
+                  urlTemplates={this.state.urlTemplates}
                   creatingPrimaryKey={this.state.creatingPrimaryKey}
                   deletingPrimaryKey={this.state.deletingPrimaryKey}
                   addingColumn={this.state.addingColumn}

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableOverview.jsx
@@ -23,6 +23,7 @@ export default React.createClass({
     tableAliases: PropTypes.array.isRequired,
     tableLinks: PropTypes.array.isRequired,
     sapiToken: PropTypes.object.isRequired,
+    urlTemplates: PropTypes.object.isRequired,
     creatingPrimaryKey: PropTypes.bool.isRequired,
     deletingPrimaryKey: PropTypes.bool.isRequired,
     settingAliasFilter: PropTypes.bool.isRequired,
@@ -179,7 +180,12 @@ export default React.createClass({
 
     if (sapiToken.getIn(['owner', 'id']) !== table.getIn(['sourceTable', 'project', 'id'])) {
       if (this.props.sapiToken.getIn(['admin', 'isOrganizationMember'])) {
-        return <ExternalProjectTableLink table={table.get('sourceTable')} />;
+        return (
+          <ExternalProjectTableLink
+            table={table.get('sourceTable')}
+            urlTemplates={this.props.urlTemplates}
+          />
+        );
       }
       return (
         <span>
@@ -221,7 +227,11 @@ export default React.createClass({
 
         {this.props.tableLinks.map(alias => (
           <div key={alias.get('id')}>
-            <ProjectAliasLink sapiToken={this.props.sapiToken} alias={alias} />
+            <ProjectAliasLink
+              sapiToken={this.props.sapiToken}
+              urlTemplates={this.props.urlTemplates}
+              alias={alias}
+            />
           </div>
         ))}
       </span>


### PR DESCRIPTION
Fixes #2738

Proposed changes:

- use `urlTemplates` from application store when linking to ext. project
