### PR TITLE
Jobs List - Python/R/OpenRefine transformation - show configuration

### DIFF
--- a/src/scripts/modules/jobs/Routes.js
+++ b/src/scripts/modules/jobs/Routes.js
@@ -8,7 +8,7 @@ import JobDetailButtons from './react/components/JobDetailButtons';
 import JobsStore from './stores/JobsStore';
 import InstalledComponentsActionCreators from '../components/InstalledComponentsActionCreators';
 import { createTablesRoute } from '../table-browser/routes';
-import getComponentId from './getJobComponentId';
+import { getJobComponentId } from './utils';
 
 export default {
   name: 'jobs',
@@ -81,7 +81,7 @@ export default {
               job.hasIn(['params', 'config']) &&
               job.hasIn(['params', 'row'])
             ) {
-              return InstalledComponentsActionCreators.loadComponentConfigsData(getComponentId(job));
+              return InstalledComponentsActionCreators.loadComponentConfigsData(getJobComponentId(job));
             }
           })
       ],

--- a/src/scripts/modules/jobs/getJobComponentId.js
+++ b/src/scripts/modules/jobs/getJobComponentId.js
@@ -1,9 +1,0 @@
-/**
- * Returns componentId from job
- * First checks for component in params (docker and ex-generic uses this) then fallbacks to component attribute
- * @param {Object} job Job
- * @return {string} Component Id
- */
-export default function(job) {
-  return job.getIn(['params', 'component'], job.get('component'));
-}

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
@@ -9,7 +9,7 @@ import SoundNotifications from '../../../../../utils/SoundNotifications';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import JobsStore from '../../../stores/JobsStore';
-import { getJobComponentId, getUserConfiguredJob } from '../../../utils';
+import { getJobComponentId } from '../../../utils';
 import ComponentsStore from '../../../../components/stores/ComponentsStore';
 import InstalledComponentsStore from '../../../../components/stores/InstalledComponentsStore';
 import ConfigurationRowsStore from '../../../../configurations/ConfigurationRowsStore';
@@ -362,7 +362,7 @@ export default React.createClass({
   },
 
   _renderConfiguration(configurationJob) {
-    let job = getUserConfiguredJob(configurationJob);
+    let job = JobsStore.getUserRunnedParentJob(configurationJob);
 
     return (
       <div className="row">

--- a/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
+++ b/src/scripts/modules/jobs/react/pages/job-detail/JobDetail.jsx
@@ -9,6 +9,7 @@ import SoundNotifications from '../../../../../utils/SoundNotifications';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 import RoutesStore from '../../../../../stores/RoutesStore';
 import JobsStore from '../../../stores/JobsStore';
+import { getJobComponentId, getUserConfiguredJob } from '../../../utils';
 import ComponentsStore from '../../../../components/stores/ComponentsStore';
 import InstalledComponentsStore from '../../../../components/stores/InstalledComponentsStore';
 import ConfigurationRowsStore from '../../../../configurations/ConfigurationRowsStore';
@@ -18,7 +19,6 @@ import ComponentName from '../../../../../react/common/ComponentName';
 import ComponentIcon from '../../../../../react/common/ComponentIcon';
 import Duration from '../../../../../react/common/Duration';
 import JobRunId from '../../../../../react/common/JobRunId';
-import getComponentId from '../../../getJobComponentId';
 import JobStatusLabel from '../../../../../react/common/JobStatusLabel';
 import ComponentConfigurationLink from '../../../../components/react/components/ComponentConfigurationLink';
 import ComponentConfigurationRowLink from '../../../../components/react/components/ComponentConfigurationRowLink';
@@ -107,7 +107,7 @@ export default React.createClass({
     let message;
     const exceptionId = job.getIn(['result', 'exceptionId']);
     const parts = [];
-    const componentId = getComponentId(job);
+    const componentId = getJobComponentId(job);
     if (job.get('error') === APPLICATION_ERROR) {
       message = 'Internal Error';
     } else {
@@ -229,7 +229,7 @@ export default React.createClass({
   },
 
   _renderConfigurationLink(job) {
-    let componentId = getComponentId(job);
+    let componentId = getJobComponentId(job);
     let configuration = this._getConfiguration(job);
 
     if (configuration.count()) {
@@ -270,7 +270,7 @@ export default React.createClass({
   },
 
   _renderConfigurationRowLink(job) {
-    let componentId = getComponentId(job);
+    let componentId = getJobComponentId(job);
     let configuration = this._getConfiguration(job);
     let configId = configuration.get('id');
     let rowId = job.getIn(['params', 'transformations', 0], null);
@@ -361,40 +361,8 @@ export default React.createClass({
     );
   },
 
-  _renderConfiguration(job) {
-    if (job.get('nestingLevel') > 0 && !job.hasIn(['params', 'config'])) {
-      const runIdParts = job.get('runId', []).split('.')
-      let parentRunId = '';
-      let parentJob = null;
-
-      for (let index = 1; index <= runIdParts.length; index++) {
-        parentRunId = runIdParts.slice(0, index * -1).join('.');
-        parentJob = JobsStore.getAll().find((job) => {
-          return job.get('runId') === parentRunId && job.hasIn(['params', 'config']);
-        });
-
-        if (parentJob) {
-          break;
-        }
-      }
-
-      return (
-        <div className="row">
-          <span className="col-md-3">Configuration</span>
-          {parentJob && parentJob.count() > 0 ? (
-            <strong className="col-md-9">
-              {this._renderConfigurationLink(parentJob)}
-              {this._renderConfigurationRowLink(parentJob)}
-              {this._renderConfigVersion(parentJob)}
-            </strong>
-          ) : (
-            <strong className="col-md-9">
-              <em>N/A</em>
-            </strong>
-          )}
-        </div>
-      );
-    }
+  _renderConfiguration(configurationJob) {
+    let job = getUserConfiguredJob(configurationJob);
 
     return (
       <div className="row">
@@ -488,7 +456,7 @@ export default React.createClass({
   },
 
   _renderGeneralInfoRow(job) {
-    const componentId = getComponentId(job);
+    const componentId = getJobComponentId(job);
     let component = ComponentsStore.getComponent(componentId);
     if (!component) {
       component = ComponentsStore.unknownComponent(componentId);
@@ -533,7 +501,7 @@ export default React.createClass({
   },
 
   _isGoodDataWriter() {
-    return getComponentId(this.state.job) === 'gooddata-writer';
+    return getJobComponentId(this.state.job) === 'gooddata-writer';
   },
 
   _contactSupport() {
@@ -589,6 +557,6 @@ export default React.createClass({
   _getConfiguration(job) {
     const config = job.getIn(['params', 'config'], '');
 
-    return InstalledComponentsStore.getConfig(getComponentId(job), config.toString());
+    return InstalledComponentsStore.getConfig(getJobComponentId(job), config.toString());
   }
 });

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
@@ -74,8 +74,6 @@ export default React.createClass({
       const configId = job.getIn(['params', 'config']);
       const rowId = job.getIn(['params', 'transformations', 0], null);
 
-      console.log(TransformationsStore.getTransformationName(configId, rowId)); // eslint-disable-line
-
       if (rowId) {
         return (
           <span>

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobRow.jsx
@@ -10,19 +10,19 @@ import ComponentsStore from '../../../../components/stores/ComponentsStore';
 import InstalledComponentsStore from '../../../../components/stores/InstalledComponentsStore';
 import TransformationsStore from '../../../../transformations/stores/TransformationsStore';
 import date from '../../../../../utils/date';
-import { getJobComponentId, getUserConfiguredJob } from '../../../utils';
+import { getJobComponentId } from '../../../utils';
 
 export default React.createClass({
   mixins: [PureRenderMixin],
 
   propTypes: {
     job: React.PropTypes.object.isRequired,
+    userRunnedJob: React.PropTypes.object.isRequired,
     query: React.PropTypes.string.isRequired
   },
 
   render() {
     const component = this.getComponent();
-    const userConfiguredJob = getUserConfiguredJob(this.props.job);
 
     return (
       <Link className="tr" to="jobDetail" params={this.linkParams()} query={this.linkQuery()}>
@@ -31,8 +31,8 @@ export default React.createClass({
           <ComponentName component={component} showType />
         </div>
         <div className="td">
-          <JobPartialRunLabel job={userConfiguredJob} />
-          {this.jobConfiguration(userConfiguredJob)}
+          <JobPartialRunLabel job={this.props.userRunnedJob} />
+          {this.jobConfiguration(this.props.userRunnedJob)}
         </div>
         <div className="td">{this.props.job.getIn(['token', 'description'])}</div>
         <div className="td">{date.format(this.props.job.get('createdTime'))}</div>

--- a/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.jsx
+++ b/src/scripts/modules/jobs/react/pages/jobs-index/JobsIndex.jsx
@@ -74,7 +74,16 @@ export default React.createClass({
   },
 
   renderJob(job) {
-    return <JobRow job={job} key={job.get('id')} query={this.state.query} />;
+    const userRunnedJob = JobsStore.getUserRunnedParentJob(job);
+
+    return (
+      <JobRow 
+        key={job.get('id')} 
+        job={job}
+        userRunnedJob={userRunnedJob}
+        query={this.state.query} 
+      />
+    );
   },
 
   handleSearch(query) {

--- a/src/scripts/modules/jobs/stores/JobsStore.js
+++ b/src/scripts/modules/jobs/stores/JobsStore.js
@@ -74,6 +74,29 @@ const JobsStore = StoreUtils.createStore({
 
   getIsJobTerminating(jobId) {
     return _store.get('terminatingJobs').contains(jobId);
+  },
+
+  getUserRunnedParentJob(configurationJob) {
+    let job = configurationJob;
+
+    if (job.get('nestingLevel') > 0 && !job.hasIn(['params', 'config'])) {
+      const jobs = this.getAll();
+      const runIdParts = job.get('runId', []).split('.');
+      let parentRunId = '';
+      let parentJob = null;
+
+      for (let index = 1; index <= runIdParts.length; index++) {
+        parentRunId = runIdParts.slice(0, index * -1).join('.');
+        parentJob = jobs.find((job) => job.get('runId') === parentRunId && job.hasIn(['params', 'config']));
+
+        if (parentJob && parentJob.count() > 0) {
+          job = parentJob;
+          break;
+        }
+      }
+    }
+
+    return job;
   }
 });
 

--- a/src/scripts/modules/jobs/utils.js
+++ b/src/scripts/modules/jobs/utils.js
@@ -1,31 +1,5 @@
-import JobsStore from './stores/JobsStore';
-
 const getJobComponentId = (job) => {
   return job.getIn(['params', 'component'], job.get('component'));
 };
 
-const getUserConfiguredJob = (configurationJob) => {
-  let job = configurationJob;
-
-  if (job.get('nestingLevel') > 0 && !job.hasIn(['params', 'config'])) {
-    const runIdParts = job.get('runId', []).split('.');
-    let parentRunId = '';
-    let parentJob = null;
-
-    for (let index = 1; index <= runIdParts.length; index++) {
-      parentRunId = runIdParts.slice(0, index * -1).join('.');
-      parentJob = JobsStore.getAll().find((job) => {
-        return job.get('runId') === parentRunId && job.hasIn(['params', 'config']);
-      });
-
-      if (parentJob && parentJob.count() > 0) {
-        job = parentJob;
-        break;
-      }
-    }
-  }
-
-  return job;
-};
-
-export { getJobComponentId, getUserConfiguredJob };
+export { getJobComponentId };

--- a/src/scripts/modules/jobs/utils.js
+++ b/src/scripts/modules/jobs/utils.js
@@ -1,0 +1,31 @@
+import JobsStore from './stores/JobsStore';
+
+const getJobComponentId = (job) => {
+  return job.getIn(['params', 'component'], job.get('component'));
+};
+
+const getUserConfiguredJob = (configurationJob) => {
+  let job = configurationJob;
+
+  if (job.get('nestingLevel') > 0 && !job.hasIn(['params', 'config'])) {
+    const runIdParts = job.get('runId', []).split('.');
+    let parentRunId = '';
+    let parentJob = null;
+
+    for (let index = 1; index <= runIdParts.length; index++) {
+      parentRunId = runIdParts.slice(0, index * -1).join('.');
+      parentJob = JobsStore.getAll().find((job) => {
+        return job.get('runId') === parentRunId && job.hasIn(['params', 'config']);
+      });
+
+      if (parentJob && parentJob.count() > 0) {
+        job = parentJob;
+        break;
+      }
+    }
+  }
+
+  return job;
+};
+
+export { getJobComponentId, getUserConfiguredJob };


### PR DESCRIPTION
Fixes #1027

- helper `getJobComponentId` jsem hodil nově do `utils`, tam jsem přidal i tu novou funkci
- nově tam je teda také `getUserConfiguredJob` - název nevím zda je ok
- ještě jsem přidal hledání i ve `TransformationsStore` když mám transformační rowID do `JobRow`, je to tak podobně jaké v `JobDetail`

Asi by toho šlo extrahovat do utils ale to není cíl tohoto PR.