### PR TITLE
Use props directly not through new variable

### DIFF
--- a/src/scripts/modules/components/react/components/SidebarVersions.jsx
+++ b/src/scripts/modules/components/react/components/SidebarVersions.jsx
@@ -24,13 +24,13 @@ export default React.createClass({
     prepareVersionsDiffData: PropTypes.func
   },
 
-  getDefaultProps: function() {
+  getDefaultProps() {
     return {
       limit: 5
     };
   },
 
-  getVersionsLinkParams: function() {
+  getVersionsLinkParams() {
     if (this.props.versionsLinkParams) {
       return this.props.versionsLinkParams;
     }
@@ -40,19 +40,18 @@ export default React.createClass({
     };
   },
 
-  getVersionsLinkTo: function() {
+  getVersionsLinkTo() {
     if (this.props.versionsLinkTo) {
       return this.props.versionsLinkTo;
     }
     return this.props.componentId + '-versions';
   },
 
-  renderVersions: function() {
-    const props = this.props;
+  renderVersions() {
     const self = this;
     if (this.props.versions.count() || this.props.isLoading) {
-      return this.props.versions.slice(0, 3).map(function(version) {
-        const isLast = (version.get('version') === props.versions.first().get('version'));
+      return this.props.versions.slice(0, 3).map((version) => {
+        const isLast = (version.get('version') === this.props.versions.first().get('version'));
         return (
           <Link
             className="list-group-item"
@@ -115,7 +114,7 @@ export default React.createClass({
   },
 
 
-  render: function() {
+  render() {
     return (
       <div>
         <h4>Updates

--- a/src/scripts/modules/components/react/components/generic/ColumnsSelectRow.jsx
+++ b/src/scripts/modules/components/react/components/generic/ColumnsSelectRow.jsx
@@ -50,9 +50,8 @@ export default React.createClass({
     if (!this.props.value.get('source')) {
       return [];
     }
-    const props = this.props;
     const table = this.props.allTables.find((t) => {
-      return t.get('id') === props.value.get('source');
+      return t.get('id') === this.props.value.get('source');
     }, null, Map());
     return table.get('columns', List()).toJS();
   },

--- a/src/scripts/modules/components/react/components/generic/DataFilterRow.jsx
+++ b/src/scripts/modules/components/react/components/generic/DataFilterRow.jsx
@@ -74,9 +74,8 @@ export default React.createClass({
     if (!this.props.value.get('source')) {
       return [];
     }
-    const props = this.props;
     const table = this.props.allTables.find((t) => {
-      return t.get('id') === props.value.get('source');
+      return t.get('id') === this.props.value.get('source');
     }, null, Map());
     return table.get('columns', List()).toJS();
   },

--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTable.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTable.jsx
@@ -84,11 +84,10 @@ export default React.createClass({
   },
 
   renderTableRows() {
-    const props = this.props;
     const state = this.state;
-    return this.props.rows.map(function(row, rowIndex) {
-      const thisRowOrderPending = props.orderPending.get(row.get('id'), false);
-      const rowsOrderPending = props.orderPending.count() > 0;
+    return this.props.rows.map((row, rowIndex) => {
+      const thisRowOrderPending = this.props.orderPending.get(row.get('id'), false);
+      const rowsOrderPending = this.props.orderPending.count() > 0;
       let disabledMoveLabel;
       if (rowsOrderPending) {
         disabledMoveLabel = 'Order saving';
@@ -97,23 +96,23 @@ export default React.createClass({
       }
       return (
         <Row
-          columns={props.columns}
+          columns={this.props.columns}
           row={row}
-          componentId={props.componentId}
-          component={props.component}
-          configurationId={props.configurationId}
+          componentId={this.props.componentId}
+          component={this.props.component}
+          configurationId={this.props.configurationId}
           key={state.sortableKeyPrefix + '_' + row.get('id')}
           rowNumber={rowIndex + 1}
-          linkTo={props.rowLinkTo}
-          isDeletePending={props.rowDeletePending(row.get('id'))}
-          onDelete={function() {
-            return props.rowDelete(row.get('id'));
+          linkTo={this.props.rowLinkTo}
+          isDeletePending={this.props.rowDeletePending(row.get('id'))}
+          onDelete={() => {
+            return this.props.rowDelete(row.get('id'));
           }}
-          isEnableDisablePending={props.rowEnableDisablePending(row.get('id'))}
-          onEnableDisable={function() {
-            return props.rowEnableDisable(row.get('id'));
+          isEnableDisablePending={this.props.rowEnableDisablePending(row.get('id'))}
+          onEnableDisable={() => {
+            return this.props.rowEnableDisable(row.get('id'));
           }}
-          disabledMove={props.disabledMove || rowsOrderPending}
+          disabledMove={this.props.disabledMove || rowsOrderPending}
           disabledMoveLabel={disabledMoveLabel}
           orderPending={thisRowOrderPending}
         />

--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTableRow.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTableRow.jsx
@@ -41,14 +41,15 @@ const TableRow = React.createClass({
   render() {
     const router = RoutesStore.getRouter();
 
-
-    const props = this.props;
     return (
       <div
         className="tr"
-        data-id={props.row.get('id')}
+        data-id={this.props.row.get('id')}
         onClick={() => {
-          router.transitionTo(this.props.linkTo, {config: this.props.configurationId, row: this.props.row.get('id')});
+          router.transitionTo(this.props.linkTo, {
+            config: this.props.configurationId,
+            row: this.props.row.get('id')
+          });
         }}
       >
         <div className="td" key="handle">
@@ -57,16 +58,16 @@ const TableRow = React.createClass({
         <div className="td" key="row-number">
           {this.props.rowNumber}
         </div>
-        {this.props.columns.map(function(columnDefinition, index) {
+        {this.props.columns.map((columnDefinition, index) => {
           return (
             <div className="td kbc-break-all" key={index}>
               <ConfigurationRowsTableCell
                 type={columnDefinition.get('type', 'value')}
                 valueFn={columnDefinition.get('value')}
-                row={props.row}
-                component={props.component}
-                componentId={props.componentId}
-                configurationId={props.configurationId}
+                row={this.props.row}
+                component={this.props.component}
+                componentId={this.props.componentId}
+                configurationId={this.props.configurationId}
               />
             </div>
           );
@@ -79,7 +80,6 @@ const TableRow = React.createClass({
   },
 
   renderRowActionButtons() {
-    const props = this.props;
     return [
       (<DeleteConfigurationRowButton
         key="delete"
@@ -98,10 +98,10 @@ const TableRow = React.createClass({
         key="run"
         title="Run"
         component={this.props.componentId}
-        runParams={function() {
+        runParams={() => {
           return {
-            config: props.configurationId,
-            row: props.row.get('id')
+            config: this.props.configurationId,
+            row: this.props.row.get('id')
           };
         }}
       >

--- a/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
+++ b/src/scripts/modules/ex-aws-s3/react/components/Configuration.jsx
@@ -48,7 +48,6 @@ export default React.createClass({
 
   renderCsvHeader() {
     if (this.props.value.columnsFrom === 'manual') {
-      const props = this.props;
       return (
         <div className="form-group">
           <div className="col-xs-4 control-label">Column Names</div>
@@ -61,8 +60,8 @@ export default React.createClass({
               delimiter=","
               placeholder="Add a column"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({columns: value});
+              onChange={(value) => {
+                this.props.onChange({columns: value});
               }}
               disabled={this.props.disabled || this.props.value.columnsFrom === 'header'}
             />
@@ -76,7 +75,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <div className="form-horizontal">
         <h3>Source</h3>
@@ -86,8 +84,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.bucket}
-              onChange={function(e) {
-                props.onChange({bucket: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({bucket: e.target.value});
               }}
               placeholder="mybucket"
               disabled={this.props.disabled}
@@ -100,8 +98,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.key}
-              onChange={function(e) {
-                props.onChange({key: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({key: e.target.value});
               }}
               placeholder="myfolder/myfile.csv"
               disabled={this.props.disabled}
@@ -122,8 +120,8 @@ export default React.createClass({
             <Col xs={8} xsOffset={4}>
               <Checkbox
                 checked={this.props.value.newFilesOnly}
-                onChange={function(e) {
-                  props.onChange({newFilesOnly: e.target.checked});
+                onChange={(e) => {
+                  this.props.onChange({newFilesOnly: e.target.checked});
                 }}
                 disabled={this.props.disabled}
               >
@@ -138,12 +136,12 @@ export default React.createClass({
             <Col xs={8} xsOffset={4}>
               <Checkbox
                 checked={this.props.value.wildcard}
-                onChange={function(e) {
+                onChange={(e) => {
                   let change = {wildcard: e.target.checked};
                   if (change.wildcard === false) {
                     change.subfolders = false;
                   }
-                  props.onChange(change);
+                  this.props.onChange(change);
                 }}
                 disabled={this.props.disabled}
               >
@@ -156,8 +154,8 @@ export default React.createClass({
             <Col xs={8} xsOffset={4}>
               <Checkbox
                 checked={this.props.value.subfolders}
-                onChange={function(e) {
-                  props.onChange({subfolders: e.target.checked});
+                onChange={(e) => {
+                  this.props.onChange({subfolders: e.target.checked});
                 }}
                 disabled={this.props.disabled || !this.props.value.wildcard}
               >
@@ -171,8 +169,8 @@ export default React.createClass({
         <CsvDelimiterInput
           type="text"
           value={this.props.value.delimiter}
-          onChange={function(value) {
-            props.onChange({delimiter: value});
+          onChange={(value) => {
+            this.props.onChange({delimiter: value});
           }}
           disabled={this.props.disabled}
           help={<span>Field delimiter used in the CSV file. Use <code>\t</code> for tabulator.</span>}
@@ -183,8 +181,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.enclosure}
-              onChange={function(e) {
-                props.onChange({enclosure: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({enclosure: e.target.value});
               }}
               disabled={this.props.disabled}
             />
@@ -204,8 +202,8 @@ export default React.createClass({
               clearable={false}
               options={columnsFromOptions}
               disabled={this.props.disabled}
-              onChange={function(value) {
-                props.onChange({columnsFrom: value});
+              onChange={(value) => {
+                this.props.onChange({columnsFrom: value});
               }}
             />
           </div>
@@ -218,8 +216,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.name}
-              onChange={function(e) {
-                props.onChange({name: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({name: e.target.value});
               }}
               placeholder="mytable"
               disabled={this.props.disabled}
@@ -231,8 +229,8 @@ export default React.createClass({
           <Col xs={8} xsOffset={4}>
             <Checkbox
               checked={this.props.value.incremental}
-              onChange={function(e) {
-                props.onChange({incremental: e.target.checked});
+              onChange={(e) => {
+                this.props.onChange({incremental: e.target.checked});
               }}
               disabled={this.props.disabled}
             >
@@ -256,8 +254,8 @@ export default React.createClass({
               delimiter=","
               placeholder="Add a column to the primary key"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({primaryKey: value});
+              onChange={(value) => {
+                this.props.onChange({primaryKey: value});
               }}
               disabled={this.props.disabled}
             />
@@ -269,8 +267,8 @@ export default React.createClass({
           <Col xs={8} xsOffset={4}>
             <Checkbox
               checked={this.props.value.decompress}
-              onChange={function(e) {
-                props.onChange({decompress: e.target.checked});
+              onChange={(e) => {
+                this.props.onChange({decompress: e.target.checked});
               }}
               disabled={this.props.disabled}
             >
@@ -291,8 +289,8 @@ export default React.createClass({
             <Col xs={8} xsOffset={4}>
               <Checkbox
                 checked={this.props.value.addFilenameColumn}
-                onChange={function(e) {
-                  props.onChange({addFilenameColumn: e.target.checked});
+                onChange={(e) => {
+                  this.props.onChange({addFilenameColumn: e.target.checked});
                 }}
                 disabled={this.props.disabled}
               >
@@ -307,8 +305,8 @@ export default React.createClass({
             <Col xs={8} xsOffset={4}>
               <Checkbox
                 checked={this.props.value.addRowNumberColumn}
-                onChange={function(e) {
-                  props.onChange({addRowNumberColumn: e.target.checked});
+                onChange={(e) => {
+                  this.props.onChange({addRowNumberColumn: e.target.checked});
                 }}
                 disabled={this.props.disabled}
               >

--- a/src/scripts/modules/ex-aws-s3/react/components/Credentials.jsx
+++ b/src/scripts/modules/ex-aws-s3/react/components/Credentials.jsx
@@ -17,7 +17,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <div className="form-horizontal">
         <FormGroup>
@@ -26,8 +25,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.awsAccessKeyId}
-              onChange={function(e) {
-                props.onChange({awsAccessKeyId: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({awsAccessKeyId: e.target.value});
               }}
               placeholder="MYAWSACCESSKEYID123"
               disabled={this.props.disabled}
@@ -50,8 +49,8 @@ export default React.createClass({
             <FormControl
               type="password"
               value={this.props.value.awsSecretAccessKey}
-              onChange={function(e) {
-                props.onChange({awsSecretAccessKey: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({awsSecretAccessKey: e.target.value});
               }}
               disabled={this.props.disabled}
             />

--- a/src/scripts/modules/ex-ftp/react/components/SourceServer.jsx
+++ b/src/scripts/modules/ex-ftp/react/components/SourceServer.jsx
@@ -20,7 +20,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <Form horizontal>
         <FormGroup>
@@ -30,14 +29,14 @@ export default React.createClass({
               componentClass="select"
               placeholder="select"
               value={this.props.value.connectionType}
-              onChange={function(e) {
+              onChange={(e) => {
                 let port;
                 if (e.target.value === 'SFTP') {
                   port = 22;
                 } else {
                   port = 21;
                 }
-                props.onChange({connectionType: e.target.value, port: port});
+                this.props.onChange({connectionType: e.target.value, port: port});
               }}
             >
               <option value="" disabled>Select type</option>
@@ -55,8 +54,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.host}
-              onChange={function(e) {
-                props.onChange({host: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({host: e.target.value});
               }}
             />
           </Col>
@@ -69,8 +68,8 @@ export default React.createClass({
             <FormControl
               type="number"
               value={this.props.value.port}
-              onChange={function(e) {
-                props.onChange({port: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({port: e.target.value});
               }}
             />
           </Col>
@@ -83,8 +82,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.username}
-              onChange={function(e) {
-                props.onChange({username: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({username: e.target.value});
               }}
             />
           </Col>
@@ -97,8 +96,8 @@ export default React.createClass({
             <FormControl
               type="password"
               value={this.props.value.password}
-              onChange={function(e) {
-                props.onChange({password: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({password: e.target.value});
               }}
             />
           </Col>
@@ -113,8 +112,8 @@ export default React.createClass({
             <FormControl
               type="password"
               value={this.props.value.privateKey}
-              onChange={function(e) {
-                props.onChange({privateKey: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({privateKey: e.target.value});
               }}
             />
             <HelpBlock>

--- a/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
+++ b/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
@@ -21,17 +21,16 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <Form horizontal>
         <h3>Query</h3>
         <FormGroup>
           <Col smOffset={4} sm={8}>
             <Checkbox
-              checked={props.value.useLegacySql}
-              disabled={props.disabled}
-              onChange={function(e) {
-                props.onChange({useLegacySql: e.target.checked});
+              checked={this.props.value.useLegacySql}
+              disabled={this.props.disabled}
+              onChange={(e) => {
+                this.props.onChange({useLegacySql: e.target.checked});
               }}
             >Use Legacy SQL</Checkbox>
             <HelpBlock>
@@ -48,13 +47,13 @@ export default React.createClass({
             <CodeMirror
               theme="solarized"
               mode={editorMode(ExGoogleBigQueryV2ComponentId)}
-              value={props.value.query}
-              onChange={(e) => props.onChange({query: e.target.value})}
+              value={this.props.value.query}
+              onChange={(e) => this.props.onChange({query: e.target.value})}
               lineNumbers
               lineWrapping={false}
               placeholder="e.g. SELECT `id`, `name` FROM `myTable`"
               style={{ width: '100%' }}
-              readOnly={props.disabled}
+              readOnly={this.props.disabled}
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/ex-google-bigquery-v2/react/components/SaveSettings.jsx
+++ b/src/scripts/modules/ex-google-bigquery-v2/react/components/SaveSettings.jsx
@@ -18,8 +18,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
-
     return (
       <Form horizontal>
         <h3>Save Settings</h3>
@@ -28,12 +26,12 @@ export default React.createClass({
           <Col sm={8}>
             <FormControl
               type="text"
-              value={props.value.tableName}
-              onChange={function(e) {
-                props.onChange({tableName: e.target.value.trim()});
+              value={this.props.value.tableName}
+              onChange={(e) => {
+                this.props.onChange({tableName: e.target.value.trim()});
               }}
               placeholder="mytable"
-              disabled={props.disabled}
+              disabled={this.props.disabled}
             />
             <HelpBlock>Name of the table stored in Storage.</HelpBlock>
           </Col>
@@ -41,10 +39,10 @@ export default React.createClass({
         <FormGroup>
           <Col smOffset={4} sm={8}>
             <Checkbox
-              checked={props.value.incremental}
-              disabled={props.disabled}
-              onChange={function(e) {
-                props.onChange({incremental: e.target.checked});
+              checked={this.props.value.incremental}
+              disabled={this.props.disabled}
+              onChange={(e) => {
+                this.props.onChange({incremental: e.target.checked});
               }}
             >Incremental</Checkbox>
             <HelpBlock>
@@ -59,16 +57,16 @@ export default React.createClass({
           <Col sm={8}>
             <Select
               name="primaryKey"
-              value={props.value.primaryKey}
+              value={this.props.value.primaryKey}
               multi={true}
               allowCreate={true}
               delimiter=","
               placeholder="Add a column to the primary key"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({primaryKey: value});
+              onChange={(value) => {
+                this.props.onChange({primaryKey: value});
               }}
-              disabled={props.disabled}
+              disabled={this.props.disabled}
             />
             <HelpBlock>
               If primary key is set, updates can be done on table by selecting <strong>incremental loads</strong>. Primary key can consist of multiple columns. Primary key of an existing table cannot be changed.

--- a/src/scripts/modules/ex-http/react/components/Configuration.jsx
+++ b/src/scripts/modules/ex-http/react/components/Configuration.jsx
@@ -40,7 +40,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <div className="form-horizontal">
         <h3>Download Settings</h3>
@@ -50,8 +49,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.path}
-              onChange={function(e) {
-                props.onChange({path: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({path: e.target.value});
               }}
               placeholder="/myfolder/myfile.csv"
               disabled={this.props.disabled}
@@ -62,8 +61,8 @@ export default React.createClass({
           <Col xs={8} xsOffset={4}>
             <Checkbox
               checked={this.props.value.decompress}
-              onChange={function(e) {
-                props.onChange({decompress: e.target.checked});
+              onChange={(e) => {
+                this.props.onChange({decompress: e.target.checked});
               }}
               disabled={this.props.disabled}
             >
@@ -82,8 +81,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.name}
-              onChange={function(e) {
-                props.onChange({name: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({name: e.target.value});
               }}
               placeholder="mytable"
               disabled={this.props.disabled}
@@ -97,8 +96,8 @@ export default React.createClass({
           <Col xs={8} xsOffset={4}>
             <Checkbox
               checked={this.props.value.incremental}
-              onChange={function(e) {
-                props.onChange({incremental: e.target.checked});
+              onChange={(e) => {
+                this.props.onChange({incremental: e.target.checked});
               }}
               disabled={this.props.disabled}
             >
@@ -113,8 +112,8 @@ export default React.createClass({
         <CsvDelimiterInput
           type="text"
           value={this.props.value.delimiter}
-          onChange={function(value) {
-            props.onChange({delimiter: value});
+          onChange={(value) => {
+            this.props.onChange({delimiter: value});
           }}
           disabled={this.props.disabled}
         />
@@ -124,8 +123,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.enclosure}
-              onChange={function(e) {
-                props.onChange({enclosure: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({enclosure: e.target.value});
               }}
               placeholder={'"'}
               disabled={this.props.disabled}
@@ -149,14 +148,14 @@ export default React.createClass({
               clearable={false}
               options={columnsFromOptions}
               disabled={this.props.disabled}
-              onChange={function(value) {
+              onChange={(value) => {
                 let diff = {
                   columnsFrom: value
                 };
                 if (value !== 'manual') {
                   diff.columns = [];
                 }
-                props.onChange(diff);
+                this.props.onChange(diff);
               }}
             />
           </div>
@@ -172,8 +171,8 @@ export default React.createClass({
               delimiter=","
               placeholder="Add a column"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({columns: value});
+              onChange={(value) => {
+                this.props.onChange({columns: value});
               }}
               disabled={this.props.value.columnsFrom !== 'manual' || this.props.disabled}
             />
@@ -190,8 +189,8 @@ export default React.createClass({
               delimiter=","
               placeholder="Add a column to the primary key"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({primaryKey: value});
+              onChange={(value) => {
+                this.props.onChange({primaryKey: value});
               }}
               disabled={this.props.disabled}
             />

--- a/src/scripts/modules/ex-storage/react/components/SaveSettings.jsx
+++ b/src/scripts/modules/ex-storage/react/components/SaveSettings.jsx
@@ -18,7 +18,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <Form horizontal>
         <h3>Save Settings</h3>
@@ -26,8 +25,8 @@ export default React.createClass({
           <Col smOffset={4} sm={8}>
             <Checkbox
               checked={this.props.value.incremental}
-              onChange={function(e) {
-                props.onChange({incremental: e.target.checked});
+              onChange={(e) => {
+                this.props.onChange({incremental: e.target.checked});
               }}
             >Incremental</Checkbox>
             <HelpBlock>
@@ -48,8 +47,8 @@ export default React.createClass({
               delimiter=","
               placeholder="Add a column to the primary key"
               emptyStrings={false}
-              onChange={function(value) {
-                props.onChange({primaryKey: value});
+              onChange={(value) => {
+                this.props.onChange({primaryKey: value});
               }}
               disabled={this.props.disabled}
             />

--- a/src/scripts/modules/ex-storage/react/components/SourceProject.jsx
+++ b/src/scripts/modules/ex-storage/react/components/SourceProject.jsx
@@ -16,7 +16,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <Form horizontal>
         <FormGroup>
@@ -28,8 +27,8 @@ export default React.createClass({
               componentClass="select"
               placeholder="select"
               value={this.props.value.url}
-              onChange={function(e) {
-                props.onChange({url: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({url: e.target.value});
               }}
               disabled={this.props.disabled}
             >
@@ -48,8 +47,8 @@ export default React.createClass({
             <FormControl
               type="password"
               value={this.props.value.token}
-              onChange={function(e) {
-                props.onChange({token: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({token: e.target.value});
               }}
               disabled={this.props.disabled}
             />

--- a/src/scripts/modules/ex-storage/react/components/SourceTable.jsx
+++ b/src/scripts/modules/ex-storage/react/components/SourceTable.jsx
@@ -18,7 +18,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     const panelExpanded = this.props.value.changedSince !== '';
     return (
       <Form horizontal>
@@ -31,8 +30,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.source}
-              onChange={function(e) {
-                props.onChange({source: e.target.value});
+              onChange={(e) => {
+                this.props.onChange({source: e.target.value});
               }}
               disabled={this.props.disabled}
             />
@@ -54,8 +53,8 @@ export default React.createClass({
             <Col sm={8}>
               <ChangedSinceInput
                 value={this.props.value.changedSince}
-                onChange={function(value) {
-                  props.onChange({changedSince: value});
+                onChange={(value) => {
+                  this.props.onChange({changedSince: value});
                 }}
                 disabled={this.props.disabled}
               />

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/Requires.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/Requires.jsx
@@ -26,10 +26,9 @@ export default React.createClass({
     };
   },
 
-  onValueClick: function(value) {
-    const props = this.props;
+  onValueClick(value) {
     return RoutesStore.getRouter().transitionTo('transformationDetail', {
-      config: props.bucketId,
+      config: this.props.bucketId,
       row: value.value
     });
   },

--- a/src/scripts/modules/wr-aws-s3/react/components/Configuration.jsx
+++ b/src/scripts/modules/wr-aws-s3/react/components/Configuration.jsx
@@ -17,7 +17,6 @@ export default React.createClass({
   },
 
   render() {
-    const props = this.props;
     return (
       <Form horizontal>
         <h3>Source</h3>
@@ -44,8 +43,8 @@ export default React.createClass({
             <FormControl
               type="text"
               value={this.props.value.destination}
-              onChange={function(e) {
-                props.onChange({destination: e.target.value.trim()});
+              onChange={(e) => {
+                this.props.onChange({destination: e.target.value.trim()});
               }}
               placeholder="myfolder/file.csv"
               disabled={this.props.disabled}

--- a/src/scripts/react/common/Select.jsx
+++ b/src/scripts/react/common/Select.jsx
@@ -106,8 +106,8 @@ export default React.createClass({
       }
     }
 
-    var filterOption = function(op) {
-      if (this.props.multi && exclude && fromJS(exclude).toMap().find(function(item) {
+    var filterOption = (op) => {
+      if (this.props.multi && exclude && fromJS(exclude).toMap().find((item) => {
         return item.get('value') === op.value;
       }, op)) {
         return false;
@@ -192,7 +192,7 @@ export default React.createClass({
   onChange(selected) {
     const {trimMultiCreatedValues} = this.props;
     if (this.props.multi) {
-      this.props.onChange(fromJS(selected.map(function(value) {
+      this.props.onChange(fromJS(selected.map((value) => {
         if (value.value === '%_EMPTY_STRING_%') {
           return '';
         }
@@ -216,12 +216,11 @@ export default React.createClass({
   },
 
   mapValuesSingle(value) {
-    const props = this.props;
     if (value) {
       let selectedOption = null;
       if (this.props.options) {
-        selectedOption = this.props.options.find(function(option) {
-          return option[props.valueKey] === value;
+        selectedOption = this.props.options.find((option) => {
+          return option[this.props.valueKey] === value;
         });
       }
       if (selectedOption) {
@@ -237,9 +236,8 @@ export default React.createClass({
   },
 
   mapValuesMulti(values) {
-    const props = this.props;
     if (values) {
-      return values.map(function(value) {
+      return values.map((value) => {
         if (value === '') {
           return {
             label: '%_EMPTY_STRING_%',
@@ -252,9 +250,9 @@ export default React.createClass({
           };
         } else {
           let selectedOption = null;
-          if (props.options) {
-            selectedOption = props.options.find(function(option) {
-              return option[props.valueKey] === value;
+          if (this.props.options) {
+            selectedOption = this.props.options.find((option) => {
+              return option[this.props.valueKey] === value;
             });
           }
           if (selectedOption) {


### PR DESCRIPTION
Related to #1577

Proposed changes:

- use props directly (`this.props`), not with new variable
- replaced few `function` keywords (`getX: function` -> `getX()`)
- replaced few `function` keywords with arrow `=>`