### PR TITLE
Header - conditional render of Reloader or RouterPendingIndicator

### DIFF
--- a/src/scripts/modules/transformations/react/components/TransformationsIndexReloaderButton.jsx
+++ b/src/scripts/modules/transformations/react/components/TransformationsIndexReloaderButton.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
-import RoutesStore from '../../../../stores/RoutesStore';
 import InstalledComponentsActionCreators from '../../../components/InstalledComponentsActionCreators';
 import TransformationBucketsStore from '../../stores/TransformationBucketsStore';
 import { RefreshIcon, Loader } from '@keboola/indigo-ui';
@@ -18,16 +17,11 @@ export default React.createClass({
 
   getStateFromStores() {
     return { 
-      isRoutePending: RoutesStore.getIsPending(),
       isLoading: TransformationBucketsStore.getIsLoading() 
     };
   },
 
   render() {
-    if (this.state.isRoutePending) {
-      return null;
-    }
-
     if (this.props.allowRefresh) {
       return <RefreshIcon isLoading={this.state.isLoading} onClick={this.handleRefreshClick} />;
     }

--- a/src/scripts/react/layout/Header.jsx
+++ b/src/scripts/react/layout/Header.jsx
@@ -51,8 +51,8 @@ export default React.createClass({
           <div className="kbc-main-header kbc-header">
             <div className="kbc-title">
               {!this.state.lookerPreview && this._renderComponentIcon()}
-              {this._renderBreadcrumbs()} {this._renderReloader()}{' '}
-              {this.state.isRoutePending && <RoutePendingIndicator />}
+              {this._renderBreadcrumbs()}{' '}
+              {this.state.isRoutePending ? <RoutePendingIndicator /> : this._renderReloader()}
             </div>
             <div className="kbc-buttons">{this._renderButtons()}</div>
           </div>


### PR DESCRIPTION
Related #2963

No bohužel jsme to nedořešil a už na tom asi nemá cenu pálit čas. Ještě sem napíši k čemu jsem došel.
Myslím že `breadcrumb` s tím nesouvisí. A částečně ani ne `injectProps` i když i to zlobí. Když jsem `Header.jsx` zjednodušil pouze na to aby kreslil ren `reloader` tak i tak to házelo stejnou chybu, a to také i když jsem nepoužíval vůbec `injectProps` v routes. Nějak tam zlobí to jak se to přenáší ve `currentRouteConfig`, asi jak je to immutalbe nebo se to vytváří vždy nějak znova (to jsem nezkoumal) tak to prostě vytváří nějak ty elementy tak, že React je všechny nedokáže správně vyhodit když je potřeba. Pokud tam (`Header.jsx`) použiji přímo `TransformationsIndexReloaderButton.jsx` tak vůbec nevadí že tam je RoutesStore v této komponentě.

Nicméně když tam nerenderuji nic když mám `isRoutePending` tak to můžu rovnou přenést sem do `Header` a tam to úplně vyhodit a aspoň mě to tam nebude trápit :)
Může to takto dělat problémy jinde pro jiné Reloadery? Podle mě by to mohlo být spíše lepší že to takto bude fungoval napříč routami, že buď tam bude pouze `RoutePendingIndicator` nebo ten nějaký custom.
