### PR TITLE
Storage Explorer - Unmount graphs components when is not active tab

### DIFF
--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -170,10 +170,12 @@ export default React.createClass({
                   canWriteTable={this.state.canWriteTable}
                 />
 
-                <LatestImports
-                  table={this.state.table}
-                  key={this.state.table.get('lastImportDate') || 'table-imports'}
-                />
+                {this.state.activeTab === 'overview' && (
+                  <LatestImports
+                    table={this.state.table}
+                    key={this.state.table.get('lastImportDate') || 'table-imports'}
+                  />
+                )}
 
                 <TableColumn
                   table={this.state.table}
@@ -217,10 +219,12 @@ export default React.createClass({
                 />
               </Tab.Pane>
               <Tab.Pane eventKey="graph">
-                <TableGraph
-                  key={this.state.table.get('lastImportDate') || 'table-graph'}
-                  table={this.state.table}
-                />
+                {this.state.activeTab === 'graph' && (
+                  <TableGraph
+                    key={this.state.table.get('lastImportDate') || 'table-graph'}
+                    table={this.state.table}
+                  />
+                )}
               </Tab.Pane>
             </Tab.Content>
           </div>


### PR DESCRIPTION
Fixes #2992

Koukal jsem že podobný problém `NS_ERROR_FAILURE` má kupa knihoven co pracují s grafy. Jde o to že firefox nějak jinak podporuje práci se svg za elementy co jsou za prvkem s `display: none`. Což u nás platí když je to pod taby. 

Stačí otevřít Storage ve Firefoxu a klikat mezi grafy, hned to tam začně házet errory. Nebo ještě víc pokud měním velikost okna. 

Řešení je tyto grafy vyhodit když nejsem na daném tabu. Na tabu "graph" by šla použít i props `unmountOnExit` co umí tab, ale aby to bylo jednotné s tím první (kde je graf na overview tak chci unmoutnout jen ten graf) tak to beru přes ten `activeTab`. 

Při překlikávání mezi taby teda musím vždy počkat na načtení dat a vykreslení ale co jsem koukal tak to je docela rychlé, nevím jak u většího projektu. Ale beztak nevidiím jiné řešení, možné to pak budou umět nějaké novější knihovny řešit lépe. Na to kreslení máme docela staré, ale to nebude tak snadné nahodit novější.