### PR TITLE
Transformations - Disable action (save, delete) button while processing pending actions

### DIFF
--- a/src/scripts/modules/transformations/ActionCreators.js
+++ b/src/scripts/modules/transformations/ActionCreators.js
@@ -495,13 +495,23 @@ module.exports = {
     if (!mapping) {
       return Promise.resolve();
     }
+    const pendingAction = `save-${mappingType}`;
+
+    dispatcher.handleViewAction({
+      type: constants.ActionTypes.TRANSFORMATION_EDIT_SAVE_START,
+      transformationId: transformationId,
+      bucketId: bucketId,
+      pendingAction
+    });
+
     return transformationsApi.saveTransformation(bucketId, transformationId, transformation.toJS(), changeDescription).then(function(response) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.TRANSFORMATION_EDIT_SAVE_SUCCESS,
         transformationId: transformationId,
         bucketId: bucketId,
         editingId: editingId,
-        data: response
+        data: response,
+        pendingAction
       });
       return reloadVersions(bucketId, transformationId);
     }).catch(function(error) {
@@ -509,7 +519,8 @@ module.exports = {
         type: constants.ActionTypes.TRANSFORMATION_EDIT_SAVE_ERROR,
         transformationId: transformationId,
         bucketId: bucketId,
-        error: error
+        error: error,
+        pendingAction
       });
       throw error;
     });

--- a/src/scripts/modules/transformations/react/modals/InputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/InputMapping.jsx
@@ -21,12 +21,14 @@ export default React.createClass({
     onChange: PropTypes.func.isRequired,
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
-    definition: PropTypes.object
+    definition: PropTypes.object,
+    disabled: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      definition: Immutable.Map()
+      definition: Immutable.Map(),
+      disabled: false
     };
   },
 
@@ -91,7 +93,7 @@ export default React.createClass({
     if (this.props.mode === MODE_EDIT) {
       return (
         <Tooltip tooltip="Edit Input" placement="top">
-          <Button bsStyle="link" onClick={this.handleOpenButtonLink}>
+          <Button bsStyle="link" onClick={this.handleOpenButtonLink} disabled={this.props.disabled}>
             <span className="fa fa-pencil" />
           </Button>
         </Tooltip>

--- a/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/OutputMapping.jsx
@@ -22,12 +22,14 @@ export default React.createClass({
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     otherOutputMappings: PropTypes.object.isRequired,
-    definition: PropTypes.object
+    definition: PropTypes.object,
+    disabled: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      definition: Immutable.Map()
+      definition: Immutable.Map(),
+      disabled: false
     };
   },
 
@@ -112,7 +114,7 @@ export default React.createClass({
     if (this.props.mode === MODE_EDIT) {
       return (
         <Tooltip tooltip="Edit Output" placement="top">
-          <Button bsStyle="link" onClick={this.handleOpenButtonLink}>
+          <Button bsStyle="link" onClick={this.handleOpenButtonLink} disabled={this.props.disabled}>
             <span className="fa fa-pencil" />
           </Button>
         </Tooltip>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
@@ -74,11 +74,11 @@ export default React.createClass({
                 </span>
               ]}
             <span className="td col-xs-1 text-right kbc-no-wrap">
-              {this.props.inputMapping.get('source') !== '' &&
-                !this.props.disabled && (
+              {this.props.inputMapping.get('source') !== '' && (
                 <DeleteButton
                   tooltip="Delete Input"
                   isPending={this.props.pendingActions.get(`delete-input-${this.props.mappingIndex}`)}
+                  isEnabled={!this.props.disabled}
                   confirm={{
                     title: 'Delete Input',
                     text: (
@@ -91,20 +91,19 @@ export default React.createClass({
                   }}
                 />
               )}
-              {!this.props.disabled && (
-                <InputMappingModal
-                  mode="edit"
-                  tables={this.props.tables}
-                  backend={this.props.transformation.get('backend')}
-                  type={this.props.transformation.get('type')}
-                  mapping={this.props.editingInputMapping}
-                  otherDestinations={this.props.otherDestinations}
-                  onChange={this._handleChange}
-                  onCancel={this._handleCancel}
-                  onSave={this._handleSave}
-                  definition={this.props.definition}
-                />
-              )}
+              <InputMappingModal
+                mode="edit"
+                tables={this.props.tables}
+                backend={this.props.transformation.get('backend')}
+                type={this.props.transformation.get('type')}
+                mapping={this.props.editingInputMapping}
+                otherDestinations={this.props.otherDestinations}
+                onChange={this._handleChange}
+                onCancel={this._handleCancel}
+                onSave={this._handleSave}
+                definition={this.props.definition}
+                disabled={this.props.disabled}
+              />
             </span>
           </span>
         </span>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
@@ -78,11 +78,11 @@ export default React.createClass({
                 </span>
               ]}
             <span className="td col-xs-1 col-xs-1 text-right kbc-no-wrap">
-              {this.props.outputMapping.get('destination') !== '' &&
-                !this.props.disabled && (
+              {this.props.outputMapping.get('destination') !== '' && (
                 <DeleteButton
                   tooltip="Delete Output"
                   isPending={this.props.pendingActions.get(`delete-output-${this.props.mappingIndex}`)}
+                  isEnabled={!this.props.disabled}
                   confirm={{
                     title: 'Delete Output',
                     text: (
@@ -95,22 +95,21 @@ export default React.createClass({
                   }}
                 />
               )}
-              {!this.props.disabled && (
-                <OutputMappingModal
-                  transformationBucket={this.props.bucket}
-                  mode="edit"
-                  tables={this.props.tables}
-                  buckets={this.props.buckets}
-                  backend={this.props.transformation.get('backend')}
-                  type={this.props.transformation.get('type')}
-                  mapping={this.props.editingOutputMapping}
-                  onChange={this._handleChange}
-                  onCancel={this._handleCancel}
-                  onSave={this._handleSave}
-                  definition={this.props.definition}
-                  otherOutputMappings={this.props.otherOutputMappings}
-                />
-              )}
+              <OutputMappingModal
+                transformationBucket={this.props.bucket}
+                mode="edit"
+                tables={this.props.tables}
+                buckets={this.props.buckets}
+                backend={this.props.transformation.get('backend')}
+                type={this.props.transformation.get('type')}
+                mapping={this.props.editingOutputMapping}
+                onChange={this._handleChange}
+                onCancel={this._handleCancel}
+                onSave={this._handleSave}
+                definition={this.props.definition}
+                otherOutputMappings={this.props.otherOutputMappings}
+                disabled={this.props.disabled}
+              />
             </span>
           </span>
         </span>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/Packages.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/Packages.jsx
@@ -7,7 +7,14 @@ export default React.createClass({
     transformation: PropTypes.object.isRequired,
     packages: PropTypes.object.isRequired,
     isSaving: PropTypes.bool.isRequired,
-    onEditChange: PropTypes.func.isRequired
+    onEditChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false
+    };
   },
 
   render() {
@@ -20,13 +27,13 @@ export default React.createClass({
           <Select
             name="packages"
             value={this.props.packages}
-            multi={true}
-            disabled={this.props.isSaving}
+            multi
+            disabled={this.props.isSaving || this.props.disabled}
             onChange={this.props.onEditChange}
             placeholder="Add packages..."
             isLoading={this.props.isSaving}
-            allowCreate={true}
-            trimMultiCreatedValues={true}
+            allowCreate
+            trimMultiCreatedValues
           />
           <span className="help-block">
             {this.hint()}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/SavedFiles.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/SavedFiles.jsx
@@ -6,7 +6,14 @@ export default React.createClass({
   propTypes: {
     tags: PropTypes.object.isRequired,
     isSaving: PropTypes.bool.isRequired,
-    onEditChange: PropTypes.func.isRequired
+    onEditChange: PropTypes.func.isRequired,
+    disabled: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false
+    };
   },
 
   render() {
@@ -20,7 +27,7 @@ export default React.createClass({
             name="tags"
             value={this.props.tags}
             multi={true}
-            disabled={this.props.isSaving}
+            disabled={this.props.isSaving || this.props.disabled}
             onChange={this.props.onEditChange}
             placeholder="Add tags..."
             isLoading={this.props.isSaving}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/Scripts.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/Scripts.jsx
@@ -15,7 +15,14 @@ export default React.createClass({
     onDescriptionChange: PropTypes.func.isRequired,
     changeDescription: PropTypes.string.isRequired,
     onEditSubmit: PropTypes.func.isRequired,
-    isChanged: PropTypes.bool.isRequired
+    isChanged: PropTypes.bool.isRequired,
+    disabled: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false
+    };
   },
 
   render() {
@@ -41,7 +48,7 @@ export default React.createClass({
           isChanged={this.props.isChanged}
           onSave={this.props.onEditSubmit}
           onReset={this.props.onEditCancel}
-          disabled={!this.props.isEditingValid}
+          disabled={!this.props.isEditingValid || this.props.disabled}
           onDescriptionChange={this.props.onDescriptionChange}
           changeDescription={this.props.changeDescription}
         />

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -182,6 +182,7 @@ export default React.createClass({
           transformation={this.props.transformation}
           transformations={this.props.transformations}
           isSaving={this.props.pendingActions.has('save-requires')}
+          disabled={this.isDisabled()}
           requires={this.props.editingFields.get('requires', this.props.transformation.get('requires'))}
           bucketId={this.props.bucketId}
           onEditChange={newValue => {
@@ -304,12 +305,13 @@ export default React.createClass({
                               pendingActions={this.props.pendingActions}
                               otherDestinations={this._inputMappingDestinations(key)}
                               definition={definition}
+                              disabled={this.isDisabled()}
                             />
                           </div>
                         }
                       >
                         <InputMappingDetail
-                          fill={true}
+                          fill
                           transformationBackend={this.props.transformation.get('backend')}
                           inputMapping={input}
                           tables={this.props.tables}
@@ -376,6 +378,7 @@ export default React.createClass({
                                 otherOutputMappings={this.props.transformation
                                   .get('output')
                                   .filter((otherOutputMapping, otherOutputMappingKey) => otherOutputMappingKey !== key)}
+                                disabled={this.isDisabled()}
                               />
                             </div>
                           }
@@ -402,6 +405,7 @@ export default React.createClass({
             <Packages
               transformation={this.props.transformation}
               isSaving={this.props.pendingActions.has('save-packages')}
+              disabled={this.isDisabled()}
               packages={this.props.editingFields.get('packages', this.props.transformation.get('packages', List()))}
               onEditChange={newValue => {
                 TransformationsActionCreators.updateTransformationEditingField(
@@ -420,6 +424,7 @@ export default React.createClass({
             <div>
               <SavedFiles
                 isSaving={this.props.pendingActions.has('save-tags')}
+                disabled={this.isDisabled()}
                 tags={this.props.editingFields.get('tags', this.props.transformation.get('tags', List()))}
                 onEditChange={newValue => {
                   TransformationsActionCreators.updateTransformationEditingField(
@@ -451,6 +456,7 @@ export default React.createClass({
           transformation={this.props.transformation}
           isEditing={this.props.editingFields.has('queriesString')}
           isSaving={this.props.pendingActions.has('save-queries')}
+          disabled={this.isDisabled()}
           scripts={this.props.editingFields.get('queriesString', this.props.transformation.get('queriesString'))}
           isEditingValid={this.props.isEditingValid}
           isChanged={this.props.editingFields.get('queriesChanged', false)}
@@ -507,6 +513,7 @@ export default React.createClass({
         transformation={this.props.transformation}
         isEditing={this.props.editingFields.has('queriesString')}
         isSaving={this.props.pendingActions.has('save-queries')}
+        disabled={this.isDisabled()}
         queries={this.props.editingFields.get('queriesString', this.props.transformation.get('queriesString'))}
         splitQueries={this.props.editingFields.get('splitQueries', this.props.transformation.get('queries'))}
         isQueriesProcessing={this.props.isQueriesProcessing}
@@ -563,5 +570,11 @@ export default React.createClass({
         }}
       />
     );
+  },
+
+  isDisabled() {
+    const actions = this.props.pendingActions.delete('queries-processing');
+
+    return actions.count() > 0;
   }
 });


### PR DESCRIPTION
Fixes #2989

Reprodukce je třeba taková, že mám rozpracovanou Query, ale zjistím že mi chybí nějaká tabulka v IM, tak ji přidám a hned jak kliknu na přidat a zavře se mi modal, hned také uložím rozpracovanou Query. Odešlou se tak dva PUT requesty skoro souběžně a skončí to 500 error.

Hodně těch komponent měli `disabled` prop jen se třeba nepoužívala, tak nově jí používám. Některé to neměli tak jsem to přidal. Vše dělám podle `pendingActions`, kde jsem z toho akorát vyloučil `queries-processing` které nic neposílají na server. Nevím zda jsem ještě na něco nezapomněl co tam třeba přidat jako "vy jímku" aby to někde nezakazovalo edit blbě.