### PR TITLE
Replace 'react-code-mirror' with 'react-codemirror2'

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "react-autosuggest": "^9.4.3",
     "react-bootstrap": "^0.31.5",
     "react-clipboard.js": "^2.0.3",
-    "react-code-mirror": "^3.1.0",
+    "react-codemirror2": "^5.1.0",
     "react-datetime": "^2.16.3",
     "react-document-title": "^2.0.3",
     "react-dom": "^15.6.2",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bluebird": "^3.5.3",
     "byte-converter": "^0.1.4",
     "classnames": "^2.2.6",
-    "codemirror": "^5.44.0",
+    "codemirror": "^5.45.0",
     "create-react-class": "^15.6.3",
     "crypto-js": "^3.1.9-1",
     "d3": "~4.3.0",

--- a/src/scripts/modules/apify/react/Index/Index.jsx
+++ b/src/scripts/modules/apify/react/Index/Index.jsx
@@ -22,7 +22,7 @@ import SidebarJobsContainer from '../../../components/react/components/SidebarJo
 import LatestVersions from '../../../components/react/components/SidebarVersionsWrapper';
 import SetupModal from './SetupModal';
 import { ExternalLink } from '@keboola/indigo-ui';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 const COMPONENT_ID = 'apify.apify';
 
@@ -277,13 +277,15 @@ export default createReactClass({
     return (
       <div className="form-control-static">
         <CodeMirror
-          theme="solarized"
-          lineNumbers={false}
           value={value}
-          readOnly={true}
-          cursorHeight={0}
-          mode="application/json"
-          lineWrapping={true}
+          options={{
+            theme: 'solarized',
+            mode: 'application/json',
+            lineNumbers: false,
+            readOnly: true,
+            lineWrapping: true,
+            cursorHeight: 0,
+          }}
         />
       </div>
     );

--- a/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
+++ b/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
@@ -5,7 +5,7 @@ import { Tab, Tabs, FormGroup, Radio, HelpBlock } from 'react-bootstrap';
 import SapiTableSelector from '../../../components/react/components/SapiTableSelector';
 import ApifyObjectSelector from './ApifyObjectSelector';
 import { ExternalLink } from '@keboola/indigo-ui';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 export const CRAWLER_KEY = 1;
 export const AUTH_KEY = 2;
@@ -153,16 +153,19 @@ export default createReactClass({
           </div>
           <div className="col-xs-10">
             <CodeMirror
-              theme="solarized"
-              lineNumbers={false}
               value={this.props.settings}
-              readOnly={false}
-              mode="application/json"
-              lineWrapping={true}
-              autofocus={false}
-              onChange={this.handleCrawlerSettingsChange}
-              lint={true}
-              gutters={['CodeMirror-lint-markers']}/>
+              onBeforeChange={this.handleCrawlerSettingsChange}
+              options={{
+                theme: 'solarized',
+                mode: 'application/json',
+                lineNumbers: false,
+                readOnly: false,
+                lineWrapping: true,
+                autofocus: false,
+                lint: true,
+                gutters: ['CodeMirror-lint-markers']
+              }}
+            />
             <div className="help-text">
               (Optional) Contains input for the Actor in JSON format.
             </div>
@@ -183,16 +186,18 @@ export default createReactClass({
   renderCrawlerSettingsForm() {
     const editor = (
       <CodeMirror
-        theme="solarized"
-        lineNumbers={false}
         value={this.props.settings}
-        readOnly={false}
-        mode="application/json"
-        lineWrapping={true}
-        autofocus={false}
-        onChange={this.handleCrawlerSettingsChange}
-        lint={true}
-        gutters={['CodeMirror-lint-markers']}
+        onBeforeChange={this.handleCrawlerSettingsChange}
+        options={{
+          theme: 'solarized',
+          lineNumbers: false,
+          readOnly: false,
+          mode: 'application/json',
+          lineWrapping: true,
+          autofocus: false,
+          lint: true,
+          gutters: ['CodeMirror-lint-markers']
+        }}
       />
     );
     const eidHelp = 'Execution ID of the Crawler run to retrieve the results from.';
@@ -246,8 +251,7 @@ export default createReactClass({
     );
   },
 
-  handleCrawlerSettingsChange(e) {
-    const value = e.target.value;
+  handleCrawlerSettingsChange(editor, data, value) {
     this.props.updateSettings(value);
   },
 

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -1,11 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-// import ConfirmButtons from '../../../../react/common/ConfirmButtons';
-import JSONSchemaEditor from './JSONSchemaEditor';
 import Immutable from 'immutable';
+import { Controlled as CodeMirror } from 'react-codemirror2'
+import JSONSchemaEditor from './JSONSchemaEditor';
 import SaveButtons from '../../../../react/common/SaveButtons';
-import CodeMirror from 'react-code-mirror';
 
 export default createReactClass({
   propTypes: {
@@ -71,22 +70,24 @@ export default createReactClass({
         <p className="help-block small">Properties prefixed with <code>#</code> sign will be encrypted on save. Already encrypted strings will persist.</p>
         <CodeMirror
           value={this.props.data}
-          theme="solarized"
-          lineNumbers={true}
-          mode="application/json"
-          autofocus={true}
-          lineWrapping={true}
-          onChange={this.handleChange}
-          readOnly={this.props.isSaving}
-          lint={true}
-          gutters={['CodeMirror-lint-markers']}
+          onBeforeChange={this.handleChange}
+          options={{
+            theme: 'solarized',
+            mode: 'application/json',
+            lineNumbers: true,
+            autofocus: true,
+            lineWrapping: true,
+            readOnly: this.props.isSaving,
+            lint: true,
+            gutters: ['CodeMirror-lint-markers']
+          }}
         />
       </span>
     );
   },
 
-  handleChange(e) {
-    this.props.onChange(e.target.value);
+  handleChange(editor, data, value) {
+    this.props.onChange(value);
   },
 
   handleParamsChange(value) {

--- a/src/scripts/modules/components/react/components/ProcessorsInput.jsx
+++ b/src/scripts/modules/components/react/components/ProcessorsInput.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import { ExternalLink } from '@keboola/indigo-ui';
 
 export default createReactClass({
@@ -11,34 +11,25 @@ export default createReactClass({
     disabled: PropTypes.bool.isRequired
   },
 
-  componentWillUpdate(nextProps) {
-    if (this.refs.CodeMirror) {
-      if (nextProps.value === '') {
-        this.refs.CodeMirror.editor.setOption('lint', false);
-      } else {
-        this.refs.CodeMirror.editor.setOption('lint', true);
-      }
-    }
-  },
-
   render() {
     return (
       <div className="kbc-processor-edit">
         <div>
           <div className="edit form-group kbc-processor-editor">
             <CodeMirror
-              ref='CodeMirror'
-              theme='solarized'
-              mode='application/json'
-              autofocus
-              lineNumbers
-              lineWrapping
-              lint={false}
               value={this.props.value}
-              onChange={this.handleChange}
-              readOnly={this.props.disabled}
-              gutters={['CodeMirror-lint-markers']}
-              placeholder={JSON.stringify({before: [], after: []}, null, 2)}
+              onBeforeChange={this.handleChange}
+              options={{
+                theme: 'solarized',
+                mode: 'application/json',
+                autofocus: true,
+                lineNumbers: true,
+                lineWrapping: true,
+                lint: !!this.props.value,
+                readOnly: this.props.disabled,
+                gutters: ['CodeMirror-lint-markers'],
+                placeholder: JSON.stringify({before: [], after: []}, null, 2)
+              }}
             />
           </div>
           <div className="small help-block">
@@ -49,7 +40,7 @@ export default createReactClass({
     );
   },
 
-  handleChange(e) {
-    this.props.onChange(e.target.value);
+  handleChange(editor, data, value) {
+    this.props.onChange(value);
   }
 });

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -3,9 +3,9 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { ExternalLink } from '@keboola/indigo-ui';
 import JSONSchemaEditor from './JSONSchemaEditor';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import TemplateSelector from './ConfigurationTemplateSelector';
 import SaveButtons from '../../../../react/common/SaveButtons';
-import CodeMirror from 'react-code-mirror';
 
 export default createReactClass({
 
@@ -88,18 +88,19 @@ export default createReactClass({
         <p className="kbc-template-editor-toggle"><a onClick={this.switchToTemplateEditor}><small>Switch to templates</small></a></p>
         <p>JSON configuration uses <ExternalLink href="https://developers.keboola.com/extend/generic-extractor/">Generic extractor</ExternalLink> format.</p>
         <CodeMirror
-          ref="string"
           value={this.props.editingString}
-          theme="solarized"
-          lineNumbers={true}
-          mode="application/json"
-          lineWrapping={true}
-          autofocus={true}
-          onChange={this.handleStringChange}
-          readOnly={this.props.isSaving ? 'nocursor' : false}
-          lint={true}
-          gutters={['CodeMirror-lint-markers']}
-          placeholder="{}"
+          onBeforeChange={this.handleStringChange}
+          options={{
+            theme: 'solarized',
+            mode: 'application/json',
+            lineNumbers: true,
+            lineWrapping: true,
+            autofocus: true,
+            readOnly: this.props.isSaving,
+            lint: true,
+            gutters: ['CodeMirror-lint-markers'],
+            placeholder: '{}'
+          }}
         />
       </span>
     );
@@ -125,8 +126,8 @@ export default createReactClass({
     this.props.onChangeTemplate(value);
   },
 
-  handleStringChange(e) {
-    this.props.onChangeString(e.target.value);
+  handleStringChange(editor, data, value) {
+    this.props.onChangeString(value);
   },
 
   handleParamsChange(value) {

--- a/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
+++ b/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 export default createReactClass({
   propTypes: {
@@ -16,17 +16,19 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-json-editor">
             <CodeMirror
-              theme='solarized'
-              mode='application/json'
-              placeholder='Your JSON config goes here...'
-              lineNumbers
-              lint
-              autofocus
-              lineWrapping
               value={this.props.value}
-              onChange={this.handleChange}
-              readOnly={this.props.disabled}
-              gutters={['CodeMirror-lint-markers']}
+              onBeforeChange={this.handleChange}
+              options={{
+                theme: 'solarized',
+                mode: 'application/json',
+                placeholder: 'Your JSON config goes here...',
+                lineNumbers: true,
+                lint: true,
+                autofocus: true,
+                lineWrapping: true,
+                readOnly: this.props.disabled,
+                gutters: ['CodeMirror-lint-markers']
+              }}
             />
           </div>
           <div className="small help-block">
@@ -41,7 +43,7 @@ export default createReactClass({
     return null;
   },
 
-  handleChange(e) {
-    this.props.onChange(e.target.value);
+  handleChange(editor, data, value) {
+    this.props.onChange(value);
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import Immutable from 'immutable';
 import _ from 'underscore';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import { Button, Alert, FormGroup, ControlLabel, HelpBlock, Checkbox, Col } from 'react-bootstrap';
 
 import Select from '../../../../react/common/Select';
@@ -107,7 +107,7 @@ export default createReactClass({
     return this.props.onChange(this.props.query.setIn(['state', 'component'], Immutable.fromJS({})));
   },
 
-  handleQueryChange(value) {
+  handleQueryChange(editor, data, value) {
     return this.props.onChange(this.props.query.set('query', value));
   },
 
@@ -451,13 +451,15 @@ export default createReactClass({
           <label className="control-label">SQL Query</label>
           {this.renderQueryHelpBlock()}
           <CodeMirror
-            theme="solarized"
-            mode={editorMode(this.props.componentId)}
             value={this.getQuery()}
-            onChange={(e) => this.handleQueryChange(e.target.value)}
-            lineNumbers
-            lineWrapping={false}
-            placeholder={getQueryEditorPlaceholder(this.props.componentId)}
+            onBeforeChange={this.handleQueryChange}
+            options={{
+              theme: 'solarized',
+              mode: editorMode(this.props.componentId),
+              lineNumbers: true,
+              lineWrapping: false,
+              placeholder: getQueryEditorPlaceholder(this.props.componentId),
+            }}
             style={{ width: '100%' }}
           />
         </div>

--- a/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
+++ b/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import immutableMixin from 'react-immutable-render-mixin';
 import {Form, FormGroup, ControlLabel, Col, HelpBlock, Checkbox} from 'react-bootstrap';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 import editorMode from "../../../ex-db-generic/templates/editorMode";
 
@@ -46,15 +46,17 @@ export default createReactClass({
           </Col>
           <Col sm={8}>
             <CodeMirror
-              theme="solarized"
-              mode={editorMode(ExGoogleBigQueryV2ComponentId)}
               value={this.props.value.query}
-              onChange={(e) => this.props.onChange({query: e.target.value})}
-              lineNumbers
-              lineWrapping={false}
-              placeholder="e.g. SELECT `id`, `name` FROM `myTable`"
+              onBeforeChange={(editor, data, value) => this.props.onChange({query: value})}
+              options={{
+                theme: 'solarized',
+                mode: editorMode(ExGoogleBigQueryV2ComponentId),
+                lineNumbers: true,
+                lineWrapping: false,
+                readOnly: this.props.disabled,
+                placeholder: 'e.g. SELECT `id`, `name` FROM `myTable`'
+              }}
               style={{ width: '100%' }}
-              readOnly={this.props.disabled}
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryDetailStatic.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryDetailStatic.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import SapiTableLinkEx from '../../../components/react/components/StorageApiTableLinkEx';
 import editorMode from '../../../ex-db-generic/templates/editorMode';
 
@@ -61,12 +61,14 @@ const QueryDetailStatic = ({ query, componentId }) => {
             <div className="form-control-static">
               {query.get('query').length ? (
                 <CodeMirror
-                  theme="solarized"
-                  mode={editorMode(componentId)}
                   value={query.get('query')}
-                  lineNumbers={false}
-                  lineWrapping={false}
-                  readOnly
+                  options={{
+                    theme: 'solarized',
+                    mode: editorMode(componentId),
+                    lineNumbers: false,
+                    lineWrapping: false,
+                    readOnly: true
+                  }}
                   style={{width: '100%'}}
                 />
               ) : (

--- a/src/scripts/modules/ex-google-bigquery/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/components/QueryEditor.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import Select from '../../../../react/common/Select';
 import AutosuggestWrapper from '../../../transformations/react/components/mapping/AutoSuggestWrapper';
 import editorMode from '../../../ex-db-generic/templates/editorMode';
@@ -31,7 +31,7 @@ export default createReactClass({
     return this.props.onChange(this.props.query.set('useLegacySql', event.target.checked));
   },
 
-  _handleQueryChange(value) {
+  _handleQueryChange(editor, data, value) {
     return this.props.onChange(this.props.query.set('query', value));
   },
 
@@ -123,13 +123,15 @@ export default createReactClass({
             <div className="col-md-10 ">
               <div className="form-control-static">
                 <CodeMirror
-                  theme="solarized"
-                  mode={editorMode(this.props.componentId)}
                   value={this.props.query.get('query')}
-                  onChange={(e) => this._handleQueryChange(e.target.value)}
-                  lineNumbers
-                  lineWrapping={false}
-                  placeholder="e.g. SELECT `id`, `name` FROM `myTable`"
+                  onBeforeChange={this._handleQueryChange}
+                  options={{
+                    theme: 'solarized',
+                    mode: editorMode(this.props.componentId),
+                    lineNumbers: true,
+                    lineWrapping: false,
+                    placeholder: 'e.g. SELECT `id`, `name` FROM `myTable`'
+                  }}
                   style={{width: '100%'}}
                 />
               </div>

--- a/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import { FormGroup, FormControl, Col, ControlLabel, HelpBlock, Checkbox } from 'react-bootstrap';
 
 import LinkToDocs from './LinkToDocs';
@@ -22,17 +22,17 @@ export default createReactClass({
   handleIncrementalChange(event) {
     return this.props.onChange(this.props.query.set('incremental', event.target.checked));
   },
-  handleQueryChange(event) {
-    return this.props.onChange(this.props.query.set('query', event.target.value));
+  handleQueryChange(editor, data, value) {
+    return this.props.onChange(this.props.query.set('query', value));
   },
-  handleSortChange(event) {
-    return this.props.onChange(this.props.query.set('sort', event.target.value));
+  handleSortChange(editor, data, value) {
+    return this.props.onChange(this.props.query.set('sort', value));
   },
   handleLimitChange(event) {
     return this.props.onChange(this.props.query.set('limit', event.target.value));
   },
-  handleMappingChange(event) {
-    return this.props.onChange(this.props.query.set('mapping', event.target.value));
+  handleMappingChange(editor, data, value) {
+    return this.props.onChange(this.props.query.set('mapping', value));
   },
   handleCollectionChange(event) {
     return this.props.onChange(this.props.query.set('collection', event.target.value));
@@ -78,14 +78,16 @@ export default createReactClass({
             <Col componentClass={ControlLabel} md={3}>Query</Col>
             <Col md={9}>
               <CodeMirror
-                lineNumbers
-                lineWrapping
-                lint
-                mode="application/json"
-                onChange={this.handleQueryChange}
-                placeholder={'optional, e.g. {"isActive": 1, "isDeleted": 0}'}
-                theme="solarized"
                 value={this.props.query.has('query') ? this.props.query.get('query') : ''}
+                onBeforeChange={this.handleQueryChange}
+                options={{
+                  theme: 'solarized',
+                  mode: 'application/json',
+                  lineNumbers: true,
+                  lineWrapping: true,
+                  lint: true,
+                  placeholder: 'optional, e.g. {"isActive": 1, "isDeleted": 0}'
+                }}
               />
               <HelpBlock>Query to filter documents. Has to be valid JSON.</HelpBlock>
             </Col>
@@ -95,14 +97,16 @@ export default createReactClass({
             <Col componentClass={ControlLabel} md={3}>Sort</Col>
             <Col md={9}>
               <CodeMirror
-                lineNumbers
-                lineWrapping
-                lint
-                mode="application/json"
-                onChange={this.handleSortChange}
-                placeholder={'optional, e.g. {"creationDate": -1}'}
-                theme="solarized"
                 value={this.props.query.has('sort') ? this.props.query.get('sort').toString() : ''}
+                onBeforeChange={this.handleSortChange}
+                options={{
+                  theme: 'solarized',
+                  mode: 'application/json',
+                  lineNumbers: true,
+                  lineWrapping: true,
+                  lint: true,
+                  placeholder: 'optional, e.g. {"creationDate": -1}'
+                }}
               />
               <HelpBlock>Sort results by specified keys. Has to be valid JSON.</HelpBlock>
             </Col>
@@ -167,14 +171,16 @@ export default createReactClass({
           <Col componentClass={ControlLabel} md={3}>Mapping</Col>
           <Col md={9}>
             <CodeMirror
-              lineNumbers
-              lineWrapping
-              lint
-              mode="application/json"
-              onChange={this.handleMappingChange}
-              placeholder={'e.g. {"_id.$oid": "id", "name": "name"}'}
-              theme="solarized"
               value={mappingValue}
+              onBeforeChange={this.handleMappingChange}
+              options={{
+                theme: 'solarized',
+                mode: 'application/json',
+                lineNumbers: true,
+                lineWrapping: true,
+                lint: true,
+                placeholder: 'e.g. {"_id.$oid": "id", "name": "name"}'
+              }}
             />
             <HelpBlock>Mapping to define the structure of exported tables. Has to be valid JSON.</HelpBlock>
           </Col>

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 export default createReactClass({
   propTypes: {
@@ -24,34 +24,37 @@ export default createReactClass({
       return (
         <CodeMirror
           value={this.props.data}
-          theme="solarized"
-          lineNumbers={true}
-          mode="application/json"
-          autofocus={true}
-          lineWrapping={true}
-          onChange={this.handleChange}
-          readOnly={this.props.isSaving}
-          lint={true}
-          gutters={['CodeMirror-lint-markers']}
-        />
-      );
-    } else {
-      return (
-        <CodeMirror
-          theme="solarized"
-          lineNumbers={true}
-          defaultValue={this.props.data}
-          readOnly={true}
-          cursorHeight={0}
-          mode="application/json"
-          lineWrapping={true}
+          onBeforeChange={this.handleChange}
+          options={{
+            theme: 'solarized',
+            mode: 'application/json',
+            lineNumbers: true,
+            autofocus: true,
+            lineWrapping: true,
+            readOnly: this.props.isSaving,
+            lint: true,
+            gutters: ['CodeMirror-lint-markers']
+          }}
         />
       );
     }
+
+    return (
+      <CodeMirror
+        value={this.props.data}
+        options={{
+          theme: 'solarized',
+          mode: 'application/json',
+          lineNumbers: true,
+          readOnly: true,
+          lineWrapping: true,
+          cursorHeight: 0
+        }}
+      />
+    );
   },
 
-  handleChange(e) {
-    const value = e.target.value;
+  handleChange(editor, data, value) {
     this.props.onChange(value);
   }
 });

--- a/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
+++ b/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { Modal, ButtonToolbar, Button } from 'react-bootstrap';
 import Tooltip from '../../../../react/common/Tooltip';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 export default createReactClass({
   propTypes: {
@@ -40,18 +40,20 @@ export default createReactClass({
   renderJsonArea() {
     return (
       <CodeMirror
-        theme="solarized"
-        lineNumbers={true}
         value={this.state.parametersString}
-        readOnly={!this.props.isEditable}
-        cursorHeight={!this.props.isEditable ? 0 : 1}
-        height="auto"
-        mode="application/json"
-        lineWrapping={true}
-        autoFocus={this.props.isEditable}
-        onChange={this._handleChange}
-        lint={true}
-        gutters={['CodeMirror-lint-markers']}
+        onBeforeChange={this._handleChange}
+        options={{
+          theme: 'solarized',
+          mode: 'application/json',
+          cursorHeight: !this.props.isEditable ? 0 : 1,
+          height: 'auto',
+          readOnly: !this.props.isEditable,
+          autoFocus: this.props.isEditable,
+          lineNumbers: true,
+          lineWrapping: true,
+          lint: true,
+          gutters: ['CodeMirror-lint-markers']
+        }}
       />
     );
   },
@@ -92,13 +94,13 @@ export default createReactClass({
     );
   },
 
-  _handleChange(e) {
+  _handleChange(editor, data, value) {
     this.setState({
-      parametersString: e.target.value
+      parametersString: value
     });
     try {
       return this.setState({
-        parameters: JSON.parse(e.target.value),
+        parameters: JSON.parse(value),
         isValid: true
       });
     } catch (error) {

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 import resolveHighlightMode from './resolveHighlightMode';
 import {ExternalLink} from '@keboola/indigo-ui';
 import normalizeNewlines from './normalizeNewlines';
@@ -34,15 +34,17 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-queries-editor">
             <CodeMirror 
-              theme='solarized'
-              lineNumbers
-              autofocus
-              lineWrapping
               value={normalizeNewlines(this.props.script)}
-              mode={resolveHighlightMode('docker', this.props.backend)}
-              onChange={this.handleChange}
-              readOnly={this.props.disabled}
-              {...codeMirrorParams}
+              onBeforeChange={this.handleChange}
+              options={{
+                theme: 'solarized',
+                mode: resolveHighlightMode('docker', this.props.backend),
+                lineNumbers: true,
+                autofocus: true,
+                lineWrapping: true,
+                readOnly: this.props.disabled,
+                ...codeMirrorParams
+              }}
             />
           </div>
           <div className="small help-block">
@@ -65,7 +67,7 @@ export default createReactClass({
     }
   },
 
-  handleChange(e) {
-    this.props.onChange(normalizeNewlines(e.target.value));
+  handleChange(editor, data, value) {
+    this.props.onChange(normalizeNewlines(value));
   }
 });

--- a/src/scripts/react/common/VersionsDiffModalComponents/DetailedDiff.jsx
+++ b/src/scripts/react/common/VersionsDiffModalComponents/DetailedDiff.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import _ from 'underscore';
 import {createTwoFilesPatch} from 'diff';
-import CodeMirror from 'react-code-mirror';
+import { Controlled as CodeMirror } from 'react-codemirror2'
 
 function multiDiffValueToString(value) {
   if (_.isArray(value)) {
@@ -96,12 +96,14 @@ export default createReactClass({
 
     return (
       <CodeMirror
-        theme="solarized"
-        mode="diff"
         value={multiDiff}
-        lineNumbers={false}
-        lineWrapping={false}
-        readOnly
+        options={{
+          theme: 'solarized',
+          mode: 'diff',
+          lineNumbers: false,
+          lineWrapping: false,
+          readOnly: true
+        }}
         style={{width: '100%'}}
       />
     );

--- a/src/styles/theme-kbc-codemirror.less
+++ b/src/styles/theme-kbc-codemirror.less
@@ -14,9 +14,6 @@ pre.CodeMirror-placeholder {
 .kbc-main-content .CodeMirror {
   height: auto;
   background: none;
-  .CodeMirror-cursors {
-
-  }
 }
 
 .kbc-main-content .edit .CodeMirror {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1957,10 +1957,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@^5.44.0:
-  version "5.44.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.44.0.tgz#80dc2a231eeb7aab25ec2405cdca37e693ccf9cc"
-  integrity sha512-3l42syTNakCdCQuYeZJXTyxina6Y9i4V0ighSJXNCQtRbaCN76smKKLu1ZHPHQon3rnzC7l4i/0r4gp809K1wg==
+codemirror@^5.45.0:
+  version "5.45.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.45.0.tgz#db5ebbb3bf44028c684053f3954d011efcec27ad"
+  integrity sha512-c19j644usCE8gQaXa0jqn2B/HN9MnB2u6qPIrrhrMkB+QAP42y8G4QnTwuwbVSoUS1jEl7JU9HZMGhCDL0nsAw==
 
 collection-visit@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7549,10 +7549,10 @@ react-clipboard.js@^2.0.3:
     clipboard "^2.0.0"
     prop-types "^15.5.0"
 
-react-code-mirror@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-code-mirror/-/react-code-mirror-3.1.0.tgz#d1e34a417dc9555dddbd63528f9fa6370d46fc44"
-  integrity sha1-0eNKQX3JVV3dvWNSj5+mNw1G/EQ=
+react-codemirror2@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-5.1.0.tgz#62de4460178adea40eb52eabf7491669bf3794b8"
+  integrity sha512-Cksbgbviuf2mJfMyrKmcu7ycK6zX/ukuQO8dvRZdFWqATf5joalhjFc6etnBdGCcPA2LbhIwz+OPnQxLN/j1Fw==
 
 react-datetime@^2.16.3:
   version "2.16.3"


### PR DESCRIPTION
Related #3032 (required React 15)

Update šel dobře. V nové verzi se bud používá Controller nebo Uncontroller verze, vše jsem převedl na Controlled.

- většinou šlo o to jen přesunout nastavení do props `options`.
- pak místo `onChange => e` přepsat na `onBeforeChange = (editor, data, value) =>`
- místo `ref` použít `editorDidMount => editor`

Jen u `ProcessorsInput` jsem vymazal nějakou logiku kolem lintu a hodil to přímo do těch options.