### PR TITLE
Don't offer linked buckets (read-only) in output mappings

### DIFF
--- a/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
@@ -182,13 +182,11 @@ export default createReactClass({
             <DestinationTableSelector
               currentSource={this.props.value.get('source')}
               updatePart={this._updateDestinationPart}
-              disabled={false}
               parts={this._parseDestination().parts}
               tables={this.props.tables}
               buckets={this.props.buckets}
-              placeholder={
-                'Storage table where \
-the source file data will be loaded to - you can create a new table or use an existing one.'
+              helpText={
+                'Storage table where the source file data will be loaded to - you can create a new table or use an existing one.'
               }
             />
           </Col>

--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
@@ -218,11 +218,10 @@ export default createReactClass({
             <DestinationTableSelector
               currentSource={this.props.value.get('source')}
               updatePart={this._updateDestinationPart}
-              disabled={false}
               parts={this._parseDestination().parts}
               tables={this.props.tables}
               buckets={this.props.buckets}
-              placeholder={
+              helpText={
                 'Storage table where the source table data will be loaded to - you can create a new table or use an existing one.'
               }
             />

--- a/src/scripts/react/common/DestinationTableSelector.jsx
+++ b/src/scripts/react/common/DestinationTableSelector.jsx
@@ -2,33 +2,97 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Select from 'react-select';
-import stringUtils from '../../utils/string';
-const { webalize } = stringUtils;
-
+import { HelpBlock } from 'react-bootstrap';
+import { webalize } from '../../utils/string';
 
 export default createReactClass({
   propTypes: {
     currentSource: PropTypes.string,
-    disabled: PropTypes.bool.isRequired,
     tables: PropTypes.object.isRequired,
     buckets: PropTypes.object.isRequired,
     parts: PropTypes.object.isRequired,
     updatePart: PropTypes.func.isRequired,
-    placeholder: PropTypes.string.isRequired
+    helpText: PropTypes.string.isRequired,
+    disabled: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      disabled: false
+    };
+  },
+
+  render() {
+    return (
+      <div>
+        <div className="kbc-dst-table-selector">
+          <span className="kbc-select-stage">{this.renderStageSelect()}</span>
+          <span className="kbc-dot-separator">.</span>
+          <span className="kbc-select-bucket">{this.renderBucketSelect()}</span>
+          <span className="kbc-dot-separator">.</span>
+          <span className="kbc-select-table">{this.renderTableSelect()}</span>
+        </div>
+        <HelpBlock>{this.props.helpText}</HelpBlock>
+      </div>
+    );
+  },
+
+  renderStageSelect() {
+    return (
+      <Select
+        searchable={false}
+        disabled={this.props.disabled}
+        clearable={false}
+        value={this.props.parts.stage}
+        onChange={({ value }) => this.selectStage(value)}
+        options={['out', 'in'].map((v) => ({ label: v, value: v }))}
+      />
+    );
+  },
+
+  renderBucketSelect() {
+    return (
+      <Select.Creatable
+        promptTextCreator={(label) => label}
+        disabled={this.props.disabled}
+        placeholder="Select a bucket or create a new one"
+        value={this.props.parts.bucket}
+        onChange={this.selectBucket}
+        options={this.prepareBucketsOptions().toJS()}
+        autosize={false}
+        newOptionCreator={this.selectBucketOptionCreator}
+      />
+    );
+  },
+
+  renderTableSelect() {
+    return (
+      <Select.Creatable
+        promptTextCreator={(label) => label}
+        disabled={this.props.disabled}
+        placeholder="Select a table or create a new one"
+        value={this.props.parts.table}
+        onChange={this.selectTable}
+        options={this.prepareTablesOptions().toJS()}
+        autosize={false}
+        newOptionCreator={this.selectTableOptionCreator}
+      />
+    );
   },
 
   prepareBucketsOptions() {
     const stage = this.props.parts.stage;
     const bucket = this.props.parts.bucket;
     const buckets = this.props.buckets
-      .filter(b => b.get('stage') === stage)
-      .map(b => ({label: b.get('name'), value: b.get('name')}))
+      .filter((b) => b.get('stage') === stage)
+      .map((b) => ({ label: b.get('name'), value: b.get('name') }))
       .toList();
-    if (!!bucket && !buckets.find(b => b.label === bucket)) {
-      return buckets.push({label: bucket, value: bucket});
-    } else {
-      return buckets;
+
+    if (!!bucket && !buckets.find((b) => b.label === bucket)) {
+      return buckets.push({ label: bucket, value: bucket });
     }
+
+    return buckets;
   },
 
   prepareTablesOptions() {
@@ -36,83 +100,23 @@ export default createReactClass({
     const bucketId = parts.stage + '.' + parts.bucket;
     const table = parts.table;
     let tables = this.props.tables
-      .filter(t => t.getIn(['bucket', 'id']) === bucketId)
-      .map(t => ({label: t.get('name'), value: t.get('name')}))
+      .filter((t) => t.getIn(['bucket', 'id']) === bucketId)
+      .map((t) => ({ label: t.get('name'), value: t.get('name') }))
       .toList();
-    if (!!table && !tables.find(t => t.label === table)) {
-      tables = tables.push({label: table, value: table});
+    if (!!table && !tables.find((t) => t.label === table)) {
+      tables = tables.push({ label: table, value: table });
     }
-    const {currentSource} = this.props;
-    const webalizedSource = webalize(currentSource || '', {caseSensitive: true});
-    if (!!webalizedSource && !tables.find(t => t.label === webalizedSource)) {
-      tables = tables.insert(0, {label: `Create new table ${webalizedSource}`, value: webalizedSource});
+    const { currentSource } = this.props;
+    const webalizedSource = webalize(currentSource || '', { caseSensitive: true });
+
+    if (!!webalizedSource && !tables.find((t) => t.label === webalizedSource)) {
+      tables = tables.insert(0, {
+        label: `Create new table ${webalizedSource}`,
+        value: webalizedSource
+      });
     }
 
     return tables;
-  },
-
-  render() {
-    const parts = this.props.parts;
-    const stageSelect = (
-      <Select
-        searchable={false}
-        disabled={this.props.disabled}
-        clearable={false}
-        value={parts.stage}
-        onChange={({value}) => this.selectStage(value)}
-        options={['out', 'in'].map(v => ({label: v, value: v}))}
-      />
-    );
-    const bucketSelect = (
-      <Select.Creatable
-        promptTextCreator={label => label}
-        clearable={true}
-        disabled={this.props.disabled}
-        placeholder="Select a bucket or create a new one"
-        value={parts.bucket}
-        onChange={this.selectBucket}
-        options={this.prepareBucketsOptions().toJS()}
-        autosize={false}
-        newOptionCreator={this.selectBucketOptionCreator}
-      />
-    );
-
-    const tableSelect = (
-      <Select.Creatable
-        promptTextCreator={label => label}
-        clearable={true}
-        disabled={this.props.disabled}
-        placeholder="Select a table or create a new one"
-        value={parts.table}
-        onChange={this.selectTable}
-        options={this.prepareTablesOptions().toJS()}
-        autosize={false}
-        newOptionCreator={this.selectTableOptionCreator}
-      />
-    );
-
-    return (
-      <div>
-        <div className="kbc-dst-table-selector">
-          <span className="kbc-select-stage">
-            {stageSelect}
-          </span>
-          <span className="kbc-dot-separator">
-            .
-          </span>
-          <span className="kbc-select-bucket">
-            {bucketSelect}
-          </span>
-          <span className="kbc-dot-separator">
-            .
-          </span>
-          <span className="kbc-select-table" >
-            {tableSelect}
-          </span>
-        </div>
-        <div className="help-block">{this.props.placeholder}</div>
-      </div>
-    );
   },
 
   selectStage(stage) {
@@ -121,9 +125,11 @@ export default createReactClass({
 
   selectBucket(selection) {
     const bucket = selection ? selection.value || '' : '';
-    if (!!bucket &&
-        !bucket.startsWith('c-') &&
-        !this.prepareBucketsOptions().find(b => b.label === bucket)) {
+    if (
+      !!bucket &&
+      !bucket.startsWith('c-') &&
+      !this.prepareBucketsOptions().find((b) => b.label === bucket)
+    ) {
       this.updateValue('bucket', 'c-' + bucket);
     } else {
       this.updateValue('bucket', bucket);
@@ -140,7 +146,8 @@ export default createReactClass({
   },
 
   selectBucketOptionCreator({ label }) {
-    const option = (label.startsWith('c-') ? '' : 'c-') + webalize(label, {caseSensitive: true});
+    const option = (label.startsWith('c-') ? '' : 'c-') + webalize(label, { caseSensitive: true });
+
     return {
       label: 'Create new bucket ' + option,
       value: option
@@ -148,7 +155,8 @@ export default createReactClass({
   },
 
   selectTableOptionCreator({ label }) {
-    const option = webalize(label, {caseSensitive: true});
+    const option = webalize(label, { caseSensitive: true });
+
     return {
       label: 'Create new table ' + option,
       value: option

--- a/src/scripts/react/common/DestinationTableSelector.jsx
+++ b/src/scripts/react/common/DestinationTableSelector.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Select from 'react-select';
 import { HelpBlock } from 'react-bootstrap';
-import { webalize } from '../../utils/string';
+import stringUtils from '../../utils/string';
 
 export default createReactClass({
   propTypes: {
@@ -107,7 +107,7 @@ export default createReactClass({
       tables = tables.push({ label: table, value: table });
     }
     const { currentSource } = this.props;
-    const webalizedSource = webalize(currentSource || '', { caseSensitive: true });
+    const webalizedSource = stringUtils.webalize(currentSource || '', { caseSensitive: true });
 
     if (!!webalizedSource && !tables.find((t) => t.label === webalizedSource)) {
       tables = tables.insert(0, {
@@ -146,7 +146,7 @@ export default createReactClass({
   },
 
   selectBucketOptionCreator({ label }) {
-    const option = (label.startsWith('c-') ? '' : 'c-') + webalize(label, { caseSensitive: true });
+    const option = (label.startsWith('c-') ? '' : 'c-') + stringUtils.webalize(label, { caseSensitive: true });
 
     return {
       label: 'Create new bucket ' + option,
@@ -155,7 +155,7 @@ export default createReactClass({
   },
 
   selectTableOptionCreator({ label }) {
-    const option = webalize(label, { caseSensitive: true });
+    const option = stringUtils.webalize(label, { caseSensitive: true });
 
     return {
       label: 'Create new table ' + option,

--- a/src/scripts/react/common/DestinationTableSelector.jsx
+++ b/src/scripts/react/common/DestinationTableSelector.jsx
@@ -84,7 +84,7 @@ export default createReactClass({
     const stage = this.props.parts.stage;
     const bucket = this.props.parts.bucket;
     const buckets = this.props.buckets
-      .filter((b) => b.get('stage') === stage)
+      .filter((b) => b.get('stage') === stage && !b.has('sourceBucket'))
       .map((b) => ({ label: b.get('name'), value: b.get('name') }))
       .toList();
 


### PR DESCRIPTION
Fixes #3096

První a druhý commit jsem jen trošku upravoval tu komponentu. Importy, nebo disabled props jsem dal defaultProps když je použito jen dvakrát a všude false. Nějaké render metody abych to neměl vše inline v render. Samé drobnosti.

Důležité je ten poslední commit. Tam to nakonec bylo snadné to jen vyfiltrovat pryč.
Ještě nevím zda to nějak více hlídat, protože uživatel má možnost si tam napsat i tak cokoli tak zase může napsat nějaký ten shared bucket name. Budeme i to nějak hlídat?