### PR TITLE
Replace Raven with Sentry

### DIFF
--- a/src/scripts/utils/ReactErrorHandler.js
+++ b/src/scripts/utils/ReactErrorHandler.js
@@ -24,13 +24,10 @@ function logError(Component, error) {
 
   console.error(errorMsg, 'Error details:', error); // eslint-disable-line
 
-  /* global Raven */
-  if (!process.env.__DEV__ && typeof Raven !== 'undefined' && typeof Raven.captureException === 'function') {
-    Raven.captureException(new Error(errorMsg), {
-      extra: {
-        errorStack: error.stack
-      }
-    });
+  /* global Sentry */
+  if (!process.env.__DEV__ && typeof Sentry !== 'undefined' && typeof Sentry.captureException === 'function') {
+    Sentry.setExtra('errorStack', error.stack);
+    Sentry.captureException(new Error(errorMsg));
   }
 }
 

--- a/src/scripts/utils/ReactErrorHandler.js
+++ b/src/scripts/utils/ReactErrorHandler.js
@@ -26,7 +26,9 @@ function logError(Component, error) {
 
   /* global Sentry */
   if (!process.env.__DEV__ && typeof Sentry !== 'undefined' && typeof Sentry.captureException === 'function') {
-    Sentry.setExtra('errorStack', error.stack);
+    Sentry.configureScope((scope) => {
+      scope.setExtra('errorStack', error.stack);
+    })
     Sentry.captureException(new Error(errorMsg));
   }
 }


### PR DESCRIPTION
Koukal jsem že na konci minulého roku byla vydána nové verze Sentry (Ravenu).

https://github.com/getsentry/sentry-javascript/releases/tag/4.0.0

aktuální verze podle dokumentace: https://browser.sentry-cdn.com/4.6.4/bundle.min.js

My máme verzi 3.17.0. Poslední aktuální verze 3 je tuším někde kolem 3.26.0, to by už mohl být dobrý update a nebylo by potřeba nic měnit v UI. Oni tam mají kupu bugfixů či nových funkcí.

Nicméně pak právě byla vydána verze 4 kde se to přejmenovalo na Sentry browser. Tam už je potřeba upravit kód víc ale myslím že i tak těch úprav je minimum.

V rámci UI to je jen to co jde zde v PR:

https://github.com/getsentry/sentry-javascript/tree/master/packages/browser#usage

V rámci inicializace (změna v connection) je potřeba upravit kód cca takto:

```js
Sentry.init({
  dsn: 'URL',
  release: 'RELEASE'
});

Sentry.configureScope((scope) => {
  scope.setUser({ id: 'ID' });
});
```

Pak by to šlo ještě posunout dále. Pokud by si mi do `process.env` poslal api klíč, tak bych mohl napojit Sentry na webpack build. A mohly by se odesílat sourcemap soubory do sentry. Pak nám zobrazí kupu chyb lépe.

https://github.com/getsentry/sentry-webpack-plugin
