### PR TITLE
Move static select options definitions out of createClass spec

### DIFF
--- a/src/scripts/modules/tokens/react/components/tokenEditor/ExpiresInEdit.jsx
+++ b/src/scripts/modules/tokens/react/components/tokenEditor/ExpiresInEdit.jsx
@@ -5,23 +5,23 @@ import Select from 'react-select';
 const NEVER_EXPIRES = -2;
 const CUSTOM_VALUE = -1;
 const DEFAULT_CUSTOM_VALUE = 0;
-export default React.createClass({
 
+const selectOptions = [
+  {label: 'Never',    value: NEVER_EXPIRES},
+  {label: '1 hour',   value: 1 * 3600},
+  {label: '2 hours',  value: 2 * 3600},
+  {label: '12 hours', value: 12 * 3600},
+  {label: '24 hours', value: 24 * 3600},
+  {label: '48 hours', value: 48 * 3600},
+  {label: 'Custom',   value: CUSTOM_VALUE}
+];
+
+export default React.createClass({
   propTypes: {
     value: PropTypes.number,
     disabled: PropTypes.bool.isRequired,
     onChange: PropTypes.func.isRequired
   },
-
-  selectOptions: [
-    {label: 'Never',    value: NEVER_EXPIRES},
-    {label: '1 hour',   value: 1 * 3600},
-    {label: '2 hours',  value: 2 * 3600},
-    {label: '12 hours', value: 12 * 3600},
-    {label: '24 hours', value: 24 * 3600},
-    {label: '48 hours', value: 48 * 3600},
-    {label: 'Custom',   value: CUSTOM_VALUE}
-  ],
 
   getInitialState() {
     return this.getStateFromProps(this.props);
@@ -32,7 +32,7 @@ export default React.createClass({
   },
 
   getStateFromProps(props) {
-    const hasSelectValue = props.value === null || this.selectOptions.reduce((memo, option) => memo || option.value === props.value, false);
+    const hasSelectValue = props.value === null || selectOptions.reduce((memo, option) => memo || option.value === props.value, false);
     const initSelectValue = props.value === null ? NEVER_EXPIRES : props.value;
     const selectValue = this.state ? this.state.selectValue : initSelectValue;
 
@@ -49,7 +49,7 @@ export default React.createClass({
             disabled={this.props.disabled}
             clearable={false}
             searchable={false}
-            options={this.selectOptions}
+            options={selectOptions}
             value={this.state.selectValue}
             onChange={this.handleSelectChange}
           />

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
@@ -10,6 +10,12 @@ import ChangedSinceInput from '../../../../../react/common/ChangedSinceInput';
 import { PanelWithDetails } from '@keboola/indigo-ui';
 import whereOperatorConstants from '../../../../../react/common/whereOperatorConstants';
 
+const distStyleOptions = [
+  { label: 'EVEN', value: 'EVEN' },
+  { label: 'KEY', value: 'KEY' },
+  { label: 'ALL', value: 'ALL' }
+];
+
 export default React.createClass({
   propTypes: {
     value: PropTypes.object.isRequired,
@@ -19,21 +25,6 @@ export default React.createClass({
     initialShowDetails: PropTypes.bool.isRequired,
     isDestinationDuplicate: PropTypes.bool.isRequired
   },
-
-  distStyleOptions: [
-    {
-      label: 'EVEN',
-      value: 'EVEN'
-    },
-    {
-      label: 'KEY',
-      value: 'KEY'
-    },
-    {
-      label: 'ALL',
-      value: 'ALL'
-    }
-  ],
 
   _handleChangeSource(value) {
     // use only table name from the table identifier
@@ -349,7 +340,7 @@ export default React.createClass({
                 disabled={this.props.disabled || !this.props.value.get('source')}
                 placeholder="Style"
                 onChange={this._handleChangeDistStyle}
-                options={this.distStyleOptions}
+                options={distStyleOptions}
               />
             </Col>
             <Col sm={5}>

--- a/src/scripts/react/common/ChangedSinceInput.jsx
+++ b/src/scripts/react/common/ChangedSinceInput.jsx
@@ -1,81 +1,28 @@
-/*
-   ChangedSinceInput
- */
 import PropTypes from 'prop-types';
-
 import React from 'react';
 import { Creatable } from 'react-select';
 import changedSinceOptionCreator from './changedSinceOptionCreator';
 
+const selectOptions = [
+  { label: '10 minutes', value: '-10 minutes' },
+  { label: '15 minutes', value: '-15 minutes' },
+  { label: '30 minutes', value: '-30 minutes' },
+  { label: '45 minutes', value: '-45 minutes' },
+  { label: '1 hour', value: '-1 hours' },
+  { label: '2 hours', value: '-2 hours' },
+  { label: '4 hours', value: '-4 hours' },
+  { label: '6 hours', value: '-6 hours' },
+  { label: '12 hours', value: '-12 hours' },
+  { label: '18 hours', value: '-18 hours' },
+  { label: '1 day', value: '-1 days' },
+  { label: '2 days', value: '-2 days' },
+  { label: '3 days', value: '-3 days' },
+  { label: '7 days', value: '-7 days' },
+  { label: '15 days', value: '-15 days' },
+  { label: '30 days', value: '-30 days' }
+];
+
 export default React.createClass({
-
-  selectOptions: [
-    {
-      'label': '10 minutes',
-      'value': '-10 minutes'
-    },
-    {
-      'label': '15 minutes',
-      'value': '-15 minutes'
-    },
-    {
-      'label': '30 minutes',
-      'value': '-30 minutes'
-    },
-    {
-      'label': '45 minutes',
-      'value': '-45 minutes'
-    },
-    {
-      'label': '1 hour',
-      'value': '-1 hours'
-    },
-    {
-      'label': '2 hours',
-      'value': '-2 hours'
-    },
-    {
-      'label': '4 hours',
-      'value': '-4 hours'
-    },
-    {
-      'label': '6 hours',
-      'value': '-6 hours'
-    },
-    {
-      'label': '12 hours',
-      'value': '-12 hours'
-    },
-    {
-      'label': '18 hours',
-      'value': '-18 hours'
-    },
-    {
-      'label': '1 day',
-      'value': '-1 days'
-    },
-    {
-      'label': '2 days',
-      'value': '-2 days'
-    },
-    {
-      'label': '3 days',
-      'value': '-3 days'
-    },
-    {
-      'label': '7 days',
-      'value': '-7 days'
-    },
-    {
-      'label': '15 days',
-      'value': '-15 days'
-    },
-    {
-      'label': '30 days',
-      'value': '-30 days'
-    }
-  ],
-
   propTypes: {
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
@@ -84,17 +31,18 @@ export default React.createClass({
   },
 
   getSelectOptions() {
-    const props = this.props;
-    let selectOptions = this.selectOptions;
-    if (this.props.value && selectOptions.filter(function(item) {
-      return item.value === props.value;
-    }).length === 0) {
-      selectOptions.push({
+    if (!this.props.value) {
+      return selectOptions;
+    }
+
+    const options = [...selectOptions];
+    if (options.filter((item) => item.value === this.props.value).length === 0) {
+      options.push({
         label: this.props.value.replace('-', ''),
         value: this.props.value
       });
     }
-    return selectOptions;
+    return options;
   },
 
   onChange(value) {


### PR DESCRIPTION
Related #1577

Při převodu na `ES6 Class` nebo `createReactClass` si tady Codemod stěžoval. On to skipnul tak se nic nestalo a jen použil rovnou `createReactClass`, ale když to bude pryč tak to třeba i převede na normal třídu pokud to bude možné.