### PR TITLE
delete GoodData provisioned project when deleting GoodData writer config

### DIFF
--- a/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
+++ b/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
@@ -6,6 +6,7 @@ import ConfigurationLink from '../components/ComponentConfigurationLink';
 import RunConfigurationButton from '../components/RunComponentButton';
 import DeleteButton from '../../../../react/common/DeleteButton';
 import DeleteConfigurationButtonNoConfirm from '../../../../react/common/DeleteConfigurationButtonNoConfirm';
+import DeleteGoodDataWriterButton from '../../../gooddata-writer-v3/react/components/DeleteGoodDataWriterButton';
 import InstalledComponentsActionCreators from '../../InstalledComponentsActionCreators';
 import descriptionExcerpt from '../../../../utils/descriptionExcerpt';
 import {isObsoleteComponent} from '../../../../modules/trash/utils';
@@ -42,23 +43,42 @@ export default createReactClass({
               createdTime={this.props.config.get('created')}
             />
           </span>
-          {isObsoleteComponent(this.props.componentId) ? (
-            <DeleteButton
-              tooltip="Move to Trash"
-              isPending={this.props.isDeleting}
-              confirm={this.deleteConfirmProps()}
-            />
-          ) : (
-            <DeleteConfigurationButtonNoConfirm
-              tooltip="Move to Trash"
-              isPending={this.props.isDeleting}
-              onDeleteFn={this.handleDelete}
-            />
-          )}
+          {this.renderDeleteButton()}
           {this.renderRunButton()}
         </span>
       </ConfigurationLink>
     );
+  },
+
+  renderDeleteButton() {
+    if (this.props.componentId === 'keboola.gooddata-writer') {
+      return (
+        <DeleteGoodDataWriterButton
+          configId={this.props.config.get('id')}
+          deleteConfigFn={this.handleDelete}
+          isDeletingConfig={this.props.isDeleting}
+        />
+      );
+    }
+
+    if (isObsoleteComponent(this.props.componentId)) {
+      return (
+        <DeleteButton
+          tooltip="Move to Trash"
+          isPending={this.props.isDeleting}
+          confirm={this.deleteConfirmProps()}
+        />
+      );
+
+    } else {
+      return (
+        <DeleteConfigurationButtonNoConfirm
+          tooltip="Move to Trash"
+          isPending={this.props.isDeleting}
+          onDeleteFn={this.handleDelete}
+        />
+      );
+    }
   },
 
   renderRunButton() {

--- a/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
+++ b/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
@@ -13,6 +13,10 @@ import {isObsoleteComponent} from '../../../../modules/trash/utils';
 import CreatedWithIcon from '../../../../react/common/CreatedWithIcon';
 import componentNameAsString from '../../../../react/common/componentNameAsString';
 
+import InstalledComponentsActions from '../../InstalledComponentsActionCreators';
+import InstalledComponentsStore from '../../stores/InstalledComponentsStore';
+
+
 export default createReactClass({
   mixins: [PureRenderMixin],
   propTypes: {
@@ -51,10 +55,17 @@ export default createReactClass({
   },
 
   renderDeleteButton() {
-    if (this.props.componentId === 'keboola.gooddata-writer') {
+    const {componentId} = this.props;
+    if (componentId === 'keboola.gooddata-writer') {
+      const configId = this.props.config.get('id');
       return (
         <DeleteGoodDataWriterButton
           config={this.props.config}
+          getConfigDataFn={() =>
+            InstalledComponentsActions
+              .loadComponentConfigData(componentId, configId)
+              .then(() => InstalledComponentsStore.getConfigData(componentId, configId))
+          }
           deleteConfigFn={this.handleDelete}
           isDeletingConfig={this.props.isDeleting}
         />

--- a/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
+++ b/src/scripts/modules/components/react/pages/ConfigurationRow.jsx
@@ -54,7 +54,7 @@ export default createReactClass({
     if (this.props.componentId === 'keboola.gooddata-writer') {
       return (
         <DeleteGoodDataWriterButton
-          configId={this.props.config.get('id')}
+          config={this.props.config}
           deleteConfigFn={this.handleDelete}
           isDeletingConfig={this.props.isDeleting}
         />

--- a/src/scripts/modules/gooddata-writer-v3/configProvisioning.js
+++ b/src/scripts/modules/gooddata-writer-v3/configProvisioning.js
@@ -7,6 +7,7 @@ const COMPONENT_ID = 'keboola.gooddata-writer';
 const INPUT_MAPPING_PATH = ['storage', 'input', 'tables'];
 
 export default function(configId) {
+  const config = InstalledComponentStore.getConfig(COMPONENT_ID, configId);
   const configData = InstalledComponentStore.getConfigData(COMPONENT_ID, configId) || Map();
   const { getLocalState, updateLocalState, deleteLocalStatePath } = localStateProvisioning(configId);
   const parameters = configData.get('parameters', Map());
@@ -47,6 +48,7 @@ export default function(configId) {
   }
 
   return {
+    config,
     configData,
     parameters,
     inputMapping,

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -5,9 +5,9 @@ import Tooltip from '../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../react/common/ConfirmModal';
 import InstalledComponentsActions from '../../../components/InstalledComponentsActionCreators';
 import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
-import { loadProvisioningData } from '../../../gooddata-writer-v3/goodDataProvisioning/utils';
+import { loadProvisioningData } from '../../../gooddata-writer-v3/gooddataProvisioning/utils';
 
-import GoodDataProvisioningActions from '../../../gooddata-writer-v3/goodDataProvisioning/actions';
+import GoodDataProvisioningActions from '../../../gooddata-writer-v3/gooddataProvisioning/actions';
 
 const COMPONENT_ID = 'keboola.gooddata-writer';
 

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { Button } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import Tooltip from '../../../../react/common/Tooltip';
+import ConfirmModal from '../../../../react/common/ConfirmModal';
+import InstalledComponentsActions from '../../../components/InstalledComponentsActionCreators';
+import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
+import { loadProvisioningData } from '../../../gooddata-writer-v3/goodDataProvisioning/utils';
+
+import GoodDataProvisioningActions from '../../../gooddata-writer-v3/goodDataProvisioning/actions';
+
+const COMPONENT_ID = 'keboola.gooddata-writer';
+
+export default React.createClass({
+  propTypes: {
+    configId: React.PropTypes.string.isRequired,
+    deleteConfigFn: React.PropTypes.func.isRequired,
+    isDeletingConfig: React.PropTypes.bool.isRequired,
+    renderWithCaption: React.PropTypes.bool
+  },
+
+  getInitialState() {
+    return {
+      showModal: false,
+      isDeletingProject: false,
+      loadingData: false,
+      pid: null
+    };
+  },
+
+  render() {
+    const loader = this.isPending() && <Loader />;
+    return this.props.renderWithCaption ? (
+      <a onClick={this.handleDelete}>
+        {this.renderConfirmModal()}
+        {loader || <span className="kbc-icon-cup fa fa-fw" />}
+        {' Move to Trash'}
+      </a>
+    ) : (
+      <Tooltip tooltip="Move To Trash" placement="top">
+        <Button bsStyle="link" onClick={this.handleDelete} disabled={!!loader}>
+          {this.renderConfirmModal()}
+          {loader || <i className="fa kbc-icon-cup" />}
+        </Button>
+      </Tooltip>
+    );
+  },
+
+  handleDelete(e) {
+    e.preventDefault();
+    e.stopPropagation();
+    const { configId, deleteConfigFn } = this.props;
+    const stopLoading = () => this.setState({ loadingData: false });
+    this.setState({ loadingData: true });
+    InstalledComponentsActions.loadComponentConfigData(COMPONENT_ID, configId)
+      .then(() => {
+        const configData = InstalledComponentsStore.getConfigData(COMPONENT_ID, configId);
+        const pid = configData.getIn(['parameters', 'project', 'pid']);
+        if (pid) {
+          return loadProvisioningData(pid).then((data) => {
+            if (data) {
+              return this.showExtraConfirmModal(pid);
+            } else {
+              return deleteConfigFn();
+            }
+          });
+        } else {
+          return deleteConfigFn();
+        }
+      })
+      .finally(stopLoading);
+  },
+
+  handleExtraConfirm() {
+    const { pid } = this.state;
+    this.setState({ isDeletingProject: true });
+    return GoodDataProvisioningActions.deleteProject(pid)
+      .then(() => {
+        this.closeModal();
+        return this.props.deleteConfigFn();
+      })
+      .finally(() => this.setState({ isDeletingProject: false }));
+  },
+
+  isPending() {
+    return this.props.isDeletingConfig || this.state.loadingData || this.state.isDeletingProject;
+  },
+
+  renderConfirmModal() {
+    const { pid } = this.state;
+    return (
+      <ConfirmModal
+        show={this.state.showModal}
+        onHide={this.closeModal}
+        title="Delete GoodData project and move configuration to Trash"
+        text={`This will also delete the GoodData project(${pid}). Delete the GoodData project and move the configuration to Trash?`}
+        isLoading={this.state.isDeletingProject}
+        onConfirm={() => this.handleExtraConfirm()}
+        buttonLabel="Delete project and  move to Trash"
+        buttonType="danger"
+      />
+    );
+  },
+
+  closeModal() {
+    this.setState({ showModal: false, pid: null });
+  },
+
+  showExtraConfirmModal(pid) {
+    this.setState({ showModal: true, pid });
+  }
+});

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -29,11 +29,11 @@ export default React.createClass({
   render() {
     const loader = this.isPending() && <Loader className="fa fa-fw" />;
     return this.props.renderWithCaption ? (
-      <a onClick={this.handleDelete}>
+      <button onClick={this.handleDelete} className="btn btn-link btn-block">
         {this.renderConfirmModal()}
         {loader || <span className="kbc-icon-cup fa fa-fw" />}
         {' Move to Trash'}
-      </a>
+      </button>
     ) : (
       <Tooltip tooltip="Move To Trash" placement="top">
         <Button bsStyle="link" onClick={this.handleDelete} disabled={!!loader}>

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -4,18 +4,15 @@ import { Button, Alert } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import Tooltip from '../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../react/common/ConfirmModal';
-import InstalledComponentsActions from '../../../components/InstalledComponentsActionCreators';
-import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
 import { loadProvisioningData } from '../../../gooddata-writer-v3/gooddataProvisioning/utils';
 
 import GoodDataProvisioningActions from '../../../gooddata-writer-v3/gooddataProvisioning/actions';
 
-const COMPONENT_ID = 'keboola.gooddata-writer';
-
 export default React.createClass({
   propTypes: {
-    config: PropTypes.object.isRequired,
+    config: PropTypes.func.isRequired,
     deleteConfigFn: PropTypes.func.isRequired,
+    getConfigDataFn: PropTypes.func.isRequired,
     isDeletingConfig: PropTypes.bool.isRequired,
     renderWithCaption: PropTypes.bool
   },
@@ -30,7 +27,7 @@ export default React.createClass({
   },
 
   render() {
-    const loader =  this.isPending() && <Loader className="fa fa-fw" />;
+    const loader = this.isPending() && <Loader className="fa fa-fw" />;
     return this.props.renderWithCaption ? (
       <a onClick={this.handleDelete}>
         {this.renderConfirmModal()}
@@ -51,12 +48,11 @@ export default React.createClass({
     e.preventDefault();
     e.stopPropagation();
     const { deleteConfigFn } = this.props;
-    const configId = this.props.config.get('id');
     const stopLoading = () => this.setState({ loadingData: false });
     this.setState({ loadingData: true });
-    InstalledComponentsActions.loadComponentConfigData(COMPONENT_ID, configId)
-      .then(() => {
-        const configData = InstalledComponentsStore.getConfigData(COMPONENT_ID, configId);
+    this.props
+      .getConfigDataFn()
+      .then((configData) => {
         const pid = configData.getIn(['parameters', 'project', 'pid']);
         if (pid) {
           return loadProvisioningData(pid).then((data) => {

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Button } from 'react-bootstrap';
+import { Button, Alert } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import Tooltip from '../../../../react/common/Tooltip';
 import ConfirmModal from '../../../../react/common/ConfirmModal';
@@ -13,7 +13,7 @@ const COMPONENT_ID = 'keboola.gooddata-writer';
 
 export default React.createClass({
   propTypes: {
-    configId: React.PropTypes.string.isRequired,
+    config: React.PropTypes.object.isRequired,
     deleteConfigFn: React.PropTypes.func.isRequired,
     isDeletingConfig: React.PropTypes.bool.isRequired,
     renderWithCaption: React.PropTypes.bool
@@ -49,7 +49,8 @@ export default React.createClass({
   handleDelete(e) {
     e.preventDefault();
     e.stopPropagation();
-    const { configId, deleteConfigFn } = this.props;
+    const { deleteConfigFn } = this.props;
+    const configId = this.props.config.get('id');
     const stopLoading = () => this.setState({ loadingData: false });
     this.setState({ loadingData: true });
     InstalledComponentsActions.loadComponentConfigData(COMPONENT_ID, configId)
@@ -87,16 +88,25 @@ export default React.createClass({
   },
 
   renderConfirmModal() {
-    const { pid } = this.state;
     return (
       <ConfirmModal
         show={this.state.showModal}
         onHide={this.closeModal}
-        title="Delete GoodData project and move configuration to Trash"
-        text={`This will also delete the GoodData project(${pid}). Delete the GoodData project and move the configuration to Trash?`}
+        title="Move Configuration to Trash"
+        text={(
+          <div>
+            <p>
+              Are you sure you want to move the configuration
+              {' '}<strong>{this.props.config.get('name')}</strong> to Trash?
+            </p>
+            <Alert bsStyle="warning">
+              This will also delete the GoodData project (PID: <code>{this.state.pid}</code>).
+            </Alert>
+          </div>
+        )}
         isLoading={this.state.isDeletingProject}
         onConfirm={() => this.handleExtraConfirm()}
-        buttonLabel="Delete project and  move to Trash"
+        buttonLabel="Move to Trash"
         buttonType="danger"
       />
     );

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import createReactClass from 'create-react-class';
 import { Button, Alert } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import Tooltip from '../../../../react/common/Tooltip';
@@ -8,7 +9,7 @@ import { loadProvisioningData } from '../../../gooddata-writer-v3/gooddataProvis
 
 import GoodDataProvisioningActions from '../../../gooddata-writer-v3/gooddataProvisioning/actions';
 
-export default React.createClass({
+export default createReactClass({
   propTypes: {
     config: PropTypes.object.isRequired,
     deleteConfigFn: PropTypes.func.isRequired,

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -30,7 +30,7 @@ export default React.createClass({
   },
 
   render() {
-    const loader = this.isPending() && <Loader />;
+    const loader =  this.isPending() && <Loader className="fa fa-fw" />;
     return this.props.renderWithCaption ? (
       <a onClick={this.handleDelete}>
         {this.renderConfirmModal()}
@@ -41,7 +41,7 @@ export default React.createClass({
       <Tooltip tooltip="Move To Trash" placement="top">
         <Button bsStyle="link" onClick={this.handleDelete} disabled={!!loader}>
           {this.renderConfirmModal()}
-          {loader || <i className="fa kbc-icon-cup" />}
+          {loader || <i className="fa fa-fw kbc-icon-cup" />}
         </Button>
       </Tooltip>
     );

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -10,7 +10,7 @@ import GoodDataProvisioningActions from '../../../gooddata-writer-v3/gooddataPro
 
 export default React.createClass({
   propTypes: {
-    config: PropTypes.func.isRequired,
+    config: PropTypes.object.isRequired,
     deleteConfigFn: PropTypes.func.isRequired,
     getConfigDataFn: PropTypes.func.isRequired,
     isDeletingConfig: PropTypes.bool.isRequired,

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DeleteGoodDataWriterButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 import { Button, Alert } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
@@ -13,10 +14,10 @@ const COMPONENT_ID = 'keboola.gooddata-writer';
 
 export default React.createClass({
   propTypes: {
-    config: React.PropTypes.object.isRequired,
-    deleteConfigFn: React.PropTypes.func.isRequired,
-    isDeletingConfig: React.PropTypes.bool.isRequired,
-    renderWithCaption: React.PropTypes.bool
+    config: PropTypes.object.isRequired,
+    deleteConfigFn: PropTypes.func.isRequired,
+    isDeletingConfig: PropTypes.bool.isRequired,
+    renderWithCaption: PropTypes.bool
   },
 
   getInitialState() {

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
@@ -83,7 +83,8 @@ export default createReactClass({
       tables,
       deleteTable,
       createNewTable,
-      toggleTableExport
+      toggleTableExport,
+      configProvisioning
     };
   },
 
@@ -121,7 +122,7 @@ export default createReactClass({
             <li>
               <DeleteGoodDataWriterButton
                 renderWithCaption={true}
-                configId={this.state.configurationId}
+                config={this.state.configProvisioning.config}
                 deleteConfigFn={() => InstalledComponentsActionCreators.deleteConfiguration(COMPONENT_ID, this.state.configurationId, true)}
                 isDeletingConfig={this.state.isDeletingConfig}
               />

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
@@ -1,4 +1,6 @@
 import React from 'react';
+// actions
+import InstalledComponentsActionCreators from '../../../../components/InstalledComponentsActionCreators';
 
 import createReactClass from 'create-react-class';
 
@@ -21,7 +23,6 @@ import tablesLoadSettingsAdapter from '../../../adapters/tablesLoadSettingsAdapt
 import RunComponentButton from '../../../../components/react/components/RunComponentButton';
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
-import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
 import LatestVersions from '../../../../components/react/components/SidebarVersionsWrapper';
 import SidebarJobsContainer from '../../../../components/react/components/SidebarJobsContainer';
 import {CollapsibleSection} from '../../../../configurations/utils/renderHelpers';
@@ -30,6 +31,7 @@ import ConfiguredTables from './ConfiguredTables';
 import DimensionsSection from '../../components/DimensionsSection';
 import CredentialsContainer from '../../components/CredentialsContainer';
 import TablesLoadSettings from '../../components/TablesLoadSettings';
+import DeleteGoodDataWriterButton from '../../components/DeleteGoodDataWriterButton';
 
 const COMPONENT_ID = 'keboola.gooddata-writer';
 
@@ -66,7 +68,11 @@ export default createReactClass({
     const tableLoadSettingsSectionProps = tablesLoadSettingsAdapter(configProvisioning);
     const credentialsSectionProps = credentialsAdapter(configProvisioning, localStateProvisioning);
 
+    const isDeletingConfig = InstalledComponentsStore.isDeletingConfig(COMPONENT_ID,configurationId);
+
+
     return {
+      isDeletingConfig,
       dimensionsSectionProps,
       tableLoadSettingsSectionProps,
       credentialsSectionProps,
@@ -113,9 +119,11 @@ export default createReactClass({
               </RunComponentButton>
             </li>
             <li>
-              <DeleteConfigurationButton
-                componentId={COMPONENT_ID}
+              <DeleteGoodDataWriterButton
+                renderWithCaption={true}
                 configId={this.state.configurationId}
+                deleteConfigFn={() => InstalledComponentsActionCreators.deleteConfiguration(COMPONENT_ID, this.state.configurationId, true)}
+                isDeletingConfig={this.state.isDeletingConfig}
               />
             </li>
           </ul>

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Promise from 'bluebird';
 // actions
 import InstalledComponentsActionCreators from '../../../../components/InstalledComponentsActionCreators';
 
@@ -123,6 +124,7 @@ export default createReactClass({
               <DeleteGoodDataWriterButton
                 renderWithCaption={true}
                 config={this.state.configProvisioning.config}
+                getConfigDataFn={() => Promise.resolve(this.state.configProvisioning.configData)}
                 deleteConfigFn={() => InstalledComponentsActionCreators.deleteConfiguration(COMPONENT_ID, this.state.configurationId, true)}
                 isDeletingConfig={this.state.isDeletingConfig}
               />


### PR DESCRIPTION
Fixes #2867 

Tyka sa to mazania konfigov noveho GoodData writeru zo:
- zoznamu konfigov na writers
- zoznamu konfigov na stranke komponenty GoodData writeru
- stranky detailu konfigu(index page)

Po kliku na delete sa nacita obsah konfigu a hlada sa pid GoodData projectu, ak pid existuje tak sa snazi zistit ci je ten projekt provisionovany Keboolou, ak je tak ten projekt cez confirm dialog zmaze a potom zmaze konfig.
Ak taky provisionovany projekt v konfigu neexistuje tak zmaze len konfig bez confirm dialogu.

Niesom si isty wordingom v confirm dialogu tak som toho trocha naplacal viac:
![image](https://user-images.githubusercontent.com/1412120/54301565-842b2180-45bf-11e9-9ae0-f9eb64b8cc92.png)

Este som tam musel urobit refactoring(https://github.com/keboola/kbc-ui/pull/3087/commits/1a7c49ca12ae0fc533b82f90a02f34a98c2a5db9) a premenovat niektore moduly pretoze mi to vyhadzovalo warningy typu 

```
WARNING in ./src/scripts/modules/gooddata-writer-v3/goodDataProvisioning/actions.js
There are multiple modules with names that only differ in casing.
```
