### PR TITLE
Limit use "...this.props" on react-select

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
+++ b/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
@@ -146,6 +146,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={true}
             emptyStrings={false}
@@ -157,6 +158,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
             onChange={[Function]}
             options={Array []}
             placeholder="All columns will be imported"
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Array []}
             valueKey="value"
@@ -207,6 +209,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={true}
             emptyStrings={false}
@@ -218,6 +221,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
             onChange={[Function]}
             options={Array []}
             placeholder="Select column"
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -254,6 +258,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         >
           <Select
             allowCreate={true}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={true}
@@ -264,6 +269,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
             name="whereValues"
             onChange={[Function]}
             placeholder="Add a value..."
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -490,6 +496,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -501,6 +508,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
             onChange={[Function]}
             options={Array []}
             placeholder="All columns will be imported"
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Array []}
             valueKey="value"
@@ -551,6 +559,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -562,6 +571,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
             onChange={[Function]}
             options={Array []}
             placeholder="Select column"
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -598,6 +608,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
         >
           <Select
             allowCreate={true}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={true}
@@ -608,6 +619,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
             name="whereValues"
             onChange={[Function]}
             placeholder="Add a value..."
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -834,6 +846,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -845,6 +858,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
             onChange={[Function]}
             options={Array []}
             placeholder="All columns will be imported"
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Array []}
             valueKey="value"
@@ -895,6 +909,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -906,6 +921,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
             onChange={[Function]}
             options={Array []}
             placeholder="Select column"
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -943,6 +959,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={true}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={true}
@@ -953,6 +970,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
             name="whereValues"
             onChange={[Function]}
             placeholder="Add a value..."
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Immutable.List []}
             valueKey="value"
@@ -1179,6 +1197,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -1209,6 +1228,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
               ]
             }
             placeholder="All columns will be imported"
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Array []}
             valueKey="value"
@@ -1259,6 +1279,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={false}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={false}
@@ -1289,6 +1310,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
               ]
             }
             placeholder="Select column"
+            searchable={true}
             trimMultiCreatedValues={false}
             value=""
             valueKey="value"
@@ -1326,6 +1348,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         >
           <Select
             allowCreate={true}
+            clearable={true}
             delimiter=","
             disabled={false}
             emptyStrings={true}
@@ -1336,6 +1359,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
             name="whereValues"
             onChange={[Function]}
             placeholder="Add a value..."
+            searchable={true}
             trimMultiCreatedValues={false}
             value={Immutable.List []}
             valueKey="value"

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -1,5 +1,4 @@
 import React, {PropTypes} from 'react';
-import _ from 'underscore';
 import { fromJS } from 'immutable';
 import Select from 'react-select';
 
@@ -7,34 +6,46 @@ export default React.createClass({
   propTypes: {
     value: PropTypes.any,
     emptyStrings: PropTypes.bool,
+    multi: PropTypes.bool,
+    delimiter: PropTypes.string,
+    onChange: PropTypes.func.isRequired,
+    optionRenderer: PropTypes.func,
+    options: PropTypes.array,
+    searchable: PropTypes.bool,
+    clearable: PropTypes.bool,
+    autoFocus: PropTypes.bool,
+    disabled: PropTypes.bool,
+    name: PropTypes.string,
+    placeholder: PropTypes.string,
+    noResultsText: PropTypes.string,
+    promptTextCreator: PropTypes.func,
+
+    trimMultiCreatedValues: PropTypes.bool,
+    help: PropTypes.any,
     allowCreate: PropTypes.bool,
     ignoreCase: PropTypes.bool,
-    multi: PropTypes.bool,
     matchProp: PropTypes.string,
     labelKey: PropTypes.string,
     valueKey: PropTypes.string,
     matchPos: PropTypes.string,
-    help: PropTypes.any,
-    delimiter: PropTypes.string,
-    trimMultiCreatedValues: PropTypes.bool,
-    onChange: PropTypes.func.isRequired,
-    optionRenderer: PropTypes.func,
-    options: PropTypes.array,
-    filterOption: PropTypes.func
+    filterOption: PropTypes.func,
   },
 
   getDefaultProps() {
     return {
-      trimMultiCreatedValues: false,
       value: '',
       emptyStrings: false,
-      allowCreate: false,
       multi: false,
+      delimiter: ',',
+      trimMultiCreatedValues: false,
+      searchable: true,
+      clearable: true,
+      disabled: false,
+      allowCreate: false,
       ignoreCase: true,
       matchProp: 'any',
       labelKey: 'label',
       valueKey: 'value',
-      delimiter: ','
     };
   },
 
@@ -126,7 +137,18 @@ export default React.createClass({
       return (
         <span>
           <Select.Creatable
-            {...this.selectProps()}
+            emptyStrings={this.props.emptyStrings}
+            multi={this.props.multi}
+            delimiter={this.props.delimiter}
+            optionRenderer={this.props.optionRenderer}
+            searchable={this.props.searchable}
+            clearable={this.props.clearable}
+            autoFocus={this.props.autoFocus}
+            disabled={this.props.disabled}
+            name={this.props.name}
+            placeholder={this.props.placeholder}
+            noResultsText={this.props.noResultsText}
+            promptTextCreator={this.props.promptTextCreator}
             isOptionUnique={this.isOptionUnique}
             value={this.props.value.toJS ? this.mapValues(this.props.value.toJS()) : this.mapValues(this.props.value)}
             valueRenderer={this.valueRenderer}
@@ -137,20 +159,31 @@ export default React.createClass({
           {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
         </span>
       );
-    } else {
-      return (
-        <span>
-          <Select
-            {...this.selectProps()}
-            value={this.props.value.toJS ? this.mapValues(this.props.value.toJS()) : this.mapValues(this.props.value)}
-            valueRenderer={this.valueRenderer}
-            filterOptions={this.filterOptions}
-            onChange={this.onChange}
-          />
-          {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
-        </span>
-      );
     }
+
+    return (
+      <span>
+        <Select
+          emptyStrings={this.props.emptyStrings}
+          multi={this.props.multi}
+          delimiter={this.props.delimiter}
+          optionRenderer={this.props.optionRenderer}
+          searchable={this.props.searchable}
+          clearable={this.props.clearable}
+          autoFocus={this.props.autoFocus}
+          disabled={this.props.disabled}
+          name={this.props.name}
+          placeholder={this.props.placeholder}
+          noResultsText={this.props.noResultsText}
+          promptTextCreator={this.props.promptTextCreator}
+          value={this.props.value.toJS ? this.mapValues(this.props.value.toJS()) : this.mapValues(this.props.value)}
+          valueRenderer={this.valueRenderer}
+          filterOptions={this.filterOptions}
+          onChange={this.onChange}
+        />
+        {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
+      </span>
+    );
   },
 
   onChange(selected) {
@@ -233,9 +266,5 @@ export default React.createClass({
     } else {
       return [];
     }
-  },
-
-  selectProps() {
-    return _.pick(this.props, Object.keys(Select.propTypes));
   }
 });

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -1,6 +1,7 @@
 import React, {PropTypes} from 'react';
+import _ from 'underscore';
+import { fromJS } from 'immutable';
 import Select from 'react-select';
-import Immutable from 'immutable';
 
 export default React.createClass({
   propTypes: {
@@ -93,7 +94,7 @@ export default React.createClass({
     }
 
     var filterOption = function(op) {
-      if (this.props.multi && exclude && Immutable.fromJS(exclude).toMap().find(function(item) {
+      if (this.props.multi && exclude && fromJS(exclude).toMap().find(function(item) {
         return item.get('value') === op.value;
       }, op)) {
         return false;
@@ -125,8 +126,8 @@ export default React.createClass({
       return (
         <span>
           <Select.Creatable
+            {...this.selectProps()}
             isOptionUnique={this.isOptionUnique}
-            {...this.props}
             value={this.props.value.toJS ? this.mapValues(this.props.value.toJS()) : this.mapValues(this.props.value)}
             valueRenderer={this.valueRenderer}
             filterOptions={this.filterOptions}
@@ -140,7 +141,7 @@ export default React.createClass({
       return (
         <span>
           <Select
-            {...this.props}
+            {...this.selectProps()}
             value={this.props.value.toJS ? this.mapValues(this.props.value.toJS()) : this.mapValues(this.props.value)}
             valueRenderer={this.valueRenderer}
             filterOptions={this.filterOptions}
@@ -155,7 +156,7 @@ export default React.createClass({
   onChange(selected) {
     const {trimMultiCreatedValues} = this.props;
     if (this.props.multi) {
-      this.props.onChange(Immutable.fromJS(selected.map(function(value) {
+      this.props.onChange(fromJS(selected.map(function(value) {
         if (value.value === '%_EMPTY_STRING_%') {
           return '';
         }
@@ -232,6 +233,9 @@ export default React.createClass({
     } else {
       return [];
     }
-  }
+  },
 
+  selectProps() {
+    return _.pick(this.props, Object.keys(Select.propTypes));
+  }
 });

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -180,6 +180,7 @@ export default React.createClass({
           valueRenderer={this.valueRenderer}
           filterOptions={this.filterOptions}
           onChange={this.onChange}
+          options={this.props.options}
         />
         {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
       </span>

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -138,7 +138,6 @@ export default React.createClass({
       return (
         <span>
           <Select.Creatable
-            emptyStrings={this.props.emptyStrings}
             multi={this.props.multi}
             delimiter={this.props.delimiter}
             optionRenderer={this.props.optionRenderer}
@@ -166,7 +165,6 @@ export default React.createClass({
     return (
       <span>
         <Select
-          emptyStrings={this.props.emptyStrings}
           multi={this.props.multi}
           delimiter={this.props.delimiter}
           optionRenderer={this.props.optionRenderer}

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -29,6 +29,7 @@ export default React.createClass({
     valueKey: PropTypes.string,
     matchPos: PropTypes.string,
     filterOption: PropTypes.func,
+    isLoading: PropTypes.bool,
   },
 
   getDefaultProps() {
@@ -155,6 +156,7 @@ export default React.createClass({
             filterOptions={this.filterOptions}
             onChange={this.onChange}
             options={this.props.options || []}
+            isLoading={this.props.isLoading}
           />
           {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
         </span>
@@ -181,6 +183,7 @@ export default React.createClass({
           filterOptions={this.filterOptions}
           onChange={this.onChange}
           options={this.props.options}
+          isLoading={this.props.isLoading}
         />
         {this.props.help ? (<span className="help-block">{this.props.help}</span>) : null}
       </span>


### PR DESCRIPTION
Related #1577

Přímo ten Input atd by bylo asi nadlouho nahradit, nebo vymyslet nějak jinak. Tak jsem si říkal zda nepůjde jen takto vyfiltrovat jen ty povolené props.

Vše je na stejný způsob:
```js
_.pick(this.props, Object.keys(SomeComponent.propTypes));
```

Kde by to mělo vrátil z props je vždy ty props, které jsou na dané komponentě definované. V novém Reactu se tak předejde těm varováním. 