### PR TITLE
Ex Google Analytics - Autorization 

### DIFF
--- a/src/scripts/modules/ex-google-analytics-v4/storeProvisioning.js
+++ b/src/scripts/modules/ex-google-analytics-v4/storeProvisioning.js
@@ -23,7 +23,7 @@ export const storeMixins = [InstalledComponentStore, OauthStore];
 export default function(configId, componentId) {
   const localState = () => InstalledComponentStore.getLocalState(componentId, configId) || Map();
   const configData =  InstalledComponentStore.getConfigData(componentId, configId) || Map();
-  const oauthCredentialsId = configData.getIn(['authorization', 'oauth_api', 'id'], configId);
+  const oauthCredentialsId = configData.getIn(['authorization', 'oauth_api', 'id']);
 
   const parameters = configData.get('parameters', Map());
   const queries = parameters.getIn(['queries'], List());
@@ -48,7 +48,7 @@ export default function(configId, componentId) {
 
   return {
     oauthCredentials: OauthStore.getCredentials(componentId, oauthCredentialsId) || Map(),
-    oauthCredentialsId: oauthCredentialsId,
+    oauthCredentialsId: oauthCredentialsId || configId,
 
     // local state stuff
     getLocalState(path) {


### PR DESCRIPTION
Related #2890
Related #2977

Dávám "related" místo "fixed" protože se mi to nepovedlo nasimulovat. Ale dostal jsem "podobnou" chybu, která s tím možná souvisí. Zase se to točí kolem Rollbacku.

Pokud jsem měl autorizováno, a pak jsme dal rollback na verzi kde jsem autorizován nebyl. Stýle jsem měl na detailu informaci o autorizováni a až když jsem kliknul an reset jsem dostal chybu že volám `.get` na undefined. Myslím že něco takového se mohlo stát i v originálu té issue.

Možná to má souvislost s tím jak nově mažeme tuto část `['authorization', 'oauth_api', 'id']`.
Takže dříve tento kód `onst oauthCredentialsId = configData.getIn(['authorization', 'oauth_api', 'id'], configId);` vracel `prázdný string` a nepoužil se ten default vůbec. Nově ta cesta ale neexistuje vůbec (asi díky #2836 ). Takže to ten default vrátí a asi to pak dělá zmatky.

Zkusil jsem ho teda vyhodit a použít až pak dole pro to ID, protože se to používá v dalších komponentách jako povinná prop. Ale díky tomu že to odeberu nahoře, tak se "správně" nenajde `oauthCredentials` i když v tom storu třeba existuje. Protože tím že rollbacknu, tak se to z toho storu nemaže. To by byl asi lepší fix. Ale to bych musel nějak hlídat akci Rollback a ještě poznat že se maže `authorization` což je taky takové divné.

Nic lepšího jak toto mě nenapadlo a už tak jsme s tím strávil nějakou dobu. Myslíte že to může dělat někde problém tato úprava?