### PR TITLE
Storage Explorer - Tabs - Lazy load

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/FastFade.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/FastFade.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { Fade } from 'react-bootstrap';
+
+export default React.createClass({
+  render() {
+    return <Fade {...this.props} className="fast-fade" timeout={100} />;
+  }
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -8,14 +8,15 @@ import RoutesStore from '../../../../../stores/RoutesStore';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
-import Tooltip from '../../../../../react/common/Tooltip';
-
 import { factory as eventsFactory } from '../../../../sapi-events/BucketEventsService';
+import { createTable, deleteBucket, createAliasTable, createTableFromTextInput, uploadFile } from '../../../Actions';
+
+import Tooltip from '../../../../../react/common/Tooltip';
+import FastFade from '../../components/FastFade';
 import BucketEvents from '../../components/Events';
 import DeleteBucketModal from '../../modals/DeleteBucketModal';
 import BucketOverview from './BucketOverview';
 import BucketTables from './BucketTables';
-import { createTable, deleteBucket, createAliasTable, createTableFromTextInput, uploadFile } from '../../../Actions';
 
 export default React.createClass({
   mixins: [createStoreMixin(BucketsStore, ApplicationStore, TablesStore, FilesStore)],
@@ -82,7 +83,7 @@ export default React.createClass({
                 </MenuItem>
               </NavDropdown>
             </Nav>
-            <Tab.Content animation={false}>
+            <Tab.Content mountOnEnter animation={FastFade}>
               <Tab.Pane eventKey="overview">
                 <BucketOverview
                   bucket={this.state.bucket}

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -8,18 +8,18 @@ import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import BucketsStore from '../../../../components/stores/StorageBucketsStore';
 import TablesStore from '../../../../components/stores/StorageTablesStore';
-import DataSample from '../../components/DataSample';
-import { deleteTable, truncateTable } from '../../../Actions';
 import FilesStore from '../../../../components/stores/StorageFilesStore';
-import storageApi from '../../../../components/StorageApi';
-import { exportTable, uploadFile, loadTable } from '../../../Actions';
+import StorageApi from '../../../../components/StorageApi';
+import { factory as eventsFactory } from '../../../../sapi-events/TableEventsService';
+import { deleteTable, truncateTable, exportTable, uploadFile, loadTable } from '../../../Actions';
 
 import TruncateTableModal from '../../modals/TruncateTableModal';
 import DeleteTableModal from '../../modals/DeleteTableModal';
 import LoadTableFromCsvModal from '../../modals/LoadTableFromCsvModal';
 import ExportTableModal from '../../modals/ExportTableModal';
-import { factory as eventsFactory } from '../../../../sapi-events/TableEventsService';
+import DataSample from '../../components/DataSample';
 import TableEvents from '../../components/Events';
+import FastFade from '../../components/FastFade';
 import TableOverview from './TableOverview';
 import TableColumn from './TableColumn';
 import SnapshotRestore from './SnapshotRestore';
@@ -143,7 +143,7 @@ export default React.createClass({
                 )}
               </NavDropdown>
             </Nav>
-            <Tab.Content animation={false}>
+            <Tab.Content mountOnEnter animation={FastFade}>
               <Tab.Pane eventKey="overview">
                 <TableOverview
                   table={this.state.table}
@@ -308,7 +308,7 @@ export default React.createClass({
     const tableId = this.state.table.get('id');
 
     return exportTable(tableId).then(response => {
-      return storageApi
+      return StorageApi
         .getFiles({
           runId: response.runId,
           'tags[]': ['storage-merged-export']

--- a/src/styles/Storage-explorer.less
+++ b/src/styles/Storage-explorer.less
@@ -72,4 +72,12 @@
     margin-bottom: 1em;
   }
 
+  .fast-fade {
+    opacity: 0;
+    transition: opacity 50ms linear;
+
+    &.in {
+      opacity: 1;
+    }
+  }
 }


### PR DESCRIPTION
Fixes #2885

Může se minimálně zkusit jak to bude působit.

Zkusil jsem modifikovat tu "default" Fade komponentu, aby to běhalo trochu rychleji. Animace je nutná, bez toho nejde pustit lazy load tabů. Default Fade je "pomalý".

S tímto tedy můžu použít props `mountOnEnter`. Díky tomu se kupa dat nenačítá zbytečně dopředu, ale až když poprvé aktivuji daný tab.
