### PR TITLE
Link to new console if user has devel preview feature

### DIFF
--- a/src/scripts/constants/KbcConstants.js
+++ b/src/scripts/constants/KbcConstants.js
@@ -28,7 +28,10 @@ const ActionTypes = keyMirror({
   ROUTER_ROUTER_CREATED: null
 });
 
+const FEATURE_UI_DEVEL_PREVIEW = 'ui-devel-preview';
+
 export {
   PayloadSources,
-  ActionTypes
+  ActionTypes,
+  FEATURE_UI_DEVEL_PREVIEW
 };

--- a/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import ApplicationStore from '../../../../stores/ApplicationStore';
 import { ExternalLink } from '@keboola/indigo-ui';
+import { Link } from 'react-router';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+
+const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
 
 export default React.createClass({
   propTypes: {
@@ -13,6 +16,18 @@ export default React.createClass({
   },
 
   render() {
+    if (ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)) {
+      return (
+        <Link
+          to="storage-explorer-bucket"
+          params={{
+            bucketId: this.props.bucketId
+          }}
+        >
+          {this.props.children}
+        </Link>
+      );
+    }
     return (
       <ExternalLink
         href={this.bucketUrl()}

--- a/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiBucketLink.jsx
@@ -2,8 +2,7 @@ import React from 'react';
 import { ExternalLink } from '@keboola/indigo-ui';
 import { Link } from 'react-router';
 import ApplicationStore from '../../../../stores/ApplicationStore';
-
-const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
+import { FEATURE_UI_DEVEL_PREVIEW } from '../../../../constants/KbcConstants';
 
 export default React.createClass({
   propTypes: {
@@ -16,7 +15,7 @@ export default React.createClass({
   },
 
   render() {
-    if (ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)) {
+    if (ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)) {
       return (
         <Link
           to="storage-explorer-bucket"

--- a/src/scripts/modules/components/react/components/StorageApiTableLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLink.jsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import ApplicationStore from '../../../../stores/ApplicationStore';
+import { Link } from 'react-router';
 import { ExternalLink } from '@keboola/indigo-ui';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+import { parse as parseTable } from '../../../../utils/tableIdParser';
+
+const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
 
 export default React.createClass({
   propTypes: {
@@ -13,6 +17,20 @@ export default React.createClass({
   },
 
   render() {
+    if (ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)) {
+      const parsedTable = parseTable(this.props.tableId);
+      return (
+        <Link
+          to="storage-explorer-table"
+          params={{
+            bucketId: `${parsedTable.parts.stage}.${parsedTable.parts.bucket}`,
+            tableName: parsedTable.parts.table
+          }}
+        >
+          {this.props.children}
+        </Link>
+      );
+    }
     return (
       <ExternalLink href={this.tableUrl()}>{this.props.children}</ExternalLink>
     );

--- a/src/scripts/modules/components/react/components/StorageApiTableLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLink.jsx
@@ -3,8 +3,7 @@ import { Link } from 'react-router';
 import { ExternalLink } from '@keboola/indigo-ui';
 import ApplicationStore from '../../../../stores/ApplicationStore';
 import { parse as parseTable } from '../../../../utils/tableIdParser';
-
-const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
+import { FEATURE_UI_DEVEL_PREVIEW } from '../../../../constants/KbcConstants';
 
 export default React.createClass({
   propTypes: {
@@ -17,7 +16,7 @@ export default React.createClass({
   },
 
   render() {
-    if (ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)) {
+    if (ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)) {
       const parsedTable = parseTable(this.props.tableId);
       return (
         <Link

--- a/src/scripts/modules/storage-explorer/Routes.js
+++ b/src/scripts/modules/storage-explorer/Routes.js
@@ -10,7 +10,7 @@ import { tokenVerify, loadBuckets, loadTables, loadSharedBuckets, loadJobs, load
 
 export default {
   name: 'storage-explorer',
-  title: 'Storage Explorer',
+  title: 'Storage',
   defaultRouteHandler: Index,
   requireData: [
     () => tokenVerify(),

--- a/src/scripts/modules/storage-explorer/react/components/ExternalProjectBucketLink.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/ExternalProjectBucketLink.jsx
@@ -23,7 +23,7 @@ export default React.createClass({
         </ExternalLink>
         {' / '}
         <ExternalLink
-          href={`${_.template(urlTemplates.get('project'))({ projectId })}/storage#/buckets/${bucketId}`}
+          href={`${_.template(urlTemplates.get('project'))({ projectId })}/storage-explorer/${bucketId}`}
         >
           {bucketId}
         </ExternalLink>

--- a/src/scripts/modules/storage-explorer/react/components/ExternalProjectTableLink.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/ExternalProjectTableLink.jsx
@@ -1,6 +1,7 @@
 import React, { PropTypes } from 'react';
 import { ExternalLink } from '@keboola/indigo-ui';
 import _ from 'underscore';
+import { parse as parseTable } from '../../../../utils/tableIdParser';
 
 export default React.createClass({
   propTypes: {
@@ -14,6 +15,8 @@ export default React.createClass({
     const projectId = table.getIn(['project', 'id']);
     const projectName = table.getIn(['project', 'name']);
 
+    const parsedTable = parseTable(tableId);
+
     return (
       <span>
         <ExternalLink
@@ -23,7 +26,10 @@ export default React.createClass({
         </ExternalLink>
         {' / '}
         <ExternalLink
-          href={`${_.template(urlTemplates.get('project'))({ projectId })}/storage#/tables/${tableId}`}
+          href={
+            _.template(urlTemplates.get('project'))({ projectId })
+              + `/storage-explorer/${parsedTable.parts.stage}.${parsedTable.parts.bucket}/${parsedTable.parts.table}`
+          }
         >
           {tableId}
         </ExternalLink>

--- a/src/scripts/react/layout/App.jsx
+++ b/src/scripts/react/layout/App.jsx
@@ -15,7 +15,7 @@ import UserLinks from './UserLinks';
 
 import '../../../styles/app.less';
 
-const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
+import { FEATURE_UI_DEVEL_PREVIEW } from '../../constants/KbcConstants';
 
 export default React.createClass({
   propTypes: {
@@ -40,7 +40,7 @@ export default React.createClass({
       projectFeatures: ApplicationStore.getCurrentProjectFeatures(),
       projectBaseUrl: ApplicationStore.getProjectBaseUrl(),
       scriptsBasePath: ApplicationStore.getScriptsBasePath(),
-      develPreview: ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)
+      develPreview: ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)
     };
   },
 

--- a/src/scripts/react/layout/App.jsx
+++ b/src/scripts/react/layout/App.jsx
@@ -15,6 +15,8 @@ import UserLinks from './UserLinks';
 
 import '../../../styles/app.less';
 
+const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
+
 export default React.createClass({
   propTypes: {
     isError: React.PropTypes.bool,
@@ -37,7 +39,8 @@ export default React.createClass({
       homeUrl: ApplicationStore.getUrlTemplates().get('home'),
       projectFeatures: ApplicationStore.getCurrentProjectFeatures(),
       projectBaseUrl: ApplicationStore.getProjectBaseUrl(),
-      scriptsBasePath: ApplicationStore.getScriptsBasePath()
+      scriptsBasePath: ApplicationStore.getScriptsBasePath(),
+      develPreview: ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)
     };
   },
 
@@ -64,7 +67,9 @@ export default React.createClass({
                 canCreateProject={this.state.canCreateProject}
                 projectTemplates={this.state.projectTemplates}
               />
-              <SidebarNavigation />
+              <SidebarNavigation
+                develPreview={this.state.develPreview}
+              />
               <div className="kbc-sidebar-footer">
                 <CurrentUser
                   user={this.state.currentAdmin}

--- a/src/scripts/react/layout/SidebarNavigation.jsx
+++ b/src/scripts/react/layout/SidebarNavigation.jsx
@@ -5,64 +5,17 @@ import Link from 'react-router/lib/components/Link';
 import ApplicationStore from '../../stores/ApplicationStore';
 import RoutesStore from '../../stores/RoutesStore';
 
-const _pages = [
-  {
-    id: 'home',
-    title: 'Overview',
-    icon: 'kbc-icon-overview'
-  },
-  {
-    id: 'extractors',
-    title: 'Extractors',
-    icon: 'kbc-icon-extractors'
-  },
-  {
-    id: 'transformations',
-    title: 'Transformations',
-    icon: 'kbc-icon-transformations'
-  },
-  {
-    id: 'writers',
-    title: 'Writers',
-    icon: 'kbc-icon-writers'
-  },
-  {
-    id: 'orchestrations',
-    title: 'Orchestrations',
-    icon: 'kbc-icon-orchestrations'
-  },
-  {
-    id: 'storage',
-    title: 'Storage',
-    icon: 'kbc-icon-storage'
-  },
-  {
-    id: 'jobs',
-    title: 'Jobs',
-    icon: 'kbc-icon-jobs'
-  },
-  {
-    id: 'applications',
-    title: 'Applications',
-    icon: 'kbc-icon-applications'
-  }
-];
-
-if (process.env.NODE_ENV === 'development') {
-  _pages.push({
-    id: 'storage-explorer',
-    title: 'Storage Explorer',
-    icon: 'kbc-icon-storage'
-  });
-}
-
 const SidebarNavigation = React.createClass({
   mixins: [State],
+
+  propTypes: {
+    develPreview: React.PropTypes.bool.isRequired
+  },
 
   render() {
     return (
       <ul className="kbc-nav-sidebar nav nav-sidebar">
-        {_pages.map(page => {
+        {this.getPages().map(page => {
           return (
             <li className={this.isActive(page.id) ? 'active' : ''} key={page.id}>
               {RoutesStore.hasRoute(page.id) ? (
@@ -81,6 +34,62 @@ const SidebarNavigation = React.createClass({
         })}
       </ul>
     );
+  },
+
+  getPages() {
+    return [
+      {
+        id: 'home',
+        title: 'Overview',
+        icon: 'kbc-icon-overview'
+      },
+      {
+        id: 'extractors',
+        title: 'Extractors',
+        icon: 'kbc-icon-extractors'
+      },
+      {
+        id: 'transformations',
+        title: 'Transformations',
+        icon: 'kbc-icon-transformations'
+      },
+      {
+        id: 'writers',
+        title: 'Writers',
+        icon: 'kbc-icon-writers'
+      },
+      {
+        id: 'orchestrations',
+        title: 'Orchestrations',
+        icon: 'kbc-icon-orchestrations'
+      },
+      this.getStoragePage(),
+      {
+        id: 'jobs',
+        title: 'Jobs',
+        icon: 'kbc-icon-jobs'
+      },
+      {
+        id: 'applications',
+        title: 'Applications',
+        icon: 'kbc-icon-applications'
+      }
+    ];
+  },
+
+  getStoragePage() {
+    if (this.props.develPreview) {
+      return {
+        id: 'storage-explorer',
+        title: 'Storage Explorer',
+        icon: 'kbc-icon-storage'
+      };
+    }
+    return {
+      id: 'storage',
+      title: 'Storage',
+      icon: 'kbc-icon-storage'
+    };
   }
 });
 

--- a/src/scripts/react/layout/SidebarNavigation.jsx
+++ b/src/scripts/react/layout/SidebarNavigation.jsx
@@ -81,7 +81,7 @@ const SidebarNavigation = React.createClass({
     if (this.props.develPreview) {
       return {
         id: 'storage-explorer',
-        title: 'Storage Explorer',
+        title: 'Storage',
         icon: 'kbc-icon-storage'
       };
     }

--- a/src/scripts/utils/graphUtils.js
+++ b/src/scripts/utils/graphUtils.js
@@ -1,8 +1,7 @@
 import RoutesStore from '../stores/RoutesStore';
 import { parse as parseTable } from './tableIdParser';
 import ApplicationStore from '../stores/ApplicationStore';
-
-const UI_DEVEL_PREVIEW_FEATURE = 'ui-devel-preview';
+import { FEATURE_UI_DEVEL_PREVIEW } from '../constants/KbcConstants';
 
 export default {
   addLinksToNodes(nodes) {
@@ -31,7 +30,7 @@ export default {
         }
 
         if (nodes[i].object.type === 'storage') {
-          if (ApplicationStore.hasCurrentAdminFeature(UI_DEVEL_PREVIEW_FEATURE)) {
+          if (ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)) {
             let tableData = parseTable(nodes[i].object.table);
             nodes[i].link = router.makeHref('storage-explorer-table', {
               bucketId: `${tableData.parts.stage}.${tableData.parts.bucket}`,


### PR DESCRIPTION
Fixes #2845 
Replacement of #2653 

Proposed changes:

- link to new storage console from sidebar
- rename "Storage Explorer" to "Storage"
- updated table link and bucket link components (covers also "Explore in console" in modals)
- update links to external project
- use feature var. from common constants
