### PR TITLE
Storage Explorer - Search buckets and tables

### DIFF
--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -276,6 +276,13 @@ const updateFilesSearchQuery = query => {
   });
 };
 
+const setOpenedBuckets = buckets => {
+  return dispatcher.handleViewAction({
+    type: localConstants.ActionTypes.SET_OPENED_BUCKETS,
+    buckets
+  });
+};
+
 const resetFilesSearchQuery = () => {
   updateFilesSearchQuery('');
 };
@@ -317,6 +324,7 @@ export {
   loadFiles,
   loadMoreFiles,
   updateFilesSearchQuery,
+  setOpenedBuckets,
   filterFiles,
   resetFilesSearchQuery
 };

--- a/src/scripts/modules/storage-explorer/BucketsLocalStore.js
+++ b/src/scripts/modules/storage-explorer/BucketsLocalStore.js
@@ -1,13 +1,18 @@
-import { Map } from 'immutable';
+import { Map, Set } from 'immutable';
 import StoreUtils from '../../utils/StoreUtils';
 import dispatcher from '../../Dispatcher';
 import * as constants from './Constants';
 
 let _store = Map({
+  openedBuckets: Set(),
   isReloading: false
 });
 
 const BucketsLocalStore = StoreUtils.createStore({
+  getOpenedBuckets() {
+    return _store.get('openedBuckets');
+  },
+
   getIsReloading() {
     return _store.get('isReloading', false);
   }
@@ -17,6 +22,10 @@ dispatcher.register(payload => {
   const { action } = payload;
 
   switch (action.type) {
+    case constants.ActionTypes.SET_OPENED_BUCKETS:
+      _store = _store.set('openedBuckets', action.buckets);
+      return BucketsLocalStore.emitChange();
+
     case constants.ActionTypes.RELOAD:
       _store = _store.set('isReloading', true);
       return BucketsLocalStore.emitChange();

--- a/src/scripts/modules/storage-explorer/Constants.js
+++ b/src/scripts/modules/storage-explorer/Constants.js
@@ -5,6 +5,7 @@ export const filesLimit = 50;
 
 export const ActionTypes = keyMirror({
   UPDATE_SEARCH_QUERY: null,
+  SET_OPENED_BUCKETS: null,
   RELOAD: null,
   RELOAD_SUCCESS: null,
   RELOAD_ERROR: null

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -3,7 +3,6 @@ import { ButtonGroup, Button } from 'react-bootstrap';
 import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
 
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
-import RoutesStore from '../../../../stores/RoutesStore';
 import ApplicationStore from '../../../../stores/ApplicationStore';
 import BucketsStore from '../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../components/stores/StorageTablesStore';
@@ -17,11 +16,11 @@ import BucketsList from './BucketsList';
 import { reload, createBucket } from '../../Actions';
 
 export default React.createClass({
-  mixins: [createStoreMixin(ApplicationStore, RoutesStore, BucketsLocalStore, BucketsStore, TablesStore)],
+  mixins: [createStoreMixin(ApplicationStore, BucketsLocalStore, BucketsStore, TablesStore)],
 
   getStateFromStores() {
     return {
-      bucketId: RoutesStore.getCurrentRouteParam('bucketId'),
+      openBuckets: BucketsLocalStore.getOpenedBuckets(),
       allBuckets: BucketsStore.getAll(),
       allTables: TablesStore.getAll(),
       sharedBuckets: BucketsStore.getSharedBuckets(),
@@ -47,14 +46,14 @@ export default React.createClass({
 
         {this.renderBucketsButtons()}
         <SearchBar
-          placeholder="Search bucket"
+          placeholder="Search buckets or tables"
           query={this.state.searchQuery}
           onChange={this.handleQueryChange}
         />
         <BucketsList
+          openBuckets={this.state.openBuckets}
           buckets={this.filteredBuckets()}
           tables={this.state.allTables}
-          activeBucketId={this.state.bucketId}
         />
       </div>
     );
@@ -124,8 +123,14 @@ export default React.createClass({
 
     if (this.state.searchQuery) {
       const search = this.state.searchQuery.toLowerCase();
+      const filteredTables = this.state.allTables
+        .filter(table => matchByWords(table.get('name').toLowerCase(), search))
+        .map(table => table.getIn(['bucket', 'id']))
+        .toArray();
 
-      buckets = buckets.filter(bucket => matchByWords(bucket.get('id').toLowerCase(), search));
+      buckets = buckets.filter(bucket => {
+        return filteredTables.includes(bucket.get('id')) || matchByWords(bucket.get('id').toLowerCase(), search)
+      });
     }
 
     return buckets;

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -54,6 +54,7 @@ export default React.createClass({
           openBuckets={this.state.openBuckets}
           buckets={this.filteredBuckets()}
           tables={this.state.allTables}
+          expandAllBuckets={this.state.searchQuery !== ''}
         />
       </div>
     );

--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -4,6 +4,7 @@ import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
 
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import ApplicationStore from '../../../../stores/ApplicationStore';
+import RoutesStore from '../../../../stores/RoutesStore';
 import BucketsStore from '../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../components/stores/StorageTablesStore';
 import BucketsLocalStore from '../../BucketsLocalStore';
@@ -16,10 +17,11 @@ import BucketsList from './BucketsList';
 import { reload, createBucket } from '../../Actions';
 
 export default React.createClass({
-  mixins: [createStoreMixin(ApplicationStore, BucketsLocalStore, BucketsStore, TablesStore)],
+  mixins: [createStoreMixin(ApplicationStore, RoutesStore, BucketsLocalStore, BucketsStore, TablesStore)],
 
   getStateFromStores() {
     return {
+      bucketId: RoutesStore.getCurrentRouteParam('bucketId'),
       openBuckets: BucketsLocalStore.getOpenedBuckets(),
       allBuckets: BucketsStore.getAll(),
       allTables: TablesStore.getAll(),
@@ -51,6 +53,7 @@ export default React.createClass({
           onChange={this.handleQueryChange}
         />
         <BucketsList
+          activeBucketId={this.state.bucketId}
           openBuckets={this.state.openBuckets}
           buckets={this.filteredBuckets()}
           tables={this.state.allTables}

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -9,7 +9,8 @@ export default React.createClass({
   propTypes: {
     openBuckets: PropTypes.object.isRequired,
     buckets: PropTypes.object.isRequired,
-    tables: PropTypes.object.isRequired
+    tables: PropTypes.object.isRequired,
+    expandAllBuckets: PropTypes.bool.isRequired
   },
 
   render() {
@@ -31,7 +32,7 @@ export default React.createClass({
     return (
       <Panel
         collapsible
-        expanded={this.props.openBuckets.has(bucket.get('id'))}
+        expanded={this.props.openBuckets.has(bucket.get('id')) || this.props.expandAllBuckets}
         className="storage-panel"
         header={this.renderBucketHeader(bucket)}
         key={bucket.get('id')}

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -3,19 +3,13 @@ import { Link } from 'react-router';
 import classnames from 'classnames';
 import { PanelGroup, Panel, Button } from 'react-bootstrap';
 import Tooltip from '../../../../react/common/Tooltip';
-import { navigateToBucketDetail } from '../../Actions';
+import { navigateToBucketDetail, setOpenedBuckets } from '../../Actions';
 
 export default React.createClass({
   propTypes: {
+    openBuckets: PropTypes.object.isRequired,
     buckets: PropTypes.object.isRequired,
-    tables: PropTypes.object.isRequired,
-    activeBucketId: PropTypes.string
-  },
-
-  getInitialState() {
-    return {
-      activeBucketId: null
-    };
+    tables: PropTypes.object.isRequired
   },
 
   render() {
@@ -24,14 +18,9 @@ export default React.createClass({
     }
 
     return (
-      <PanelGroup
-        accordion
-        activeKey={this.state.activeBucketId || this.props.activeBucketId}
-        onSelect={this.handleSelect}
-        className="kbc-accordion"
-      >
+      <PanelGroup className="kbc-accordion">
         {this.props.buckets
-          .sortBy(bucket => bucket.get('id').toLowerCase())
+          .sortBy((bucket) => bucket.get('id').toLowerCase())
           .map(this.renderBucketPanel)
           .toArray()}
       </PanelGroup>
@@ -41,10 +30,12 @@ export default React.createClass({
   renderBucketPanel(bucket) {
     return (
       <Panel
+        collapsible
+        expanded={this.props.openBuckets.has(bucket.get('id'))}
         className="storage-panel"
         header={this.renderBucketHeader(bucket)}
         key={bucket.get('id')}
-        eventKey={bucket.get('id')}
+        onSelect={() => this.onSelectBucket(bucket.get('id'))}
       >
         {this.renderTables(bucket)}
       </Panel>
@@ -57,7 +48,14 @@ export default React.createClass({
         <div className="storage-bucket-header">
           <h4>{bucket.get('id')}</h4>
           <Tooltip tooltip="Bucket detail" placement="top">
-            <Button bsStyle="link" bsSize="sm" onClick={() => navigateToBucketDetail(bucket.get('id'))}>
+            <Button
+              bsStyle="link"
+              bsSize="sm"
+              onClick={(event) => {
+                event.stopPropagation();
+                navigateToBucketDetail(bucket.get('id'))
+              }}
+            >
               <i className="fa fa-fw fa-chevron-right" />
             </Button>
           </Tooltip>
@@ -67,7 +65,7 @@ export default React.createClass({
   },
 
   renderTables(bucket) {
-    const tables = this.props.tables.filter(table => {
+    let tables = this.props.tables.filter((table) => {
       return table.getIn(['bucket', 'id']) === bucket.get('id');
     });
 
@@ -78,7 +76,7 @@ export default React.createClass({
     return (
       <ul className="storage-bucket-tables kbc-break-all kbc-break-word">
         {tables
-          .sortBy(table => table.get('name').toLowerCase())
+          .sortBy((table) => table.get('name').toLowerCase())
           .map(this.renderTable)
           .toArray()}
       </ul>
@@ -102,9 +100,9 @@ export default React.createClass({
     );
   },
 
-  handleSelect(bucketId) {
-    this.setState({
-      activeBucketId: bucketId
-    });
+  onSelectBucket(bucketId) {
+    const opened = this.props.openBuckets;
+
+    setOpenedBuckets(opened.has(bucketId) ? opened.delete(bucketId) : opened.add(bucketId));
   }
 });

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -14,7 +14,7 @@ export default React.createClass({
 
   render() {
     if (!this.props.buckets.count()) {
-      return <p className="kbc-inner-padding">No buckets found.</p>;
+      return <p className="kbc-inner-padding">No buckets or tables are matching your criteria.</p>;
     }
 
     return (

--- a/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/BucketsList.jsx
@@ -10,7 +10,8 @@ export default React.createClass({
     openBuckets: PropTypes.object.isRequired,
     buckets: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
-    expandAllBuckets: PropTypes.bool.isRequired
+    expandAllBuckets: PropTypes.bool.isRequired,
+    activeBucketId: PropTypes.string
   },
 
   render() {
@@ -32,7 +33,7 @@ export default React.createClass({
     return (
       <Panel
         collapsible
-        expanded={this.props.openBuckets.has(bucket.get('id')) || this.props.expandAllBuckets}
+        expanded={this.isPanelExpanded(bucket)}
         className="storage-panel"
         header={this.renderBucketHeader(bucket)}
         key={bucket.get('id')}
@@ -105,5 +106,17 @@ export default React.createClass({
     const opened = this.props.openBuckets;
 
     setOpenedBuckets(opened.has(bucketId) ? opened.delete(bucketId) : opened.add(bucketId));
+  },
+
+  isPanelExpanded(bucket) {
+    if (this.props.expandAllBuckets) {
+      return true;
+    }
+
+    if (this.props.activeBucketId === bucket.get('id')) {
+      return true;
+    }
+
+    return this.props.openBuckets.has(bucket.get('id')); 
   }
 });


### PR DESCRIPTION
Fixes #2886

- nově hledám jak bucketech tak v tabulkách
-- tabulky ale nefiltruji, pokud vyhovuje bucket nebo alespoň jedna tabulka v bucketu, tak to se zobrazí, možná by to šlo dotáhnout dále, ale pro začátek jsem to udělal takto

- dříve bylo možné mít otevřený pouze jeden bucket (panel), nově si to můžu pootvírat jak chci, ukládá se to do store, tak by to mělo vyřešit i issue co bylo tu #2880 (3) - ikdyž to mi fungovalo i prve ok

