### PR TITLE
allow goodata writer migration for early adopters

### DIFF
--- a/src/scripts/constants/KbcConstants.js
+++ b/src/scripts/constants/KbcConstants.js
@@ -29,9 +29,11 @@ const ActionTypes = keyMirror({
 });
 
 const FEATURE_UI_DEVEL_PREVIEW = 'ui-devel-preview';
+const FEATURE_EARLY_ADOPTER_PREVIEW = 'early-adopter-preview';
 
 export {
   PayloadSources,
   ActionTypes,
-  FEATURE_UI_DEVEL_PREVIEW
+  FEATURE_UI_DEVEL_PREVIEW,
+  FEATURE_EARLY_ADOPTER_PREVIEW
 };

--- a/src/scripts/modules/components/utils/hiddenComponents.js
+++ b/src/scripts/modules/components/utils/hiddenComponents.js
@@ -1,5 +1,6 @@
 import _ from 'underscore';
 import ApplicationStore from '../../../stores/ApplicationStore';
+import { FEATURE_EARLY_ADOPTER_PREVIEW } from '../../../constants/KbcConstants';
 
 // hardcoded array of hiden components(under construction components)
 // possible alternative is hasUI component property
@@ -24,8 +25,7 @@ export default {
   },
 
   hasCurrentUserEarlyAdopterFeature() {
-    const adminFeature = 'early-adopter-preview';
-    return ApplicationStore.hasCurrentAdminFeature(adminFeature);
+    return ApplicationStore.hasCurrentAdminFeature(FEATURE_EARLY_ADOPTER_PREVIEW);
   },
 
   filterHiddenRoutes(routes) {

--- a/src/scripts/modules/components/utils/hiddenComponents.js
+++ b/src/scripts/modules/components/utils/hiddenComponents.js
@@ -23,6 +23,11 @@ export default {
     return ApplicationStore.hasCurrentAdminFeature(adminFeature);
   },
 
+  hasCurrentUserEarlyAdopterFeature() {
+    const adminFeature = 'early-adopter-preview';
+    return ApplicationStore.hasCurrentAdminFeature(adminFeature);
+  },
+
   filterHiddenRoutes(routes) {
     const stack = [routes];
     while (!_.isEmpty(stack)) {

--- a/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
@@ -96,7 +96,7 @@ export default React.createClass({
     const writer = this.state.writer.get('config');
     return (
       <div className="container-fluid">
-        { hiddenComponents.hasCurrentUserDevelPreview() &&
+        { (hiddenComponents.hasCurrentUserDevelPreview() || hiddenComponents.hasCurrentUserEarlyAdopterFeature()) &&
           <MigrationRow
             componentId="gooddata-writer"
             replacementAppId="keboola.gooddata-writer"


### PR DESCRIPTION
zobrazi migracnu toolu GoodData writeru pre userov s admin featurou `early-adopter-preview`.  Chceme to postupne zapnut nejakym analytikom vid debata od https://github.com/keboola/internal/issues/60#issuecomment-464744273 a nechcem nato pouzit `ui-devel-preview` featuru.
