### PR TITLE
ErrorPage - Better error text when the error is string

### DIFF
--- a/src/scripts/modules/wr-db/templates/dockerProxyApi.js
+++ b/src/scripts/modules/wr-db/templates/dockerProxyApi.js
@@ -277,7 +277,7 @@ export default function(componentId) {
           const tables = data.getIn(['parameters', 'tables'], List());
           var table = tables.find( (t) => t.get('tableId') === tableId);
           if (!table) {
-            return Promise.reject('Error: table ' + tableId + ' not exits in the config');
+            return Promise.reject('Table ' + tableId + ' not exits in the config');
           }
           const columns = table.get('items', List()).map((c) => {
             return c.set('null', c.get('nullable', false) ? '1' : '0');

--- a/src/scripts/utils/Error.js
+++ b/src/scripts/utils/Error.js
@@ -1,4 +1,5 @@
 import { OperationalError } from 'bluebird';
+import _ from 'underscore';
 import HttpError from './HttpError';
 import { REQUEST_ABORTED_ERROR } from '../constants/superagent';
 
@@ -55,6 +56,8 @@ const createFromException = exception => {
   } else if (error instanceof OperationalError || error.isOperational) {
     // error from bluebird
     return new Error('Connection error', error.message);
+  } else if (_.isString(error)) {
+    return new Error('Error', error);
   }
 
   return new Error('Application error', 'Please try reload the browser');


### PR DESCRIPTION
Tady na to jdu možné z druhé strany, dyštak se upraví.

Pokud smažu tabulku a pak jdu na editor ve `wr-db`, je tam Reject s textem chyby. Díky tomu že to je pouze text, tak se to pak zobrazí uživateli dost neurčitě.
Nevím zda je lepší to předělat tak, aby místo reject tam byl nějaký Error, ten už umíme líp zobrazit, nebo obecněji kontrolovat zda samotný error není string a případně zobrazit to. To by mohlo řešit více situací i v budoucnu.

Před:
![pred](https://user-images.githubusercontent.com/12331181/54200964-cfb0d300-44cc-11e9-916b-1d3f570fe02c.png)

Po:
![po](https://user-images.githubusercontent.com/12331181/54200926-b9a31280-44cc-11e9-9f34-6deefd88d0c3.png)
