### PR TITLE
Storage Explorer - Jobs - Table link - stop propagation event

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/JobsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/JobsTable.jsx
@@ -94,7 +94,14 @@ export default React.createClass({
     const { stage, bucket, table } = tableIdParser.parse(tableId).parts;
 
     return (
-      <Link to="storage-explorer-table" params={{ bucketId: `${stage}.${bucket}`, tableName: table }}>
+      <Link
+        to="storage-explorer-table"
+        params={{
+          bucketId: `${stage}.${bucket}`,
+          tableName: table
+        }}
+        onClick={(event) => event.stopPropagation()}
+      >
         {tableId}
       </Link>
     );


### PR DESCRIPTION
Fixes #2874

V tabulce jobů se po kliku na link otevřel modal ještě než se přesměrovalo na ten odkaz.