### PR TITLE
Storage Explorer - can not create table right after creating bucket

### DIFF
--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -73,8 +73,9 @@ const loadTables = () => {
 const createBucket = (newBucket) => {
   return StorageActionCreators
     .createBucket(newBucket)
-    .then(bucket => {
-      navigateToBucketDetail(bucket.id);
+    .then(bucket => StorageActionCreators.tokenVerify().then(() => bucket.id))
+    .then(bucketId => {
+      navigateToBucketDetail(bucketId);
     });
 };
 


### PR DESCRIPTION
Fixes #2861
