### PR TITLE
Storage Explorer - Table Export - Cannot read property 'url' of undefined

### DIFF
--- a/src/scripts/modules/components/StorageApi.js
+++ b/src/scripts/modules/components/StorageApi.js
@@ -104,12 +104,12 @@ export default {
   },
 
   getFilesWithRetry: function(params) {
-    const maxRetries = 3;
+    const maxRetries = 3; // total attempts = max retries + 1
 
     const withRetry = (attempt = 1) => {
       return this.getFiles(params)
         .then(files => {
-          if (files.length === 0 && attempt < maxRetries) {
+          if (files.length === 0 && attempt <= maxRetries) {
             return Promise.reject(new Error("No files found yet"));
           }
           return Promise.resolve(files);

--- a/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
@@ -70,12 +70,13 @@ export default React.createClass({
 
   handleSubmit(event) {
     event.preventDefault();
+    this.setState({ error: null });
     this.props.onSubmit().then(file => {
       this.setState({ url: file.url });
     }, this.handleError);
   },
 
-  handleError(message) {
-    this.setState({ error: message });
+  handleError(error) {
+    this.setState({ error: error.message ? error.message : error });
   }
 });

--- a/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
@@ -7,15 +7,15 @@ export default React.createClass({
     show: PropTypes.bool.isRequired,
     table: PropTypes.object.isRequired,
     onSubmit: PropTypes.func.isRequired,
-    onHide: PropTypes.func.isRequired,
-    isExporting: PropTypes.bool.isRequired
+    onHide: PropTypes.func.isRequired
   },
 
   getInitialState() {
     return {
       file: null,
       url: '',
-      error: null
+      error: null,
+      isExporting: false
     };
   },
 
@@ -36,7 +36,7 @@ export default React.createClass({
           </Modal.Body>
           <Modal.Footer>
             <ButtonToolbar>
-              {this.props.isExporting && (
+              {this.state.isExporting && (
                 <span>
                   <Loader />{' '}
                 </span>
@@ -49,7 +49,7 @@ export default React.createClass({
                   <i className="fa fa-download" /> Download
                 </ExternalLink>
               ) : (
-                <Button type="submit" bsStyle="success" disabled={this.props.isExporting}>
+                <Button type="submit" bsStyle="success" disabled={this.state.isExporting}>
                   Export
                 </Button>
               )}
@@ -70,10 +70,19 @@ export default React.createClass({
 
   handleSubmit(event) {
     event.preventDefault();
-    this.setState({ error: null });
-    this.props.onSubmit().then(file => {
-      this.setState({ url: file.url });
-    }, this.handleError);
+    this.setState({
+      error: null,
+      isExporting: true
+    });
+    this.props.onSubmit()
+      .then(file => {
+        this.setState({ url: file.url });
+      }, this.handleError)
+      .finally(() => {
+        this.setState({
+          isExporting: false
+        })
+      });
   },
 
   handleError(message) {

--- a/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/ExportTableModal.jsx
@@ -76,7 +76,7 @@ export default React.createClass({
     }, this.handleError);
   },
 
-  handleError(error) {
-    this.setState({ error: error.message ? error.message : error });
+  handleError(message) {
+    this.setState({ error: message });
   }
 });

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -355,7 +355,7 @@ export default React.createClass({
         })
         .then(files => {
           if (!files || files.length === 0) {
-            return Promise.reject('Loading a file for download failed. Please try it again.');
+            return Promise.reject('Loading a file for download failed. Please try again.');
           }
 
           return files[0]

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -349,7 +349,7 @@ export default React.createClass({
 
     return exportTable(tableId).then(response => {
       return StorageApi
-        .getFiles({
+        .getFilesWithRetry({
           runId: response.runId,
           'tags[]': ['storage-merged-export']
         })

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -305,7 +305,6 @@ export default React.createClass({
         table={this.state.table}
         onSubmit={this.handleExportTable}
         onHide={this.closeActionModal}
-        isExporting={this.state.exportingTable}
       />
     );
   },

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Promise from 'bluebird';
 import { Map } from 'immutable';
 import { Tab, Nav, NavItem, NavDropdown, MenuItem, Row } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
@@ -353,8 +354,8 @@ export default React.createClass({
           'tags[]': ['storage-merged-export']
         })
         .then(files => {
-          if (!files || files.length === 0) {
-            throw new Error('Loading a file for download failed. Please try it again.');
+          if (!files || files.length === 1) {
+            return Promise.reject('Loading a file for download failed. Please try it again.');
           }
 
           return files[0]

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -352,7 +352,13 @@ export default React.createClass({
           runId: response.runId,
           'tags[]': ['storage-merged-export']
         })
-        .then(files => files[0]);
+        .then(files => {
+          if (!files || files.length === 0) {
+            throw new Error('Loading a file for download failed. Please try it again.');
+          }
+
+          return files[0]
+        });
     });
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -354,7 +354,7 @@ export default React.createClass({
           'tags[]': ['storage-merged-export']
         })
         .then(files => {
-          if (!files || files.length === 1) {
+          if (!files || files.length === 0) {
             return Promise.reject('Loading a file for download failed. Please try it again.');
           }
 


### PR DESCRIPTION
Fixes #3067

Jakto že hned po exportu může nastat situace že to nevrátí žádný soubor? 

Každopádně jsem tam přidal kontrolu zda mám nějaké soubory a pokud ne tak to nepustím dále.

Původně jsem tam měl `throw new Error(message)` ale nakonec jsem to přepsal na `Promise.reject(message)`, nevím jaké řešení je lepší. Díky tomu reject jsem nemusel upravovat ten handler přímo v komponentě, kde se čeká přímo message a ne Error objekt.