### PR TITLE
CodeMirror - new Snowflake mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Martin Halamicek",
   "dependencies": {
     "@json-editor/json-editor": "^1.3.5",
+    "@keboola/codemirror-mode-sfsql": "^0.1.3",
     "@keboola/indigo-ui": "^8.0.0",
     "aws-sdk": "^2.437.0",
     "bluebird": "^3.5.3",

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/resolveHighlightMode.js
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/resolveHighlightMode.js
@@ -5,8 +5,10 @@
  * @return {string} Show details
  */
 export default function(backend, type) {
-  if (backend === 'redshift' || backend === 'snowflake') {
+  if (backend === 'redshift') {
     return 'text/x-sql';
+  } else if (backend === 'snowflake') {
+    return 'text/x-sfsql';
   } else if (backend === 'docker') {
     if (type === 'r') {
       return 'text/x-rsrc';

--- a/src/scripts/utils/codemirror/setup.js
+++ b/src/scripts/utils/codemirror/setup.js
@@ -3,6 +3,7 @@ import 'codemirror/mode/sql/sql';
 import 'codemirror/mode/r/r';
 import 'codemirror/mode/python/python';
 import 'codemirror/mode/diff/diff';
+import '@keboola/codemirror-mode-sfsql';
 
 import 'codemirror/addon/display/placeholder';
 import 'codemirror/addon/lint/lint';

--- a/yarn.lock
+++ b/yarn.lock
@@ -939,6 +939,11 @@
   resolved "https://registry.yarnpkg.com/@json-editor/json-editor/-/json-editor-1.3.5.tgz#b8ec91b2ad53d65a031c90941e3c3bbd084bc321"
   integrity sha512-maU/05CzSvW5waIqWXhhiekLhDKwu8cOkGESIVyV2UrONedRzO/qk+WBFKkBbLmm5TeyRnkwVL6CkKNyaa2d4w==
 
+"@keboola/codemirror-mode-sfsql@^0.1.3":
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/@keboola/codemirror-mode-sfsql/-/codemirror-mode-sfsql-0.1.3.tgz#3a8563203bce129c236a8e827e3ba13c8a9f406b"
+  integrity sha512-3TLOGWQ4fRZYCbL4XGl/tdltDBNTS7mXDapWBHkGnVO4MvU14kMjy0DP9uc8ue+bbUZ5WWeQsevalGmMX5lFfQ==
+
 "@keboola/indigo-ui@^8.0.0":
   version "8.0.5"
   resolved "https://registry.yarnpkg.com/@keboola/indigo-ui/-/indigo-ui-8.0.5.tgz#09956d82642a54cb6c7ed816c2e065a5ac363a1b"


### PR DESCRIPTION
Fixes #2848

- Přidal jsem nový mode pro **Snowflake**. Syntax highlight by měla být teda lepší, dokonce to "správně" řeší ten bug v issue, kde to dříve ukazovalo jako zakomentovaný kód ale `Snowflake` to přelouskal a zpracoval. Nově se to ukáže přímo v UI jako nezakomentované. Zkoušel jsem si tam kopíroval nějaký veliký SQL a celkově tam toho bylo více lépe ukázáno (LEFT JOIN, UNION ALL, FULL OUTER JOIN atd).

Update: Nakonec přišla zpráva že to můžeme klidně použít.

> That said, I am happy to finally be able to say that yes, the file with the MIT license in the header is indeed under the MIT license. Feel free to use it under the terms of that license.

Tak dávám pryč on-hold.
