### PR TITLE
Storage Explorer - Fixes 2

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -92,11 +92,11 @@ export default React.createClass({
     return (
       <li key={table.get('id')}>
         <Link
-          className={classnames({ alias: table.get('isAlias', false) })}
+          className="storage-bucket-table-link"
           to="storage-explorer-table"
           params={{ bucketId, tableName }}
         >
-          {tableName}
+          <span className={classnames({ 'is-table-alias': table.get('isAlias', false) })}>{tableName}</span>
         </Link>
       </li>
     );

--- a/src/scripts/modules/storage-explorer/react/components/Events.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Events.jsx
@@ -45,7 +45,7 @@ export default React.createClass({
       <div>
         <SearchBar
           className="storage-search-bar"
-          placeholder="Search event"
+          placeholder="Search events"
           query={this.state.searchQuery}
           onChange={this.handleQueryChange}
           onSubmit={this.handleSearchSubmit}

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -67,7 +67,6 @@ export default React.createClass({
           <div>
             <Nav bsStyle="tabs">
               <NavItem eventKey="overview">Overview</NavItem>
-              <NavItem eventKey="tables">Tables</NavItem>
               <NavItem eventKey="events">Events</NavItem>
               <NavDropdown title="Actions">
                 <MenuItem
@@ -93,8 +92,7 @@ export default React.createClass({
                   isUnsharing={this.state.isUnsharing}
                   isChangingSharingType={this.state.isChangingSharingType}
                 />
-              </Tab.Pane>
-              <Tab.Pane eventKey="tables">
+
                 <BucketTables
                   bucket={this.state.bucket}
                   tables={this.state.tables}
@@ -157,7 +155,7 @@ export default React.createClass({
   },
 
   handleSelectTab(tab) {
-    if (['overview', 'description', 'tables', 'events'].includes(tab)) {
+    if (['overview', 'description', 'events'].includes(tab)) {
       this.setState({
         activeTab: tab
       });

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketTables.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketTables.jsx
@@ -99,7 +99,7 @@ export default React.createClass({
           <Link
             to="storage-explorer-table"
             params={{ bucketId: this.props.bucket.get('id'), tableName: table.get('name') }}
-            className={classnames({ alias: table.get('isAlias', false) })}
+            className={classnames({ 'is-table-alias': table.get('isAlias', false) })}
           >
             {table.get('name')}
           </Link>

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketTables.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketTables.jsx
@@ -34,7 +34,7 @@ export default React.createClass({
 
     return (
       <div>
-        <div className="clearfix">
+        <h2 className="clearfix">
           <div className="kbc-buttons pull-right">
             <ButtonToolbar>
               {this.canWriteBucket() && (
@@ -59,7 +59,8 @@ export default React.createClass({
               )}
             </ButtonToolbar>
           </div>
-        </div>
+          Tables
+        </h2>
 
         {this.props.tables.count() > 0 ? (
           <Row>

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
@@ -36,8 +36,14 @@ export default React.createClass({
         <h2 className="clearfix">
           {this.canAddColumn() && (
             <div className="kbc-buttons pull-right">
-              <Button onClick={this.openCreateColumnModal} disabled={addingColumn}>
-                {addingColumn ? <Loader /> : <i className="fa fa-plus" />} Create column
+              <Button bsStyle="success" onClick={this.openCreateColumnModal} disabled={addingColumn}>
+                {addingColumn ? (
+                  <span>
+                    <Loader /> Creating column...
+                  </span>
+                ) : (
+                  <span>Create column</span>
+                )}
               </Button>
             </div>
           )}

--- a/src/styles/Storage-explorer.less
+++ b/src/styles/Storage-explorer.less
@@ -33,6 +33,10 @@
     .storage-bucket-tables {
       padding-left: 16px;
     }
+
+    .storage-bucket-table-link {
+      display: block;
+    }
   }
 
   .storage-table-overview {
@@ -49,7 +53,7 @@
     padding: 0 15px;
   }
 
-  a.alias {
+  .is-table-alias {
     border-bottom: 1px dotted #08c;
   }
 


### PR DESCRIPTION
Fixes #2880 
(tu není řešeno vše ale nějaké věci hodím do nové issue)

Pojedu body co byly v issue:

**Chybí mi vyhledávání tabulek, buckety jsou dost často k ničemu.**
Toto hodím no samostatné issue - bude složitější protože tam máme teď i věc že může být otevřený pouze jedne "detail" bucketu (tabulky) #2886 - fix ve #2887

**Nejde klikat na celej řádek s názvem tabulky, musím sniperovat pouze název.**
Opraveno

**Při kliku na vyhledanou tabulku se kompletně ztratí celej kontext, co jsem do té doby dělal**
Toto se mi neděje, zatím jsem to teda přeskočil. taky fix ve #2887

**V detailu tabulky se ihned načítá Graph, nešlo by to až po otevření záložky?**
Také komplikovanější a nevím zda řešitelné. Udělám nové issue. #2885

**Detail bucketu - nešlo by třeba sloučit záložky overview a tables?**
Součeno.

**Upravit placeholdery u hledání**
Upraveno.