### PR TITLE
Ex Google BigQuery - load account projects - always return promise

### DIFF
--- a/src/scripts/modules/ex-google-bigquery/actionsProvisioning.js
+++ b/src/scripts/modules/ex-google-bigquery/actionsProvisioning.js
@@ -1,4 +1,5 @@
 import _ from 'underscore';
+import Promise from 'bluebird';
 import {Map, fromJS} from 'immutable';
 import componentsActions from '../components/InstalledComponentsActionCreators';
 import callDockerAction from '../components/DockerActionsApi';
@@ -153,10 +154,9 @@ export default function(configId) {
     },
 
     loadAccountProjects() {
-      if (!store.isAuthorized()) return null;
-      const path = store.getProjectsPath();
-
-      if (store.projects.count() > 0) return null;
+      if (!store.isAuthorized() || store.projects.count() > 0) {
+        return Promise.resolve();
+      }
 
       updateLocalState(store.getPendingPath('projects'), true);
 
@@ -180,7 +180,7 @@ export default function(configId) {
           return result.projects;
         })
         .then((projects) => {
-          return updateLocalState(path, fromJS(projects));
+          return updateLocalState(store.getProjectsPath(), fromJS(projects));
         })
         .finally(() => {
           updateLocalState(store.getPendingPath('projects'), false);


### PR DESCRIPTION
Fixes #2927

Ve `ProjectsManagerModal` se volá `this.props.loadAccountProjectsFn().catch(` tak aby to bylo konzistentní a vždy to vracelo Promise.