### PR TITLE
gdwrv3: save dimension templateId to template property if is custom

### DIFF
--- a/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
@@ -176,8 +176,9 @@ export default React.createClass({
     delete newDimension.name;
     if (newDimension.template === 'custom') {
       newDimension.template = newDimension.templateId;
-      delete newDimension.templateId;
+
     }
+    delete newDimension.templateId;
     const dimensionsToSave = {...this.props.value.dimensions, [name]: newDimension};
     this.props.onSave({dimensions: dimensionsToSave}).then(this.closeModal);
   }

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DimensionsSection.jsx
@@ -174,6 +174,10 @@ export default React.createClass({
     const newDimension = {...this.state.newDimension, includeTime: !!this.state.newDimension.includeTime};
     const name = this.state.newDimension.name;
     delete newDimension.name;
+    if (newDimension.template === 'custom') {
+      newDimension.template = newDimension.templateId;
+      delete newDimension.templateId;
+    }
     const dimensionsToSave = {...this.props.value.dimensions, [name]: newDimension};
     this.props.onSave({dimensions: dimensionsToSave}).then(this.closeModal);
   }


### PR DESCRIPTION
vyplynulo z debaty v https://github.com/keboola/gooddata-writer-v3/issues/31#issuecomment-466046264

Jedna sa o zmenu ukladania datumovej dimenzie pri jej vytvarani - ak je zvolena custom template tak hodnota form inputu templateId prepise property template a teda nova dimenze sa do konfigu ulozi bez templateId.

![image](https://user-images.githubusercontent.com/1412120/53274058-2c9f4180-36f6-11e9-9aa5-533847a82397.png)

![image](https://user-images.githubusercontent.com/1412120/53274261-edbdbb80-36f6-11e9-977b-77b227eb5514.png)
