### PR TITLE
Storage Explorer - DataSample - data preview return null

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -174,7 +174,7 @@ export default React.createClass({
 
     this.cancellablePromise = dataPreview(this.props.table.get('id'), params)
       .then(json => {
-        this.setState({ data: json, loading: false });
+        this.setState({ data: json || [], loading: false });
       })
       .catch((error) => {
         let errorMessage = null;

--- a/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/DataSample.jsx
@@ -12,7 +12,7 @@ export default React.createClass({
 
   getInitialState() {
     return {
-      data: [],
+      data: {},
       error: null,
       loading: false,
       filtered: false,
@@ -174,7 +174,7 @@ export default React.createClass({
 
     this.cancellablePromise = dataPreview(this.props.table.get('id'), params)
       .then(json => {
-        this.setState({ data: json || [], loading: false });
+        this.setState({ data: json || {}, loading: false });
       })
       .catch((error) => {
         let errorMessage = null;
@@ -187,7 +187,7 @@ export default React.createClass({
         }
 
         this.setState({
-          data: [],
+          data: {},
           loading: false,
           error: errorMessage
         });


### PR DESCRIPTION
Fixes #3079

Divné že tam je normal 200 status code ale asi to vrátilo `null`, já to tam rovnou přiřazuji a pak to končí errory. Tady jen jednoduchý fallback na prázdné pole (default hodnota).