### PR TITLE
DataPreview - do not stringify Error object

### DIFF
--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -55,14 +55,15 @@ export default React.createClass({
           } else {
             dataPreviewError = error.response.body.message;
           }
-        } else {
-          throw new Error(JSON.stringify(error));
         }
+
         this.setState({
           loadingPreview: false,
           dataPreview: null,
-          dataPreviewError: dataPreviewError
+          dataPreviewError
         });
+
+        throw error;
       });
   },
 

--- a/src/scripts/modules/table-browser/actionsProvisioning.js
+++ b/src/scripts/modules/table-browser/actionsProvisioning.js
@@ -1,10 +1,9 @@
+import _ from 'underscore';
+import { List, Map } from 'immutable';
+import storageApi from '../components/StorageApi';
+import { factory as EventsServiceFactory} from '../sapi-events/EventsService';
 import storeProvisioning from './storeProvisioning';
 import tableBrowserActions from './flux/actions';
-// import storageActions from '../components/StorageActionCreators';
-import storageApi from '../components/StorageApi';
-import { List, Map } from 'immutable';
-import { factory as EventsServiceFactory} from '../sapi-events/EventsService';
-import _ from 'underscore';
 
 const  IMPORT_EXPORT_EVENTS = ['tableImportStarted', 'tableImportDone', 'tableImportError', 'tableExported'];
 
@@ -13,17 +12,15 @@ function runExportDataSample(tableId, onSucceed, onFail) {
     .tableDataJsonPreview(tableId, {limit: 10})
     .then(onSucceed)
     .catch((error) => {
-      let dataPreviewError = null;
       if (error.response && error.response.body) {
         if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
-          dataPreviewError = 'Data sample cannot be displayed. Too many columns.';
-        } else {
-          dataPreviewError = error.response.body.message;
+          return onFail('Data sample cannot be displayed. Too many columns.');
         }
-      } else {
-        throw new Error(JSON.stringify(error));
+
+        return onFail(error.response.body.message);
       }
-      return onFail(dataPreviewError);
+      
+      throw error;
     });
 }
 


### PR DESCRIPTION
Fixes #2909

Tady se error parsoval na string, pak to nebylo zachyceno dále jako timeout podle kódu, ale spadlo to jako jiný nezachycený error až do Sentry.