### PR TITLE
Storage Explorer - Tune events

### DIFF
--- a/src/scripts/modules/storage-explorer/Constants.js
+++ b/src/scripts/modules/storage-explorer/Constants.js
@@ -15,3 +15,25 @@ export const bucketSharingTypes = {
   ORGANIZATION: 'organization',
   ORGANIZATION_PROJECT: 'organization-project'
 };
+
+export const eventsTemplates = {
+  'storage.tableImportStarted': {
+    'message': 'Import started',
+    'className': ''
+  },
+
+  'storage.tableImportDone': {
+    'message': 'Successfully imported ',
+    'className': 'success'
+  },
+
+  'storage.tableImportError': {
+    'message': 'Error on table import',
+    'className': 'error'
+  },
+
+  'storage.tableExported': {
+    'message': 'Exported to a csv file',
+    'className': 'info'
+  }
+};

--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -1,10 +1,13 @@
 import React, { PropTypes } from 'react';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
+import classnames from 'classnames';
+import { replaceAll } from 'underscore.string';
 import ComponentsStore from '../../../components/stores/ComponentsStore';
 import { Table } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import { truncate } from 'underscore.string';
 import { format } from '../../../../utils/date';
+import { eventsTemplates } from '../../Constants';
 import ComponentName from '../../../../react/common/ComponentName';
 import ComponentIcon from '../../../../react/common/ComponentIcon';
 import EventDetailModal from '../modals/EventDetailModal';
@@ -14,7 +17,8 @@ export default React.createClass({
 
   propTypes: {
     events: PropTypes.object.isRequired,
-    isSearching: PropTypes.bool.isRequired
+    isSearching: PropTypes.bool.isRequired,
+    excludeString: PropTypes.string
   },
 
   getInitialState() {
@@ -58,9 +62,22 @@ export default React.createClass({
 
   renderRow(event) {
     const component = this.getComponent(event.get('component'));
+    let info = eventsTemplates[event.get('event')];
+
+    if (!info) {
+      info = { message: event.get('message') };
+    }
+
+    if (this.props.excludeString) {
+      info.message = replaceAll(info.message, this.props.excludeString, '');
+    }
 
     return (
-      <tr key={event.get('id')} onClick={() => this.openEventDetail(event)} className="kbc-cursor-pointer">
+      <tr 
+        key={event.get('id')} 
+        onClick={() => this.openEventDetail(event)} 
+        className={classnames('kbc-cursor-pointer', info.className)}
+      >
         <td>{format(event.get('created'))}</td>
         <td>
           <span>
@@ -68,7 +85,7 @@ export default React.createClass({
             <ComponentName component={component} showType={true} capitalize={true} />
           </span>
         </td>
-        <td>{truncate(event.get('message'), 60)}</td>
+        <td>{truncate(info.message, 60)}</td>
         <td>{event.getIn(['token', 'name'])}</td>
       </tr>
     );

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketDetail.jsx
@@ -108,7 +108,10 @@ export default React.createClass({
               </Tab.Pane>
               <Tab.Pane eventKey="events">
                 <Row>
-                  <BucketEvents eventsFactory={eventsFactory(this.state.bucket.get('id'))} />
+                  <BucketEvents 
+                    eventsFactory={eventsFactory(this.state.bucket.get('id'))} 
+                    excludeString={`${this.state.bucket.get('id')}.`}  
+                  />
                 </Row>
               </Tab.Pane>
             </Tab.Content>

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -190,6 +190,7 @@ export default React.createClass({
                   <TableEvents
                     key={this.state.table.get('lastImportDate') || 'table-events'}
                     eventsFactory={eventsFactory(this.state.table.get('id'))}
+                    excludeString={this.state.table.get('id')}
                   />
                 </Row>
               </Tab.Pane>

--- a/src/scripts/modules/table-browser/react/components/EventsTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/EventsTab.jsx
@@ -6,6 +6,7 @@ import {Table} from 'react-bootstrap';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import immutableMixin from 'react-immutable-render-mixin';
 import EventDetail from '../../../sapi-events/react/EventDetail';
+import {eventsTemplates} from '../../../storage-explorer/Constants';
 
 export default React.createClass({
 
@@ -108,7 +109,7 @@ export default React.createClass({
   renderTableRows() {
     return this.props.events.map( (e) => {
       const event = e.get('event');
-      let info = this.eventsTemplates[event];
+      let info = eventsTemplates[event];
       if (!info) {
         info = {
           className: '',
@@ -165,29 +166,5 @@ export default React.createClass({
           backButton={backButton} />
       </div>
     );
-  },
-
-  eventsTemplates: {
-    'storage.tableImportStarted': {
-      'message': 'Import started',
-      'className': ''
-    },
-
-    'storage.tableImportDone': {
-      'message': 'Successfully imported ',
-      'className': 'success'
-    },
-
-    'storage.tableImportError': {
-      'message': 'Error on table import',
-      'className': 'error'
-    },
-
-    'storage.tableExported': {
-      'message': 'Exported to a csv file',
-      'className': 'info'
-    }
-
   }
-
 });

--- a/src/styles/Storage-explorer.less
+++ b/src/styles/Storage-explorer.less
@@ -51,6 +51,7 @@
 
   .nav-tabs + .storage-search-bar {
     padding: 0 15px;
+    margin-bottom: 1em;
   }
 
   .is-table-alias {
@@ -65,15 +66,12 @@
     margin-left: 1em;
     .searchbar {
       margin-top: 1em;
+      margin-bottom: 1em;
     }
     mark, .mark {
       padding: 0;
       background-color: #fea;
     }
-  }
-
-  .searchbar {
-    margin-bottom: 1em;
   }
 
   .fast-fade {


### PR DESCRIPTION
Ještě ladím eventy.

Koukal jsem že v modulu `table-browser` jsou nějaké eventy "obarvené" plus mají upravou "message". To jsem extrahoval a převzal. 

Pak jsem koukal že tam jsou chechboxy, kde se dá nějak třídit ty eventy. To se mi líbí taky, ale nakonec jsme šel cestou jakou máme v Jobech, teda `predefinedSearches`. Příjde mi to takové lepší že vidím jaké dotazy z toho lezou a postupně se sám můžu naučit sit o psát "na míru". Nemůžu zakliknout dva checkboxy jako tam, ale když to okoukám tak ten dotaz dám zachvilku do kupy sám.

Je otázkou zda třeba mít takto ty "nápovědy" jednodné pro celou storage. Nebo to udělat jako props a definovat různé hledání pro eventy v Bucketech, jiný v Tables atd.. zatím jsou všude stejné.

Poslední co, tak ještě jsem koukal že když jsem na detailu tabulky, tak to tam odstraňovalo název tabulky, aby tam byla ta dáležitá informace (kor když to je oříznuté na 60 znaků). To jsem použil taky tu jako prop. Pro tabulky mažu tabulky. Pro buckety mažu bucket + tečku (zůstavá teda info o tabulce). Na indexu nemažu nic.

Ono to totiž někdy vypadalo takto třeba:
![pred](https://user-images.githubusercontent.com/12331181/52815597-61304f00-309f-11e9-98f0-7c16668578b3.png)

Po to je docela podobné, ale už aspoň vidím co ten event vlastně říká:
![po](https://user-images.githubusercontent.com/12331181/52815660-92108400-309f-11e9-83c7-96332fb42664.png)
