### PR TITLE
StorageTableStore - getTable

### DIFF
--- a/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
@@ -21,7 +21,7 @@ export default React.createClass({
 
   getStateFromStores() {
     return {
-      table: TablesStore.get(this.props.tableId, Map())
+      table: TablesStore.getTable(this.props.tableId, Map())
     };
   },
 

--- a/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiTableLinkEx.jsx
@@ -21,7 +21,7 @@ export default React.createClass({
 
   getStateFromStores() {
     return {
-      table: TablesStore.getAll().get(this.props.tableId, Map())
+      table: TablesStore.get(this.props.tableId, Map())
     };
   },
 

--- a/src/scripts/modules/components/stores/StorageTablesStore.js
+++ b/src/scripts/modules/components/stores/StorageTablesStore.js
@@ -22,6 +22,10 @@ const StorageTablesStore = StoreUtils.createStore({
     return _store.get('tables').has(tableId);
   },
 
+  getTable(tableId, defaultValue) {
+    return _store.getIn(['tables', tableId], defaultValue);
+  },
+
   getIsLoading() {
     return _store.get('isLoading');
   },

--- a/src/scripts/modules/configurations/react/pages/Row.jsx
+++ b/src/scripts/modules/configurations/react/pages/Row.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
     const parseTableIdFn = settings.getIn(['row', 'parseTableId']);
     if (parseTableIdFn) {
       const tableId = parseTableIdFn(rowConfiguration);
-      const table = TablesStore.getAll().get(tableId);
+      const table = TablesStore.get(tableId);
       context = context.set('table', table).set('tableId', tableId);
     }
     const parseBySectionsFn = sections.makeParseFn(

--- a/src/scripts/modules/configurations/react/pages/Row.jsx
+++ b/src/scripts/modules/configurations/react/pages/Row.jsx
@@ -48,7 +48,7 @@ export default React.createClass({
     const parseTableIdFn = settings.getIn(['row', 'parseTableId']);
     if (parseTableIdFn) {
       const tableId = parseTableIdFn(rowConfiguration);
-      const table = TablesStore.get(tableId);
+      const table = TablesStore.getTable(tableId);
       context = context.set('table', table).set('tableId', tableId);
     }
     const parseBySectionsFn = sections.makeParseFn(

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
     const table = tables.get(tableId);
     const configProvisioning = makeConfigProvisioning(configurationId);
     const {isSaving, isPendingFn} = configProvisioning;
-    const storageTable = TablesStore.get(tableId);
+    const storageTable = TablesStore.getTable(tableId);
     const isPendingToggleExport = isPendingFn([tableId, 'activate']);
     const loadOnly = tableLoadSettingsAdapter(configProvisioning).value.loadOnly;
 

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/table/Table.jsx
@@ -42,7 +42,7 @@ export default React.createClass({
     const table = tables.get(tableId);
     const configProvisioning = makeConfigProvisioning(configurationId);
     const {isSaving, isPendingFn} = configProvisioning;
-    const storageTable = TablesStore.getAll().get(tableId);
+    const storageTable = TablesStore.get(tableId);
     const isPendingToggleExport = isPendingFn([tableId, 'activate']);
     const loadOnly = tableLoadSettingsAdapter(configProvisioning).value.loadOnly;
 

--- a/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
+++ b/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
 
     return {
       isSaving: InstalledComponentsStore.getSavingConfigData(componentId, configId),
-      table: StorageTablesStore.getAll().get(tableId),
+      table: StorageTablesStore.get(tableId),
       configId,
       tableId,
       columnsTypes: configData.getIn(['parameters', 'typedefs', tableId], Map()),

--- a/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
+++ b/src/scripts/modules/tde-exporter/react/components/TableHeaderButtons.jsx
@@ -38,7 +38,7 @@ export default React.createClass({
 
     return {
       isSaving: InstalledComponentsStore.getSavingConfigData(componentId, configId),
-      table: StorageTablesStore.get(tableId),
+      table: StorageTablesStore.getTable(tableId),
       configId,
       tableId,
       columnsTypes: configData.getIn(['parameters', 'typedefs', tableId], Map()),

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -42,7 +42,7 @@ export default componentId => {
       const configId = RoutesStore.getCurrentRouteParam('config');
       const tableId = RoutesStore.getCurrentRouteParam('tableId');
       const tableConfig = WrDbStore.getTableConfig(componentId, configId, tableId);
-      const storageTableColumns = StorageTablesStore.getAll().getIn([tableId, 'columns'], List());
+      const storageTableColumns = StorageTablesStore.get(tableId, Map()).get('columns', List());
       const localState = InstalledComponentsStore.getLocalState(componentId, configId);
       const tablesExportInfo = WrDbStore.getTables(componentId, configId);
       const exportInfo = tablesExportInfo.find(tab => tab.get('id') === tableId);

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -42,7 +42,7 @@ export default componentId => {
       const configId = RoutesStore.getCurrentRouteParam('config');
       const tableId = RoutesStore.getCurrentRouteParam('tableId');
       const tableConfig = WrDbStore.getTableConfig(componentId, configId, tableId);
-      const storageTableColumns = StorageTablesStore.get(tableId, Map()).get('columns', List());
+      const storageTableColumns = StorageTablesStore.getTable(tableId, Map()).get('columns', List());
       const localState = InstalledComponentsStore.getLocalState(componentId, configId);
       const tablesExportInfo = WrDbStore.getTables(componentId, configId);
       const exportInfo = tablesExportInfo.find(tab => tab.get('id') === tableId);


### PR DESCRIPTION
Jen jsem přidal `getTable` abych nemusel vždy volat `getAll().get()`. Je to více intuitivní.