### PR TITLE
Storage Explorer - Fixes 3

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableModal.jsx
@@ -50,10 +50,10 @@ export default React.createClass({
               </Col>
               <Col sm={9}>
                 <SapiTableSelector
+                  autoFocus
                   placeholder="Source table"
                   value={this.state.newTableAlias.get('sourceTable')}
                   onSelectTableFn={this.handleSourceTable}
-                  autoFocus={true}
                 />
               </Col>
             </FormGroup>
@@ -231,12 +231,18 @@ export default React.createClass({
 
   onSubmit(event) {
     event.preventDefault();
-    const tableAlias = this.state.newTableAlias.updateIn(['aliasFilter', 'values'], values => values.split(',')).toJS();
+    const tableAlias = this.state.newTableAlias
+      .update((tableAlias) => {
+        if (!tableAlias.getIn(['aliasFilter', 'column'])) {
+          return tableAlias.delete('aliasFilter');
+        }
+        return tableAlias.updateIn(['aliasFilter', 'values'], values => values.split(','))
+      })
+      .toJS();
 
+    this.setState({ error: null });
     this.props.onSubmit(tableAlias).then(this.onHide, message => {
-      this.setState({
-        error: message
-      });
+      this.setState({ error: message });
     });
   },
 

--- a/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
@@ -110,9 +110,12 @@ export default React.createClass({
   },
 
   groupedBuckets() {
-    return this.props.sharedBuckets.groupBy(bucket => {
-      return bucket.getIn(['project', 'name']);
-    });
+    return this.props.sharedBuckets
+      .sortBy((bucket) => bucket.get('id').toLowerCase())
+      .groupBy((bucket) => {
+        return bucket.getIn(['project', 'name']);
+      })
+      .sortBy((group, project) => project.toLowerCase())
   },
 
   bucketLabel(bucket) {


### PR DESCRIPTION
Oprava bugu v modalu pro Table Alias. Chodil do api prázdný string jako column podle kterého filtrovat a to hlásilo chybu a nešlo tak vytvořit alias table.

+ pokud dostanu v modalu na nový alias error tak ho mažu jak dávám znovu odeslat
+ v modalu pro linked bucket sortuje bucky i projekty