### PR TITLE
DB extractor - allow select all tables in schema on quickstart page

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -98,6 +98,7 @@ export default createReactClass({
               value={this.getQuickstartValue(this.props.quickstart.get('tables'))}
               placeholder="Select tables to copy"
               onChange={this.handleSelectChange}
+              filterOptions={this.filterOptions}
               optionRenderer={this.optionRenderer}
               options={this.transformOptions(this.getTableOptions())}
             />
@@ -131,6 +132,17 @@ export default createReactClass({
         />
       </div>
     );
+  },
+
+  filterOptions(options, filterString, values) {
+    const filterStr = filterString.toLowerCase();
+
+    return options.filter((op) => {
+      if (values.find((item) => item.label === op.label)) {
+        return false;
+      }
+      return !filterStr || op.label.toLowerCase().indexOf(filterStr) >= 0;
+    });
   },
 
   transformOptions(options) {

--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -101,7 +101,7 @@ export default createReactClass({
           <Col md={8} mdOffset={2}>
             <HelpBlock>
               Select the tables you&apos;d like to import to autogenerate your configuration. <br />
-              You can edit them later at any time.
+              Selecting a schema will add all tables from the schema.
             </HelpBlock>
           </Col>
         </Row>

--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -137,12 +137,19 @@ export default createReactClass({
   filterOptions(options, filterString, values) {
     const filterStr = filterString.toLowerCase();
 
-    return options.filter((op) => {
-      if (values.find((item) => item.label === op.label)) {
-        return false;
-      }
-      return !filterStr || op.label.toLowerCase().indexOf(filterStr) >= 0;
-    });
+    return options
+      .filter((option) => {
+        if (values.find((item) => item.label === option.label)) {
+          return false;
+        }
+        return !filterStr || option.label.toLowerCase().indexOf(filterStr) >= 0;
+      })
+      .filter((option, index, allOptions) => {
+        if (option.disabled && (!allOptions[index + 1] || allOptions[index + 1].disabled)) {
+          return false;
+        }
+        return true;
+      });
   },
 
   transformOptions(options) {
@@ -165,7 +172,6 @@ export default createReactClass({
         true
       );
       const children = o.children.map((c) => option(c.value, c.label, <div>{c.label}</div>));
-
       return acc.concat(parent).concat(children);
     }, []);
   },

--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -157,12 +157,6 @@ export default createReactClass({
           return false;
         }
         return !filterStr || option.label.toLowerCase().indexOf(filterStr) >= 0;
-      })
-      .filter((option, index, allOptions) => {
-        if (option.disabled && (!allOptions[index + 1] || allOptions[index + 1].disabled)) {
-          return false;
-        }
-        return true;
       });
   },
 


### PR DESCRIPTION
Related #3105

Koukám na to issue:
- "Když se dělá první konfigurace po zadání credentials, chtělo by to checkboxy na list tabulek + nějakej funkční search" - kvůli tomuto jsem právě přidal možnost kliknout na Schéma kde se pak přidají všechny tabulky z daného schématu

- "Když se pak přidává jen jedna nová konfigurace, chtělo by to při použití searche vidět SCHEMA tabulky, které teď zmizí." - to mi příjde že tam vidím furt schéma, že je tam `schema.name`

- "A jakmile se to nastaví, chtělo by to vidět jméno schematu už na úrovni jména konfigu." - tady jsem si říkal zda to nebude matoucí že zadám název třeba "Test" a najedou bude vlevo "schema.Test". Zda by to nemělo předvyplňovat už jméno ze schématem a pokud to uživatel tak bude chtít tak to tak nechá. Toto jsem teda zatím nedělal. Než se to neprobere.

Takže tu je jen ta možnost zvolit všechny tabulky ve schématu.

---

![Screenshot 2019-04-02 at 14 47 16](https://user-images.githubusercontent.com/419849/55403580-6c0f4800-5556-11e9-9401-f368d06a229d.png)

![Screenshot 2019-04-02 at 14 47 47](https://user-images.githubusercontent.com/419849/55403581-6c0f4800-5556-11e9-97d1-96fa58b46ce8.png)
