### PR TITLE
GoodData writer - Cannot read property 'trim' of null

### DIFF
--- a/src/scripts/modules/gooddata-writer/react/pages/table/TableGdNameEdit.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/table/TableGdNameEdit.jsx
@@ -33,7 +33,7 @@ export default React.createClass({
       this.props.configurationId,
       this.props.table.get('id'),
       this.props.fieldName,
-      this.props.table.getIn(['editingFields', this.props.fieldName]).trim()
+      this.props.table.getIn(['editingFields', this.props.fieldName], '').trim()
     );
   },
 


### PR DESCRIPTION
Fixes #3056

Tam koukám byl edit a hned asi save (uběhla 1s), ikdyž jsme to zkoušel hned klikat třebe enterem, tak se mi vždy stihla propsat aktuální hodnota do storu. Tak nevím jak se to tam povedlo.

Přidal jsem default prázdný string, aby to nepadlo.