### PR TITLE
Allow create alias of alias

### DIFF
--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -134,7 +134,7 @@ export default createReactClass({
                   )}
                 </MenuItem>
                 {this.state.canWriteTable && <MenuItem divider />}
-                {!this.state.table.get('isAlias') && this.state.canWriteTable && (
+                {this.state.table.get('isAliasable') && this.state.canWriteTable && (
                   <MenuItem eventKey="alias" onSelect={this.handleDropdownAction}>
                     <i className="fa fa-plus" /> Create alias table
                   </MenuItem>
@@ -244,12 +244,8 @@ export default createReactClass({
         {this.renderDeletingTableModal()}
         {this.renderLoadTableModal()}
         {this.renderExportTableModal()}
-        {!this.state.table.get('isAlias') && this.state.canWriteTable && (
-          <span>
-            {this.renderAliasTableModal()}
-            {this.renderTruncateTableModal()}
-          </span>
-        )}
+        {this.renderAliasTableModal()}
+        {this.renderTruncateTableModal()}
       </div>
     );
   },


### PR DESCRIPTION
Povoluje vytváření aliasů z aliasů z detailu tabulky, používá nový flag `isAliasable`.

Mergovat až po nasazení backendu https://github.com/keboola/connection/pull/1889

Co by se dalo ještě vylepšit (Možná se to nemusí řešit teď ale až v nové konzoli kde je flow sdílení vymyšleno trochu jinak):

## Zakládání aliasu z detailu bucketu
Aktuálně nabízí všechny tabulky a po vybrání a submitu tabulky která nejde aliasovat vrátí hlášku backendu.

![image](https://user-images.githubusercontent.com/903531/54811970-49de1600-4c8a-11e9-9c72-0bb0058854e8.png)

Mohlo by to v tom listu nealiasovatelné tabulky odfiltrovat nebo možná lépe je ukázat jako disabled s důvodem proč nejdou aliasovat?

## Sdílený bucket
Bylo by fajn v tom listu nějak naznačit které tabulky nejsou sdílené (`isAliasable = false`)

![image](https://user-images.githubusercontent.com/903531/54812964-afcb9d00-4c8c-11e9-9b34-3e1cba0b8902.png)

