### PR TITLE
Do not use PureRenderMixin name for "react-immutable-render-mixin"

### DIFF
--- a/src/scripts/modules/components/react/components/ColumnDataPreview.jsx
+++ b/src/scripts/modules/components/react/components/ColumnDataPreview.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import PureRenderMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { fromJS } from 'immutable';
 import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 import { truncate } from 'underscore.string';
 
 export default React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [ImmutableRenderMixin],
 
   propTypes: {
     columnName: React.PropTypes.string.isRequired,

--- a/src/scripts/modules/gooddata-writer/react/pages/table/DatasetColumnEditorRow.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/table/DatasetColumnEditorRow.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Map, fromJS } from 'immutable';
 import keyMirror from 'fbjs/lib/keyMirror';
-import PureRenderMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { FormControl, InputGroup, FormGroup } from 'react-bootstrap';
 import ColumnDataPreview from '../../../../components/react/components/ColumnDataPreview';
 import { ColumnTypes, DataTypes, SortOrderOptions } from '../../../constants';
@@ -19,7 +19,7 @@ const visibleParts = keyMirror({
 });
 
 export default React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [ImmutableRenderMixin],
   propTypes: {
     column: React.PropTypes.object.isRequired,
     referenceableColumns: React.PropTypes.object.isRequired,

--- a/src/scripts/modules/gooddata-writer/react/pages/table/DateFormatHint.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/table/DateFormatHint.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Popover, OverlayTrigger } from 'react-bootstrap';
-import PureRenderMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 
 export default React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [ImmutableRenderMixin],
   render() {
     return (
       <OverlayTrigger overlay={this._renderPopover()}>

--- a/src/scripts/modules/tde-exporter/react/pages/Table/DateFormatHint.jsx
+++ b/src/scripts/modules/tde-exporter/react/pages/Table/DateFormatHint.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import PureRenderMixin from 'react-immutable-render-mixin';
+import ImmutableRenderMixin from 'react-immutable-render-mixin';
 import { OverlayTrigger, Popover } from 'react-bootstrap';
 
 export default React.createClass({
-  mixins: [PureRenderMixin],
+  mixins: [ImmutableRenderMixin],
 
   render() {
     return (


### PR DESCRIPTION
Super drobnost, mergnu po testech. Říkal jsme asi aby to nemátlo pak React-Codemod, je tam že to hledá název "PureRenderMixin" při nějaké transformaci. Pravda že asi při jiné než co chceme použít my ale pro jistotu a přehlednot to tu pojmenuji správně.