### PR TITLE
Ex-Db - QueryEditor - Source table - filter out tables without name or schema

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -125,26 +125,25 @@ export default createReactClass({
   },
 
   sourceTableSelectOptions() {
-    if (this.props.sourceTables && this.props.sourceTables.count() > 0) {
-      const groupedTables = this.props.sourceTables.groupBy(table => table.get('schema'));
-      return groupedTables.keySeq().map(function(group) {
-        return {
-          value: group,
-          label: group,
-          children: groupedTables.get(group).map(function(table) {
-            return {
-              value: {
-                schema: table.get('schema'),
-                tableName: table.get('name')
-              },
-              label: table.get('schema') + '.' + table.get('name')
-            };
-          }).toJS()
-        };
-      });
-    } else {
+    if (!this.props.sourceTables || !this.props.sourceTables.count()) {
       return [];
     }
+
+    return this.props.sourceTables
+      .filter((table) => table.get('schema') && table.get('name'))
+      .groupBy((table) => table.get('schema'))
+      .map((tables, schema) => ({
+        value: schema,
+        label: schema,
+        children: tables.map((table) => ({
+          value: {
+            schema,
+            tableName: table.get('name')
+          },
+          label: `${schema}.${table.get('name')}`
+        })).toJS()
+      }))
+      .valueSeq();
   },
 
   getCandidateTable() {

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -76,12 +76,10 @@ function fetch(componentId, configId) {
 }
 
 function isValidQuery(query) {
+  const advancedMode = query.get('advancedMode', false);
   const nameValid = query.get('name', '').trim().length > 0;
   const queryValid = query.get('query', '').trim().length > 0;
-  const advancedMode = query.get('advancedMode', false);
-  const tableValid = (query.get('table'))
-    ? query.get('table').get('tableName', '').trim().length > 0
-    : false;
+  const tableValid = query.getIn(['table', 'tableName'], '').trim().length > 0;
   return nameValid && ((advancedMode && queryValid) || (!advancedMode && tableValid));
 }
 


### PR DESCRIPTION
Fixes #3093

Ty errory co chodily do sentry padaly na funkci `isValidQuery`. Tam musely existovat položky jako "tableName" ale museli být null nebo undefined, jinak by se použil default.

Nakonec jsem se podíval do projektu kde to padalo a tam ten select vypadal takto:
![schema](https://user-images.githubusercontent.com/12331181/54352569-3f03ff80-4652-11e9-94c7-e0761cacd7a0.png)

Dále jsem to tam nezkoumal. Ale jestli je "name" a "schema" povinné, což nevím jistě. Tak ještě než groupuji ty options, tak filitruji tabulky, které "name" nebo "schema" nemají.

Je to takto ok? Nebo dát nějak vědět uživateli že tam jsou takové divné data?

