### PR TITLE
RoutesStore - emitChange only if match action

### DIFF
--- a/src/scripts/stores/RoutesStore.js
+++ b/src/scripts/stores/RoutesStore.js
@@ -281,7 +281,7 @@ Dispatcher.register(payload => {
       if (!(currentState && currentState.get('pathname') === action.routerState.pathname)) {
         _store = _store.set('isPending', true);
       }
-      break;
+      return RoutesStore.emitChange();
 
     case Constants.ActionTypes.ROUTER_ROUTE_CHANGE_SUCCESS:
       // jobs status (playing icon in header) can be changed so wait for it
@@ -305,7 +305,7 @@ Dispatcher.register(payload => {
         store.set('breadcrumbs', generateBreadcrumbs(store));
         return store;
       });
-      break;
+      return RoutesStore.emitChange();
 
     case Constants.ActionTypes.ROUTER_ROUTE_CHANGE_ERROR:
       _store = _store.withMutations(store => {
@@ -314,15 +314,15 @@ Dispatcher.register(payload => {
           .set('error', Error.create(action.error))
           .set('breadcrumbs', generateBreadcrumbs(store));
       });
-      break;
+      return RoutesStore.emitChange();
 
     case Constants.ActionTypes.ROUTER_ROUTES_CONFIGURATION_RECEIVE:
       _store = _store.set('routesByName', nestedRoutesToByNameMap(action.routes));
-      break;
+      return RoutesStore.emitChange();
 
     case Constants.ActionTypes.ROUTER_ROUTER_CREATED:
       _store = _store.set('router', action.router);
-      break;
+      return RoutesStore.emitChange();
 
     case ComponentsConstants.INSTALLED_COMPONENTS_CONFIGDATA_LOAD_SUCCESS:
       // update breadcrumb title for generic-detail component route
@@ -343,15 +343,10 @@ Dispatcher.register(payload => {
         return breadcrumb;
       });
       _store = _store.set('breadcrumbs', breadcrumbs);
-      break;
+      return RoutesStore.emitChange();
 
     default:
-      break;
   }
-
-  // Emit change on events
-  // for example orchestration is loaed asynchronously while breadcrumbs are already rendered so it has to be rendered again
-  return RoutesStore.emitChange();
 });
 
 export default RoutesStore;


### PR DESCRIPTION
Fixes #2915

Alternativa ke #2916 , podle testu to má podobné výsledky a přitom je to daleko jednoduší, myslím ale že může být užitečné obojí.

Toto je ale obecně daleko větší změna. Podle mě to může mít výsledek na výkon aplikace obecně docela výrazný (jen teda teoreticky :) nic jsem neměřil). Bude potřeba méně používat pure mixiny apod. Jen si nejsem jistý zda to je takto jednoduché, ten kód co emitoval změny furt tam je od roku 2014 a je možné že už je právě zbytečný (doufám), ale i pokud ne, šel bych určitě cestou to řešit přímo pro nějaké další akce, než to mít takto, kdy se emituje změna pokaždé když je kdekoli v aplikaci vypálena nějaká akce.