### PR TITLE
wrgdv3: fix disable/enable create gd production project option

### DIFF
--- a/src/scripts/modules/gooddata-writer-v3/react/components/NewProjectForm.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/NewProjectForm.jsx
@@ -99,7 +99,7 @@ export default React.createClass({
           </div>
           <div>
             <Radio
-              disabled={this.props.canCreateProdProject || disabled}
+              disabled={!this.props.canCreateProdProject || disabled}
               value={TokenTypes.PRODUCTION}
               onChange={e => this.handleChange({tokenType: e.target.value})}
               checked={tokenType === TokenTypes.PRODUCTION}


### PR DESCRIPTION
Tato uprava spravne povoli/zakaze create gooddata production project ak to ma nastavene v limitoch. Chyba bola len v podmienke pre disabled property tak som ju znegoval `!this.props.canCreateProdProject`
![image](https://user-images.githubusercontent.com/1412120/54209960-f546d800-44de-11e9-839b-704e81e65afc.png)
