### PR TITLE
support new oauth in tde exporter upload writers setup

### DIFF
--- a/src/scripts/modules/components/utils/oAuthComponents.js
+++ b/src/scripts/modules/components/utils/oAuthComponents.js
@@ -4,6 +4,6 @@ import InstalledComponentsStore from '../stores/InstalledComponentsStore';
 export default {
   loadComponentsWithOAuth: () => InstalledComponentsActions.loadComponents()
     .then(() => InstalledComponentsStore.getAll()
-      .filter(component => component.get('flags').contains('genericDockerUI-authorization'))
+      .filter(component => component.get('flags').contains('genericDockerUI-authorization') || component.get('id') === 'tde-exporter')
       .map(component => InstalledComponentsActions.loadComponentConfigsData(component.get('id'))))
 };

--- a/src/scripts/modules/components/utils/oAuthMigration.js
+++ b/src/scripts/modules/components/utils/oAuthMigration.js
@@ -5,14 +5,22 @@ const ignoreComponents = [
   'tde-exporter'
 ];
 
+function needTdeExporterDestinationNewOauth(config, destinationComponentId) {
+  const path = ['configuration', 'parameters', destinationComponentId];
+  return config.hasIn(path) && config.getIn(path.concat('version')) !== 3;
+}
+
 export default {
   getConfigurationsToMigrate(component) {
+    const isTdeExporter = component.get('id') === 'tde-exporter';
     return component.get('configurations')
       .filter((config) => {
-        return (config.hasIn(['configuration', 'authorization', 'oauth_api', 'id']) &&
-                config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3 ||
-                (config.getIn(['configuration', 'parameters', 'keboola.wr-google-drive', 'version']) !== 3 &&
-                config.getIn(['configuration', 'parameters', 'keboola.wr-dropbox-v2', 'version']) !== 3)
+        return (
+          config.hasIn(['configuration', 'authorization', 'oauth_api', 'id']) &&
+          config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3 ||
+          (isTdeExporter &&
+           needTdeExporterDestinationNewOauth(config, 'keboola.wr-google-drive') &&
+           needTdeExporterDestinationNewOauth(config, 'keboola.wr-dropbox-v2'))
         );
       });
   },

--- a/src/scripts/modules/components/utils/oAuthMigration.js
+++ b/src/scripts/modules/components/utils/oAuthMigration.js
@@ -16,11 +16,12 @@ export default {
     return component.get('configurations')
       .filter((config) => {
         return (
-          config.hasIn(['configuration', 'authorization', 'oauth_api', 'id']) &&
-          config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3 ||
-          (isTdeExporter &&
-           needTdeExporterDestinationNewOauth(config, 'keboola.wr-google-drive') &&
-           needTdeExporterDestinationNewOauth(config, 'keboola.wr-dropbox-v2'))
+          config.hasIn(['configuration', 'authorization', 'oauth_api', 'id'])
+          && config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3
+          || (isTdeExporter && (
+            needTdeExporterDestinationNewOauth(config, 'keboola.wr-google-drive')
+            || needTdeExporterDestinationNewOauth(config, 'keboola.wr-dropbox-v2')
+          ))
         );
       });
   },

--- a/src/scripts/modules/components/utils/oAuthMigration.js
+++ b/src/scripts/modules/components/utils/oAuthMigration.js
@@ -1,8 +1,8 @@
-
 const ignoreComponents = [
   'esnerda.wr-zoho-crm',
   'keboola.ex-github',
-  'esnerda.ex-twitter-ads'
+  'esnerda.ex-twitter-ads',
+  'tde-exporter'
 ];
 
 export default {
@@ -10,7 +10,10 @@ export default {
     return component.get('configurations')
       .filter((config) => {
         return (config.hasIn(['configuration', 'authorization', 'oauth_api', 'id']) &&
-          config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3);
+                config.getIn(['configuration', 'authorization', 'oauth_api', 'version']) !== 3 ||
+                (config.getIn(['configuration', 'parameters', 'keboola.wr-google-drive', 'version']) !== 3 &&
+                config.getIn(['configuration', 'parameters', 'keboola.wr-dropbox-v2', 'version']) !== 3)
+        );
       });
   },
 

--- a/src/scripts/modules/home/react/Index.jsx
+++ b/src/scripts/modules/home/react/Index.jsx
@@ -91,7 +91,8 @@ export default React.createClass({
   getComponentsWithOAuth() {
     const installedComponents = this.state.installedComponents;
     return installedComponents.filter(component => {
-      return component.get('flags', List()).contains('genericDockerUI-authorization');
+      return component.get('flags', List()).contains('genericDockerUI-authorization')
+        || component.get('id') === 'tde-exporter';
     });
   },
 

--- a/src/scripts/modules/migration/react/pages/Index.jsx
+++ b/src/scripts/modules/migration/react/pages/Index.jsx
@@ -205,7 +205,7 @@ export default React.createClass({
 
   getComponentsWithOAuth() {
     return this.state.components.filter(component => {
-      return component.get('flags').contains('genericDockerUI-authorization');
+      return component.get('flags').contains('genericDockerUI-authorization') || component.get('id') === 'tde-exporter';
     });
   },
 

--- a/src/scripts/modules/tde-exporter/tdeRoutes.js
+++ b/src/scripts/modules/tde-exporter/tdeRoutes.js
@@ -17,6 +17,7 @@ import storageActionCreators from '../components/StorageActionCreators';
 import RouterStore from '../../stores/RoutesStore';
 import VersionsActionCreators from '../components/VersionsActionCreators';
 import { createTablesRoute } from '../table-browser/routes';
+import {Constants} from '../oauth-v2/Constants';
 
 const componentId = 'tde-exporter';
 const registerOAuthV2Route = writerComponentId => ({
@@ -36,7 +37,13 @@ const registerOAuthV2Route = writerComponentId => ({
           .loadCredentials(writerComponentId, credentialsId)
           .then(() => {
             const saveFn = installedComponentsActions.saveComponentConfigData;
-            const newConfig = configuration.setIn(['parameters', writerComponentId, 'id'], credentialsId);
+            const credentialsObject = Map(
+              {
+                id: credentialsId,
+                version: Constants.OAUTH_VERSION_3
+              }
+            );
+            const newConfig = configuration.setIn(['parameters', writerComponentId], credentialsObject);
 
             return saveFn(componentId, params.config, newConfig).then(() => {
               const notification = 'Account succesfully authorized.';


### PR DESCRIPTION
Fixes #2973 

related to https://github.com/keboola/tde-exporter/issues/13

- autorizacia google drive alebo dropbox destination typu vzdy ulozi oauth version: 3
![image](https://user-images.githubusercontent.com/1412120/53179349-d8139d80-35f3-11e9-92a9-99a04205ad08.png)
nastavuje sa to na `Setup Upload` stranke(klik zo side menu na indexe)
![image](https://user-images.githubusercontent.com/1412120/53179732-98998100-35f4-11e9-9bc7-d4483e213acc.png)

- zobrazi konfigu tde exportoru ktore vo svojich konfigoch v destination upload nemaju oauth v3 
![image](https://user-images.githubusercontent.com/1412120/53179774-b1099b80-35f4-11e9-95c8-862c0dedbeec.png)

- odstraneny nepotrebny kod ohladom autorizacie stareho google drive writeru

Nato aby tde exporter fungoval s oauth v3 sa to musi nasadit aj s https://github.com/keboola/tde-exporter/pull/14 (nezalezi na poradi)