### PR TITLE
feat: clear state with namespace

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsApi.js
+++ b/src/scripts/modules/components/InstalledComponentsApi.js
@@ -138,6 +138,11 @@ const installedComponentsApi = {
       return response.body;
     });
   },
+  getConfigurationRow: function(componentId, configurationId, rowId) {
+    return createRequest('GET', 'components/' + componentId + '/configs/' + configurationId + '/rows/' + rowId).send().promise().then(function(response) {
+      return response.body;
+    });
+  },
   deleteConfigurationRow: function(componentId, configurationId, rowId, changeDescription) {
     const data = {
       changeDescription: changeDescription

--- a/src/scripts/modules/configurations/react/pages/Row.jsx
+++ b/src/scripts/modules/configurations/react/pages/Row.jsx
@@ -28,6 +28,7 @@ import SidebarJobsContainer from '../../../components/react/components/SidebarJo
 import isParsableConfiguration from '../../utils/isParsableConfiguration';
 import sections from '../../utils/sections';
 import dockerActions from '../../DockerActionsActionCreators';
+import { isEmptyComponentState } from '../../utils/componentState';
 
 export default React.createClass({
   mixins: [createStoreMixin(Store, TablesStore, DockerActionsStore)],
@@ -98,9 +99,7 @@ export default React.createClass({
         Store.getPendingActions(componentId, configurationId, rowId).has('enable') ||
         Store.getPendingActions(componentId, configurationId, rowId).has('disable'),
 
-      hasState: !Store.get(componentId, configurationId, rowId)
-        .get('state', Immutable.Map())
-        .isEmpty(),
+      hasState: !isEmptyComponentState(Store.get(componentId, configurationId, rowId).get('state', Immutable.Map())),
       isClearStatePending: Store.getPendingActions(componentId, configurationId, rowId).has('clear-state')
     };
   },

--- a/src/scripts/modules/configurations/utils/componentState.js
+++ b/src/scripts/modules/configurations/utils/componentState.js
@@ -1,0 +1,29 @@
+import Immutable from 'immutable';
+
+const constants = {
+  COMPONENT_NAMESPACE_PREFIX: 'component'
+};
+
+const isEmptyComponentState = function(state) {
+  if (state.isEmpty()) {
+    return true;
+  }
+  if (state.has(constants.COMPONENT_NAMESPACE_PREFIX) && state.get(constants.COMPONENT_NAMESPACE_PREFIX).isEmpty()) {
+    return true;
+  }
+  return false;
+};
+
+const emptyComponentState = function(currentState) {
+  if (currentState.has('component')) {
+    return currentState.set(constants.COMPONENT_NAMESPACE_PREFIX, Immutable.Map());
+  } else {
+    return Immutable.fromJS({});
+  }
+};
+
+export {
+  constants,
+  isEmptyComponentState,
+  emptyComponentState
+}

--- a/src/scripts/modules/configurations/utils/componentState.spec.js
+++ b/src/scripts/modules/configurations/utils/componentState.spec.js
@@ -1,0 +1,53 @@
+import Immutable from 'immutable';
+import {emptyComponentState, isEmptyComponentState} from './componentState';
+
+
+describe('isEmptyComponentState', function() {
+  it('empty legacy state should return true', function() {
+    expect(true)
+      .toEqual(isEmptyComponentState(Immutable.fromJS({})));
+  });
+  it('nonempty legacy state should return false', function() {
+    expect(false)
+      .toEqual(isEmptyComponentState(Immutable.fromJS({key: 'value'})));
+  });
+  it('empty namespace state should return true', function() {
+    expect(true)
+      .toEqual(isEmptyComponentState(Immutable.fromJS({component: {}})));
+  });
+  it('empty namespace state with a sibling should return true', function() {
+    expect(true)
+      .toEqual(isEmptyComponentState(Immutable.fromJS({component: {}, key: 'value'})));
+  });
+  it('nonempty namespace state should return false', function() {
+    expect(false)
+      .toEqual(isEmptyComponentState(Immutable.fromJS({component: {key: 'value'}})));
+  });
+});
+
+describe('emptyComponentState', function() {
+  it('empty legacy state should return empty legacy state', function() {
+    expect({})
+      .toEqual(emptyComponentState(Immutable.fromJS({})).toJS());
+  });
+  it('nonempty legacy state should return empty legacy state', function() {
+    expect({})
+      .toEqual(emptyComponentState(Immutable.fromJS({key: 'value'})).toJS());
+  });
+  it('empty namespace state should return empty namespace state', function() {
+    expect({component: {}})
+      .toEqual(emptyComponentState(Immutable.fromJS({component: {}})).toJS());
+  });
+  it('empty namespace state with a sibling should keep the sibling', function() {
+    expect({component: {}, key: 'value'})
+      .toEqual(emptyComponentState(Immutable.fromJS({component: {}, key: 'value'})).toJS());
+  });
+  it('nonempty namespace state should return empty namespace state', function() {
+    expect({component: {}})
+      .toEqual(emptyComponentState(Immutable.fromJS({component: {key: 'value'}})).toJS());
+  });
+  it('nonempty namespace state with a sibling should keep the sibling end empty the namespace', function() {
+    expect({component: {}, key: 'value'})
+      .toEqual(emptyComponentState(Immutable.fromJS({component: {componentKey: 'componentValue'}, key: 'value'})).toJS());
+  });
+});


### PR DESCRIPTION
Fixes #3062

Proposed changes:

- tlačítko `Clear State` umí vymazat pouze namespace komponenty, pokud je namespace přítomen
- pokud state namespace nemá, na namespace to nemigruje (díky tomu je možné to nasadit ihned a nečekat)
- před uložením state se ještě znovu načte state (`InstalledComponentsApi.getConfigurationRow`), aby se nepřepisoval nějaký později uložený
- namespace prefix je konstanta

