### PR TITLE
Remove usage of React.DOM.a and React.DOM.span

### DIFF
--- a/src/scripts/modules/components/react/components/DeleteConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/DeleteConfigurationButton.jsx
@@ -59,7 +59,7 @@ export default React.createClass({
           text={text}
           buttonLabel="Move to Trash"
           onConfirm={this._handleDelete}
-          childrenRootElement={React.DOM.a}
+          childrenRootElement="a"
         >
           {this._renderIcon()}
           {' Move to Trash'}

--- a/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/index/Index.jsx
@@ -164,7 +164,7 @@ export default React.createClass({
                 buttonLabel="Upload"
                 buttonType="success"
                 onConfirm={this._handleProjectUpload}
-                childrenRootElement={React.DOM.a}
+                childrenRootElement="a"
               >
                 {this.state.writer.get('pendingActions', List()).contains('uploadProject') ? (
                   <Loader className="fa-fw" />
@@ -273,7 +273,7 @@ export default React.createClass({
                       buttonLabel="Optimize"
                       buttonType="primary"
                       onConfirm={this._handleOptimizeSLI}
-                      childrenRootElement={React.DOM.a}
+                      childrenRootElement="a"
                     >
                       <span>Optimize SLI hash</span>
                     </Confirm>
@@ -292,7 +292,7 @@ export default React.createClass({
                       }
                       buttonLabel="Reset"
                       onConfirm={this._handleProjectReset}
-                      childrenRootElement={React.DOM.a}
+                      childrenRootElement="a"
                     >
                       <span>Reset Project</span>
                     </Confirm>
@@ -313,7 +313,7 @@ export default React.createClass({
                   ]}
                   buttonLabel="Delete"
                   onConfirm={this._handleProjectDelete}
-                  childrenRootElement={React.DOM.a}
+                  childrenRootElement="a"
                 >
                   {this.state.writer.get('isDeleting') ? (
                     <Loader className="fa-fw" />

--- a/src/scripts/react/common/Confirm.jsx
+++ b/src/scripts/react/common/Confirm.jsx
@@ -8,6 +8,7 @@ export default React.createClass({
     onConfirm: React.PropTypes.func.isRequired,
     buttonLabel: React.PropTypes.string.isRequired,
     buttonType: React.PropTypes.string,
+    isLoading: React.PropTypes.bool,
     children: React.PropTypes.any,
     childrenRootElement: React.PropTypes.any
   },
@@ -46,6 +47,7 @@ export default React.createClass({
           onHide={this.closeModal}
           title={this.props.title}
           text={this.props.text}
+          isLoading={this.props.isLoading}
           onConfirm={this.props.onConfirm}
           buttonLabel={this.props.buttonLabel}
           buttonType={this.props.buttonType}

--- a/src/scripts/react/common/Confirm.jsx
+++ b/src/scripts/react/common/Confirm.jsx
@@ -15,7 +15,7 @@ export default React.createClass({
   getDefaultProps() {
     return {
       buttonType: 'danger',
-      childrenRootElement: React.DOM.span
+      childrenRootElement: 'span'
     };
   },
 
@@ -36,7 +36,21 @@ export default React.createClass({
   },
 
   render() {
-    const modal = <ConfirmModal show={this.state.showModal} onHide={this.closeModal} {...this.props} key="modal"/>;
-    return this.props.childrenRootElement({onClick: this.onButtonClick}, [this.props.children, modal]);
+    const Wrapper = this.props.childrenRootElement;
+
+    return (
+      <Wrapper onClick={this.onButtonClick}>
+        {this.props.children}
+        <ConfirmModal 
+          show={this.state.showModal} 
+          onHide={this.closeModal}
+          title={this.props.title}
+          text={this.props.text}
+          onConfirm={this.props.onConfirm}
+          buttonLabel={this.props.buttonLabel}
+          buttonType={this.props.buttonType}
+        />
+      </Wrapper>
+    )
   }
 });


### PR DESCRIPTION
Related #1577 

React 15 psal že tento přístup je také deprecated. Šlo bud použít nějakou novou knihovnu aby se zachovala funkčnost nebo přepsat takto. Našel jsem použití pouze tu tak myslím že lepší upravit.