### PR TITLE
Storage Explorer - active table not marked after change

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/Buckets.jsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { ButtonGroup, Button } from 'react-bootstrap';
 import { RefreshIcon, SearchBar } from '@keboola/indigo-ui';
 
@@ -19,7 +18,6 @@ import { reload, createBucket, updateSearchQuery } from '../../Actions';
 
 export default React.createClass({
   mixins: [
-    ImmutableRenderMixin,
     createStoreMixin(ApplicationStore, RoutesStore, BucketsLocalStore, BucketsStore, TablesStore)
   ],
 


### PR DESCRIPTION
Fixes #3002

Asi nejlepší vyhodit ten mixin no. Tím že už máme i tu opravu RoutesStore tak editace popisku tabulky atd by měla běhat furt rychle. Možné i toto pomůže třeba při hledání, kdy se u každého písmenka nebudou porovnávat všechny věci a prostě se to rovnou překreslí.