### PR TITLE
Storage Explorer - Fixes 1

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -65,7 +65,7 @@ export default React.createClass({
       <ButtonGroup justified>
         {this.canCreateBucket() && (
           <ButtonGroup>
-            <Button onClick={this.openCreateBucketModal} bsSize="sm">
+            <Button onClick={this.openCreateBucketModal}>
               <Tooltip tooltip="Create new bucket" placement="top">
                 <span><i className="fa fa-plus" /> Bucket</span>
               </Tooltip>
@@ -74,7 +74,7 @@ export default React.createClass({
         )}
         {this.canLinkBucket() && (
           <ButtonGroup>
-            <Button onClick={this.openBucketLinkModal} bsSize="sm">
+            <Button onClick={this.openBucketLinkModal}>
               <Tooltip tooltip="Link shared bucket to project" placement="top">
                 <span><i className="fa fa-random" /> Link</span>
               </Tooltip>
@@ -82,7 +82,7 @@ export default React.createClass({
           </ButtonGroup>
         )}
         <ButtonGroup>
-          <Button onClick={reload} bsSize="sm">
+          <Button onClick={reload}>
             <Tooltip tooltip="Reload buckets &amp; tables" placement="top">
               <span><RefreshIcon isLoading={this.state.isReloading} title="" /> Reload</span>
             </Tooltip>

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -67,7 +67,7 @@ export default React.createClass({
           <ButtonGroup>
             <Button onClick={this.openCreateBucketModal} bsSize="sm">
               <Tooltip tooltip="Create new bucket" placement="top">
-                <span><i className="fa fa-plus" /> Create</span>
+                <span><i className="fa fa-plus" /> Bucket</span>
               </Tooltip>
             </Button>
           </ButtonGroup>

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -76,7 +76,7 @@ export default React.createClass({
     }
 
     return (
-      <ul className="list-unstyled">
+      <ul className="storage-bucket-tables kbc-break-all kbc-break-word">
         {tables
           .sortBy(table => table.get('name').toLowerCase())
           .map(this.renderTable)

--- a/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableModal.jsx
@@ -79,9 +79,7 @@ export default React.createClass({
               </Col>
               <Col sm={3}>
                 <Select
-                  clearable={false}
-                  backspaceRemoves={false}
-                  deleteRemoves={false}
+                  clearable
                   placeholder="Column..."
                   value={this.state.newTableAlias.getIn(['aliasFilter', 'column'])}
                   onChange={this.handleAliasFilterColumn}
@@ -187,9 +185,15 @@ export default React.createClass({
   },
 
   handleAliasFilterColumn(option) {
-    this.setState({
-      newTableAlias: this.state.newTableAlias.setIn(['aliasFilter', 'column'], option.value)
-    });
+    let newTableAlias = this.state.newTableAlias;
+
+    if (option) {
+      newTableAlias = newTableAlias.setIn(['aliasFilter', 'column'], option.value);
+    } else {
+      newTableAlias = newTableAlias.deleteIn(['aliasFilter', 'column']);
+    }
+
+    this.setState({ newTableAlias });
   },
 
   handleAliasFilterValues(event) {
@@ -252,7 +256,7 @@ export default React.createClass({
       return true;
     }
 
-    if (!aliasFilter.get('column') || !aliasFilter.get('operator') || !aliasFilter.get('values')) {
+    if (aliasFilter.get('column') && (!aliasFilter.get('operator') || !aliasFilter.get('values'))) {
       return true;
     }
 

--- a/src/styles/Storage-explorer.less
+++ b/src/styles/Storage-explorer.less
@@ -62,6 +62,9 @@
     .searchbar {
       margin-top: 1em;
     }
+    .searchbar-input {
+      font-size: 14px;
+    }
   }
 
   .searchbar {

--- a/src/styles/Storage-explorer.less
+++ b/src/styles/Storage-explorer.less
@@ -29,6 +29,10 @@
       justify-content: space-between;
       align-items: center;
     }
+
+    .storage-bucket-tables {
+      padding-left: 16px;
+    }
   }
 
   .storage-table-overview {


### PR DESCRIPTION
Fixes #2856 
Fixes #2857 
Fixes #2858 
Fixes #2859 

1) upravil jsem label tlačítka na vytvoření bucketu na "Bucket"
2) upravil jsem výpis tabulek, tabulka se zalomuje, aby to nedělalo nějaký další zmatení vrátil jsem tam odrážky, jen jsem je trošku posunul doleva ať se tam vejde více textu
3) ty základní buttony na nový Bucket, Reload apod jsem udělal stejně veliké jako ostatní, trochu jsem zmenšil text v hledáním - nyní je skoro všude 14px
4) V modalu na vytvoření table alias bylo chybně vyžadováno pole "column", nyní upraveno že je volitelné. Navíc jsem přidal že je možné ho "vymazat", pokud je zadané jde vynulovat.

