### PR TITLE
Storage Explorer - errorNotification

### DIFF
--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -1,4 +1,5 @@
 import Promise from 'bluebird';
+import _ from 'underscore';
 import dispatcher from '../../Dispatcher';
 import * as constants from '../components/Constants';
 import * as localConstants from './Constants';
@@ -12,6 +13,10 @@ import StorageApi from '../components/StorageApi';
 import exportTableApi from './ExportTableApi';
 
 const errorNotification = (message) => {
+  if (!_.isString(message)) {
+    throw message;
+  }
+
   ApplicationActionCreators.sendNotification({
     type: 'error',
     message: message


### PR DESCRIPTION
Fixes #2994

Jen kontroluji zda mám string, ono když dojde k Aborted třeba tak tam příjde objekt a padne to pak na vytváření notifikace. Takto to vyhodím a pokud je to Aborted tak si s tím poradí jiný handler.