### PR TITLE
Storage Explorer - Events - not use message from eventsTemplates

### DIFF
--- a/src/scripts/modules/storage-explorer/Constants.js
+++ b/src/scripts/modules/storage-explorer/Constants.js
@@ -24,7 +24,7 @@ export const eventsTemplates = {
   },
 
   'storage.tableImportDone': {
-    'message': 'Successfully imported ',
+    'message': 'Successfully imported',
     'className': 'success'
   },
 

--- a/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/EventsTable.jsx
@@ -62,21 +62,18 @@ export default React.createClass({
 
   renderRow(event) {
     const component = this.getComponent(event.get('component'));
+    let message = event.get('message');
     let info = eventsTemplates[event.get('event')];
 
-    if (!info) {
-      info = { message: event.get('message') };
-    }
-
     if (this.props.excludeString) {
-      info.message = replaceAll(info.message, this.props.excludeString, '');
+      message = replaceAll(message, this.props.excludeString, '');
     }
 
     return (
       <tr 
         key={event.get('id')} 
         onClick={() => this.openEventDetail(event)} 
-        className={classnames('kbc-cursor-pointer', info.className)}
+        className={classnames('kbc-cursor-pointer', info && info.className)}
       >
         <td>{format(event.get('created'))}</td>
         <td>
@@ -85,7 +82,7 @@ export default React.createClass({
             <ComponentName component={component} showType={true} capitalize={true} />
           </span>
         </td>
-        <td>{truncate(info.message, 60)}</td>
+        <td>{truncate(message, 60)}</td>
         <td>{event.getIn(['token', 'name'])}</td>
       </tr>
     );


### PR DESCRIPTION
Tak ještě jednou eventy.

Koukal jsem že ty upravené zprávy z těch templatů nefungují moc dobře. Myslím že postačí jen ten exclude. Díky tomu na detailu tabulky je hezká čitelná zpráva furt. Tu je jediné místo kde by to šlo podle mě dále používat ale nevidím takový rozdíl když to tam je a není.

V eventech na bucketu nebo úplně ty všechny eventy už je potřeba tam mít více informací než jen "Successfully imported" nebo "Exported to a csv file". Protože nevím vůbec co, o jakou tabulku se jedná.
