### PR TITLE
DeleteButton - Missing Confirm modal

### DIFF
--- a/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
+++ b/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
@@ -43,7 +43,6 @@ export default React.createClass({
             tooltip="Move to Trash"
             isPending={this.props.isDeleting}
             confirm={this.deleteConfirmProps()}
-            componentId={this.props.componentId}
           />
           {this.renderRunButton()}
         </span>

--- a/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
+++ b/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
@@ -3,6 +3,7 @@ import PureRenderMixin from 'react-addons-pure-render-mixin';
 import ConfigurationLink from '../components/ComponentConfigurationLink';
 import RunConfigurationButton from '../components/RunComponentButton';
 import DeleteButton from '../../../../react/common/DeleteButton';
+import DeleteConfigurationButtonNoConfirm from '../../../../react/common/DeleteConfigurationButtonNoConfirm';
 import InstalledComponentsActionCreators from '../../InstalledComponentsActionCreators';
 import descriptionExcerpt from '../../../../utils/descriptionExcerpt';
 import {isObsoleteComponent} from '../../../../modules/trash/utils';
@@ -39,11 +40,19 @@ export default React.createClass({
               createdTime={this.props.config.get('created')}
             />
           </span>
-          <DeleteButton
-            tooltip="Move to Trash"
-            isPending={this.props.isDeleting}
-            confirm={this.deleteConfirmProps()}
-          />
+          {isObsoleteComponent(this.props.componentId) ? (
+            <DeleteButton
+              tooltip="Move to Trash"
+              isPending={this.props.isDeleting}
+              confirm={this.deleteConfirmProps()}
+            />
+          ) : (
+            <DeleteConfigurationButtonNoConfirm
+              tooltip="Move to Trash"
+              isPending={this.props.isDeleting}
+              onDeleteFn={this.handleDelete}
+            />
+          )}
           {this.renderRunButton()}
         </span>
       </ConfigurationLink>
@@ -103,6 +112,7 @@ export default React.createClass({
   },
 
   handleDelete() {
-    InstalledComponentsActionCreators.deleteConfiguration(this.props.componentId, this.props.config.get('id'), false);
+    InstalledComponentsActionCreators
+      .deleteConfiguration(this.props.componentId, this.props.config.get('id'), false);
   }
 });

--- a/src/scripts/react/common/DeleteButton.jsx
+++ b/src/scripts/react/common/DeleteButton.jsx
@@ -1,19 +1,15 @@
-/*
-  Delete button with confirm and loading state
-*/
-
 import React from 'react';
 import classnames from 'classnames';
-import Tooltip from './Tooltip';
+import { Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import Confirm from './Confirm';
-import { isObsoleteComponent } from '../../modules/trash/utils';
+import Tooltip from './Tooltip';
 
 export default React.createClass({
   propTypes: {
-    tooltip: React.PropTypes.string,
-    confirm: React.PropTypes.object, // Confirm props
+    confirm: React.PropTypes.object.isRequired,
     isPending: React.PropTypes.bool,
+    tooltip: React.PropTypes.string,
     isEnabled: React.PropTypes.bool,
     label: React.PropTypes.string,
     pendingLabel: React.PropTypes.string,
@@ -30,49 +26,55 @@ export default React.createClass({
       label: '',
       pendingLabel: '',
       fixedWidth: false,
-      icon: 'kbc-icon-cup'
+      icon: 'kbc-icon-cup',
+      componentId: ''
     };
   },
 
   render() {
     if (this.props.isPending) {
       return (
-        <span className="btn btn-link" disabled={true}>
-          <Loader className="fa-fw" />
-          {this.props.pendingLabel && ` ${this.props.pendingLabel}`}
-        </span>
+        <Button bsStyle="link" disabled>
+          {this.renderLoader()}
+        </Button>
       );
     }
 
     if (!this.props.isEnabled) {
       return (
-        <button className="btn btn-link disabled" disabled={true}>
-          <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />
-          {this.props.label && ` ${this.props.label}`}
-        </button>
-      );
-    }
-
-    if (isObsoleteComponent(this.props.componentId)) {
-      return (
-        <Confirm buttonLabel="Delete" {...this.props.confirm}>
-          <Tooltip tooltip={this.props.tooltip} id="delete" placement="top">
-            <button className="btn btn-link">
-              <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />
-              {this.props.label && ` ${this.props.label}`}
-            </button>
-          </Tooltip>
-        </Confirm>
+        <Button bsStyle="link" disabled>
+          {this.renderIcon()}
+          {this.renderLabel()}
+        </Button>
       );
     }
 
     return (
       <Confirm buttonLabel="Delete" {...this.props.confirm}>
-        <button className="btn btn-link" onClick={this.props.confirm.onConfirm}>
-          <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />
-          {this.props.label && ` ${this.props.label}`}
-        </button>
+        <Tooltip tooltip={this.props.tooltip} placement="top">
+          <Button bsStyle="link">
+            {this.renderIcon()}
+            {this.renderLabel()}
+          </Button>
+        </Tooltip>
       </Confirm>
+    );
+  },
+
+  renderIcon() {
+    return <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />;
+  },
+
+  renderLabel() {
+    return this.props.label || null;
+  },
+
+  renderLoader() {
+    return (
+      <span>
+        <Loader className={classnames({ 'fa-fw': this.props.fixedWidth })} />
+        {this.props.pendingLabel && ` ${this.props.pendingLabel}`}
+      </span>
     );
   }
 });

--- a/src/scripts/react/common/DeleteButton.jsx
+++ b/src/scripts/react/common/DeleteButton.jsx
@@ -14,8 +14,7 @@ export default React.createClass({
     label: React.PropTypes.string,
     pendingLabel: React.PropTypes.string,
     fixedWidth: React.PropTypes.bool,
-    icon: React.PropTypes.string,
-    componentId: React.PropTypes.string
+    icon: React.PropTypes.string
   },
 
   getDefaultProps() {
@@ -26,8 +25,7 @@ export default React.createClass({
       label: '',
       pendingLabel: '',
       fixedWidth: false,
-      icon: 'kbc-icon-cup',
-      componentId: ''
+      icon: 'kbc-icon-cup'
     };
   },
 

--- a/src/scripts/react/common/DeleteButton.jsx
+++ b/src/scripts/react/common/DeleteButton.jsx
@@ -9,7 +9,7 @@ export default React.createClass({
   propTypes: {
     confirm: PropTypes.shape({
       title: PropTypes.string.isRequired,
-      onConfirm: PropTypes.func.isReqquired,
+      onConfirm: PropTypes.func.isRequired,
       text: PropTypes.any,
       buttonLabel: PropTypes.string
     }).isRequired,

--- a/src/scripts/react/common/DeleteButton.jsx
+++ b/src/scripts/react/common/DeleteButton.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import classnames from 'classnames';
 import { Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
@@ -7,14 +7,19 @@ import Tooltip from './Tooltip';
 
 export default React.createClass({
   propTypes: {
-    confirm: React.PropTypes.object.isRequired,
-    isPending: React.PropTypes.bool,
-    tooltip: React.PropTypes.string,
-    isEnabled: React.PropTypes.bool,
-    label: React.PropTypes.string,
-    pendingLabel: React.PropTypes.string,
-    fixedWidth: React.PropTypes.bool,
-    icon: React.PropTypes.string
+    confirm: PropTypes.shape({
+      title: PropTypes.string.isRequired,
+      onConfirm: PropTypes.func.isReqquired,
+      text: PropTypes.any,
+      buttonLabel: PropTypes.string
+    }).isRequired,
+    isPending: PropTypes.bool,
+    tooltip: PropTypes.string,
+    isEnabled: PropTypes.bool,
+    label: PropTypes.string,
+    pendingLabel: PropTypes.string,
+    fixedWidth: PropTypes.bool,
+    icon: PropTypes.string
   },
 
   getDefaultProps() {

--- a/src/scripts/react/common/DeleteConfigurationButtonNoConfirm.jsx
+++ b/src/scripts/react/common/DeleteConfigurationButtonNoConfirm.jsx
@@ -1,0 +1,81 @@
+import React, { PropTypes } from 'react';
+import classnames from 'classnames';
+import { Button } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import Tooltip from './Tooltip';
+
+export default React.createClass({
+  propTypes: {
+    onDeleteFn: PropTypes.func.isRequired,
+    isPending: PropTypes.bool,
+    tooltip: PropTypes.string,
+    isEnabled: PropTypes.bool,
+    label: PropTypes.string,
+    pendingLabel: PropTypes.string,
+    fixedWidth: PropTypes.bool,
+    icon: PropTypes.string
+  },
+
+  getDefaultProps() {
+    return {
+      tooltip: 'Delete',
+      isPending: false,
+      isEnabled: true,
+      label: '',
+      pendingLabel: '',
+      fixedWidth: false,
+      icon: 'kbc-icon-cup'
+    };
+  },
+
+  render() {
+    if (this.props.isPending) {
+      return (
+        <Button bsStyle="link" disabled>
+          {this.renderLoader()}
+        </Button>
+      );
+    }
+
+    if (!this.props.isEnabled) {
+      return (
+        <Button bsStyle="link" disabled>
+          {this.renderIcon()}
+          {this.renderLabel()}
+        </Button>
+      );
+    }
+
+    return (
+      <Tooltip tooltip={this.props.tooltip} placement="top">
+        <Button bsStyle="link" onClick={this.handleDelete}>
+          {this.renderIcon()}
+          {this.renderLabel()}
+        </Button>
+      </Tooltip>
+    );
+  },
+
+  handleDelete(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.props.onDeleteFn();
+  },
+
+  renderIcon() {
+    return <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />;
+  },
+
+  renderLabel() {
+    return this.props.label || null;
+  },
+
+  renderLoader() {
+    return (
+      <span>
+        <Loader className={classnames({ 'fa-fw': this.props.fixedWidth })} />
+        {this.props.pendingLabel && ` ${this.props.pendingLabel}`}
+      </span>
+    );
+  }
+});

--- a/src/scripts/react/common/DeleteConfigurationButtonNoConfirm.jsx
+++ b/src/scripts/react/common/DeleteConfigurationButtonNoConfirm.jsx
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import classnames from 'classnames';
 import { Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import Tooltip from './Tooltip';
@@ -7,24 +6,13 @@ import Tooltip from './Tooltip';
 export default React.createClass({
   propTypes: {
     onDeleteFn: PropTypes.func.isRequired,
-    isPending: PropTypes.bool,
-    tooltip: PropTypes.string,
-    isEnabled: PropTypes.bool,
-    label: PropTypes.string,
-    pendingLabel: PropTypes.string,
-    fixedWidth: PropTypes.bool,
-    icon: PropTypes.string
+    tooltip: PropTypes.string.isRequired,
+    isPending: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      tooltip: 'Delete',
-      isPending: false,
-      isEnabled: true,
-      label: '',
-      pendingLabel: '',
-      fixedWidth: false,
-      icon: 'kbc-icon-cup'
+      isPending: false
     };
   },
 
@@ -32,16 +20,7 @@ export default React.createClass({
     if (this.props.isPending) {
       return (
         <Button bsStyle="link" disabled>
-          {this.renderLoader()}
-        </Button>
-      );
-    }
-
-    if (!this.props.isEnabled) {
-      return (
-        <Button bsStyle="link" disabled>
-          {this.renderIcon()}
-          {this.renderLabel()}
+          <Loader />
         </Button>
       );
     }
@@ -49,8 +28,7 @@ export default React.createClass({
     return (
       <Tooltip tooltip={this.props.tooltip} placement="top">
         <Button bsStyle="link" onClick={this.handleDelete}>
-          {this.renderIcon()}
-          {this.renderLabel()}
+          <i className="fa kbc-icon-cup" />
         </Button>
       </Tooltip>
     );
@@ -60,22 +38,5 @@ export default React.createClass({
     e.preventDefault();
     e.stopPropagation();
     this.props.onDeleteFn();
-  },
-
-  renderIcon() {
-    return <i className={classnames('fa', this.props.icon, { 'fa-fw': this.props.fixedWidth })} />;
-  },
-
-  renderLabel() {
-    return this.props.label || null;
-  },
-
-  renderLoader() {
-    return (
-      <span>
-        <Loader className={classnames({ 'fa-fw': this.props.fixedWidth })} />
-        {this.props.pendingLabel && ` ${this.props.pendingLabel}`}
-      </span>
-    );
   }
 });


### PR DESCRIPTION
Fixes #2882

Tak upraveno. Koukal jsem na použití komponenty a `confirm` prop je použita všude. Ono by to bez ní ani nešlo pokud tam je v tom tak akce co se má stát. Takže jsem tu props udělal jako povinnou.

Úplně jsem vyhodil tu kontrolu `isObsoleteComponent `, bylo to použito pouze v jedné komponentě (kde se posílala componentId). Ale zároveň už tam se podle toho měnil ten objekt `confirm` což je dostačující. Takže není potřeba to kontrolovat tu. Navíc to dělalo další nesrovnalosti. Tu byl tooltip ale pokud nešlo o "obsolate" komponentu tak tam tooltip nebyl.

Nově je teda Confirm modal úplně všude aby to respektovalo props co jsou posílány do tého komponenty. Zároveň bude tooltip všude což teď také nebylo.

Myslím že budou pak asi úkoly, že někde tuto komponentu už vůbec nepoužijeme, protože nechceme mít ten Confrim modal. Protože do teď na spouště místech ten modal nebyl a teď najednou bude skákat. Ale to budou jiné úkoly a asi se tam prostě použije jiná komponenta nebo rovnou jen button + akce.