### PR TITLE
Avoid using "void 0"

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -155,7 +155,9 @@ module.exports = {
       configId: configId
     });
     dataToSave = InstalledComponentsStore.getSavingConfigData(componentId, configId);
-    dataToSave = dataToSave !== null ? dataToSave.toJS() : void 0;
+    if (dataToSave) {
+      dataToSave = dataToSave.toJS();
+    }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update configuration').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
       return dispatcher.handleViewAction({
@@ -181,10 +183,14 @@ module.exports = {
       configId: configId
     });
     parametersToSave = InstalledComponentsStore.getSavingConfigDataParameters(componentId, configId);
-    parametersToSave = parametersToSave !== null ? parametersToSave.toJS() : void 0;
+    if (parametersToSave) {
+      parametersToSave = parametersToSave.toJS();
+    }
     dataToSave = InstalledComponentsStore.getConfigData(componentId, configId);
-    dataToSave = dataToSave !== null ? dataToSave.toJS() : void 0;
-    dataToSave.parameters = parametersToSave;
+    if (dataToSave) {
+      dataToSave = dataToSave.toJS();
+      dataToSave.parameters = parametersToSave;
+    }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update parameters').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
       return dispatcher.handleViewAction({
@@ -211,7 +217,9 @@ module.exports = {
       forceData: forceData
     });
     dataToSave = InstalledComponentsStore.getSavingConfigData(componentId, configId);
-    dataToSave = dataToSave !== null ? dataToSave.toJS() : void 0;
+    if (dataToSave) {
+      dataToSave = dataToSave.toJS();
+    }
     return storeEncodedConfig(componentId, configId, dataToSave, changeDescription).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
       return dispatcher.handleViewAction({
@@ -711,7 +719,9 @@ module.exports = {
       configId: configId
     });
     dataToSave = InstalledComponentsStore.getSavingConfigData(componentId, configId);
-    dataToSave = dataToSave !== null ? dataToSave.toJS() : void 0;
+    if (dataToSave) {
+      dataToSave = dataToSave.toJS();
+    }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update parameters').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
       return dispatcher.handleViewAction({

--- a/src/scripts/modules/components/react/components/RunComponentButton.jsx
+++ b/src/scripts/modules/components/react/components/RunComponentButton.jsx
@@ -151,7 +151,7 @@ module.exports = React.createClass({
         onClick={this.onOpenButtonClick}
       >
         {this.renderModal()}
-        {this._renderIcon()} {this.props.label ? ' ' + this.props.label : void 0}
+        {this._renderIcon()}{this.props.label && ` ${this.props.label}`}
       </Button>
     );
   },


### PR DESCRIPTION
Všiml jsem si že máme někde "void 0" použitý, to už jsem neviděl dlouho nikde, používal jsem to u odkazů co si pomatuji.

Asi tam by i jeden bug, kdy to mohlo dopadnout jako void a pak se volalo:
```js
dataToSave.parameters = parametersToSave;
```
Což by asi skončilo chybou. Ale jinak spíš drobnosti.