### PR TITLE
Storage Explorer - Link bucket  - use React-select for select shared bucket

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import { Alert, Modal, Form, Col, FormGroup, ControlLabel, FormControl } from 'react-bootstrap';
+import Select from 'react-select';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
 
 const INITIAL_STATE = {
@@ -37,26 +38,13 @@ export default React.createClass({
                 Shared buckets
               </Col>
               <Col sm={8}>
-                <FormControl autoFocus componentClass="select" onChange={this.handleBucket} value={this.state.bucket}>
-                  <option value="">Select bucket...</option>
-                  {this.groupedBuckets()
-                    .map((group, groupName) => {
-                      return (
-                        <optgroup key={groupName} label={groupName}>
-                          {group
-                            .map((bucket, index) => {
-                              return (
-                                <option key={index} value={JSON.stringify(bucket.toJS())}>
-                                  {this.bucketLabel(bucket)}
-                                </option>
-                              );
-                            })
-                            .toArray()}
-                        </optgroup>
-                      );
-                    })
-                    .toArray()}
-                </FormControl>
+                <Select
+                  disabled={false}
+                  placeholder="Select bucket..."
+                  value={this.state.bucket}
+                  onChange={this.handleBucket}
+                  options={this.groupedBuckets()}
+                />
               </Col>
             </FormGroup>
 
@@ -111,11 +99,12 @@ export default React.createClass({
 
   groupedBuckets() {
     return this.props.sharedBuckets
-      .sortBy((bucket) => bucket.get('id').toLowerCase())
-      .groupBy((bucket) => {
-        return bucket.getIn(['project', 'name']);
-      })
-      .sortBy((group, project) => project.toLowerCase())
+      .map((bucket) => ({
+        value: bucket.get('id'),
+        label: `${bucket.getIn(['project', 'name'])} - ${bucket.get('name')}`
+      }))
+      .sortBy((option) => option.label.toLowerCase())
+      .toArray();
   },
 
   bucketLabel(bucket) {
@@ -145,10 +134,8 @@ export default React.createClass({
     this.setState({ error: message });
   },
 
-  handleBucket(event) {
-    this.setState({
-      bucket: event.target.value
-    });
+  handleBucket(bucket) {
+    this.setState({ bucket });
   },
 
   handleName(event) {

--- a/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
@@ -25,7 +25,7 @@ export default React.createClass({
 
   render() {
     return (
-      <Modal show={this.props.show} onHide={this.onHide}>
+      <Modal bsSize="large" show={this.props.show} onHide={this.onHide}>
         <Form onSubmit={this.handleSubmit} horizontal>
           <Modal.Header closeButton>
             <Modal.Title>Link bucket</Modal.Title>
@@ -34,10 +34,10 @@ export default React.createClass({
             {this.renderError()}
 
             <FormGroup>
-              <Col sm={4} componentClass={ControlLabel}>
+              <Col sm={3} componentClass={ControlLabel}>
                 Shared buckets
               </Col>
-              <Col sm={8}>
+              <Col sm={9}>
                 <Select
                   autoFocus
                   disabled={false}
@@ -50,19 +50,19 @@ export default React.createClass({
             </FormGroup>
 
             <FormGroup>
-              <Col sm={4} componentClass={ControlLabel}>
+              <Col sm={3} componentClass={ControlLabel}>
                 Name
               </Col>
-              <Col sm={8}>
+              <Col sm={9}>
                 <FormControl type="text" value={this.state.name} onChange={this.handleName} />
               </Col>
             </FormGroup>
 
             <FormGroup>
-              <Col sm={4} componentClass={ControlLabel}>
+              <Col sm={3} componentClass={ControlLabel}>
                 Stage
               </Col>
-              <Col sm={8}>
+              <Col sm={9}>
                 <FormControl
                   componentClass="select"
                   placeholder="Select stage..."
@@ -101,21 +101,11 @@ export default React.createClass({
   groupedBuckets() {
     return this.props.sharedBuckets
       .map((bucket) => ({
-        value: bucket.get('id'),
-        label: `${bucket.getIn(['project', 'name'])} - ${bucket.get('name')}`
+        value: JSON.stringify(bucket.toJS()),
+        label: `${bucket.getIn(['project', 'name'])} | ${bucket.get('id')}`
       }))
       .sortBy((option) => option.label.toLowerCase())
       .toArray();
-  },
-
-  bucketLabel(bucket) {
-    let label = bucket.get('id');
-
-    if (bucket.get('description')) {
-      label += ` - ${bucket.get('description')}`;
-    }
-
-    return label;
   },
 
   handleSubmit(event) {

--- a/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
@@ -39,6 +39,7 @@ export default React.createClass({
               </Col>
               <Col sm={8}>
                 <Select
+                  autoFocus
                   disabled={false}
                   placeholder="Select bucket..."
                   value={this.state.bucket}

--- a/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/SharedBucketsModal.jsx
@@ -44,7 +44,7 @@ export default React.createClass({
                   placeholder="Select bucket..."
                   value={this.state.bucket}
                   onChange={this.handleBucket}
-                  options={this.groupedBuckets()}
+                  options={this.bucketsOptions()}
                 />
               </Col>
             </FormGroup>
@@ -98,11 +98,11 @@ export default React.createClass({
     return <Alert bsStyle="danger">{this.state.error}</Alert>;
   },
 
-  groupedBuckets() {
+  bucketsOptions() {
     return this.props.sharedBuckets
       .map((bucket) => ({
-        value: JSON.stringify(bucket.toJS()),
-        label: `${bucket.getIn(['project', 'name'])} | ${bucket.get('id')}`
+        value: JSON.stringify(bucket.toJSON()),
+        label: `${bucket.getIn(['project', 'name'])} / ${bucket.get('id')}`
       }))
       .sortBy((option) => option.label.toLowerCase())
       .toArray();
@@ -125,20 +125,16 @@ export default React.createClass({
     this.setState({ error: message });
   },
 
-  handleBucket(bucket) {
-    this.setState({ bucket });
+  handleBucket(selected) {
+    this.setState({ bucket: selected ? selected.value : null });
   },
 
   handleName(event) {
-    this.setState({
-      name: event.target.value
-    });
+    this.setState({ name: event.target.value });
   },
 
   handleStage(event) {
-    this.setState({
-      stage: event.target.value
-    });
+    this.setState({ stage: event.target.value });
   },
 
   onHide() {


### PR DESCRIPTION
Fixes #2920

Nevím jak se React-select chová v Safari, zda hezky zalamuje řádky atd jako v Chrome, pokud jo tak by to takto mohlo stačit než půjde použít novější ReactSelect s podporou optgroup.