### PR TITLE
Storage Explorer - DataSample - catch timeout error

### DIFF
--- a/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
+++ b/src/scripts/modules/configurations/react/components/StorageTableColumnsEditor.jsx
@@ -63,7 +63,9 @@ export default React.createClass({
           dataPreviewError
         });
 
-        throw error;
+        if (!dataPreviewError) {
+          throw error;
+        }
       });
   },
 

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -178,12 +178,25 @@ export default React.createClass({
       .then(json => {
         this.setState({ data: json, loading: false });
       })
-      .catch(({ message, response }) => {
-        const errorMessage =
-          response.body.code === 'storage.maxNumberOfColumnsExceed'
-            ? 'Data sample cannot be displayed. Too many columns.'
-            : message;
-        this.setState({ data: [], error: errorMessage, loading: false });
+      .catch((error) => {
+        let errorMessage = null;
+        if (error.response && error.response.body) {
+          if (error.response.body.code === 'storage.maxNumberOfColumnsExceed') {
+            errorMessage = 'Data sample cannot be displayed. Too many columns.';
+          } else {
+            errorMessage = error.response.body.message;
+          }
+        }
+
+        this.setState({ 
+          data: [],
+          loading: false,
+          error: errorMessage
+        });
+
+        if (!errorMessage) {
+          throw error;
+        }
       });
 
     return this.cancellablePromise;


### PR DESCRIPTION
Fixes #2913

Stejné řešení jako u toho `tableDataJsonPreview`, tam jsem to ještě upravil, že pokud ten error message mám na zobrazení přímo v té komponentě, tak nevyhazuji error dál (do notifikace). Stejné pak tu.