### PR TITLE
Inputs, Checkboxes atc - Do not set value as null or undefined

### DIFF
--- a/src/scripts/modules/components/react/components/generic/FileInputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileInputMappingEditor.jsx
@@ -98,7 +98,7 @@ export default createReactClass({
             <Col xs={10}>
               <FormControl
                 type="text"
-                value={this.props.value.get('query')}
+                value={this.props.value.get('query', '')}
                 onChange={this._handleChangeQuery}
                 disabled={this.props.disabled}
                 placeholder="Search query"

--- a/src/scripts/modules/components/react/components/generic/FileOutputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileOutputMappingEditor.jsx
@@ -69,7 +69,7 @@ export default createReactClass({
             <FormControl
               type="text"
               autoFocus
-              value={this.props.value.get('source')}
+              value={this.props.value.get('source', '')}
               onChange={this._handleChangeSource}
               disabled={this.props.disabled}
             />
@@ -99,7 +99,7 @@ export default createReactClass({
           <FormGroup>
             <Col xs={10} xsOffset={2}>
               <Checkbox
-                checked={this.props.value.get('is_public')}
+                checked={this.props.value.get('is_public', false)}
                 onChange={this._handleChangeIsPublic}
                 disabled={this.props.disabled}
               >
@@ -113,7 +113,7 @@ export default createReactClass({
           <FormGroup>
             <Col xs={10} xsOffset={2}>
               <Checkbox
-                checked={this.props.value.get('is_permanent')}
+                checked={this.props.value.get('is_permanent', false)}
                 onChange={this._handleChangeIsPermanent}
                 disabled={this.props.disabled}
               >

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.jsx
@@ -41,7 +41,7 @@ export default createReactClass({
           <label className="col-xs-2 control-label">Source</label>
           <div className="col-xs-10">
             <SapiTableSelector
-              value={this.props.value.get('source')}
+              value={this.props.value.get('source', '')}
               disabled={this.props.disabled}
               placeholder="Source table"
               onSelectTableFn={this.handleChangeSource}
@@ -57,7 +57,7 @@ export default createReactClass({
             <Col xs={10}>
               <FormControl
                 type="text"
-                value={this.props.value.get('destination')}
+                value={this.props.value.get('destination', '')}
                 disabled={this.props.disabled}
                 placeholder="File name"
                 onChange={this.handleChangeDestination}

--- a/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableOutputMappingEditor.jsx
@@ -163,7 +163,7 @@ export default createReactClass({
                 type="text"
                 name="source"
                 autoFocus
-                value={this.props.value.get('source')}
+                value={this.props.value.get('source', '')}
                 disabled={this.props.disabled}
                 placeholder="File name"
                 onFocus={this._handleFocusSource}
@@ -196,7 +196,7 @@ export default createReactClass({
             <Col xs={10} xsOffset={2}>
               <Checkbox
                 name="incremental"
-                checked={this.props.value.get('incremental')}
+                checked={this.props.value.get('incremental', false)}
                 disabled={this.props.disabled}
                 onChange={this._handleChangeIncremental}
               >

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -430,12 +430,12 @@ export default createReactClass({
           <div className="col-md-9 col-md-offset-3 checkbox">
             <label>
               <input
-                standalone={true}
                 type="checkbox"
                 label="Use query editor"
                 checked={!!this.props.query.get('advancedMode')}
                 disabled={this.props.disabled}
-                onChange={this.handleToggleUseQueryEditor}/>
+                onChange={this.handleToggleUseQueryEditor}
+              />
               Create your own query using an SQL editor
             </label>
           </div>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.jsx
@@ -153,7 +153,7 @@ export default createReactClass({
             <Col sm={10}>
               <FormControl
                 type="text"
-                value={this.props.value.get('destination')}
+                value={this.props.value.get('destination', '')}
                 disabled={this.props.disabled}
                 placeholder="File name"
                 onChange={this._handleChangeDestination}

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
@@ -224,7 +224,6 @@ export default createReactClass({
               <div className="checkbox">
                 <label>
                   <input
-                    standalone={true}
                     type="checkbox"
                     checked={this.props.value.get('optional')}
                     disabled={this.props.disabled}

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -277,7 +277,7 @@ export default createReactClass({
           <Col sm={10}>
             <FormControl
               type="text"
-              value={this.props.value.get('destination')}
+              value={this.props.value.get('destination', '')}
               disabled={this.props.disabled}
               placeholder="Destination table name in transformation DB"
               onChange={this._handleChangeDestination}

--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
@@ -172,7 +172,7 @@ export default createReactClass({
                     autoFocus
                     type="text"
                     name="source"
-                    value={this.props.value.get('source')}
+                    value={this.props.value.get('source', '')}
                     disabled={this.props.disabled}
                     placeholder="File name"
                     onFocus={this._handleFocusSource}

--- a/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
+++ b/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
@@ -62,6 +62,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         onChange={[Function]}
         placeholder="Destination table name in transformation DB"
         type="text"
+        value=""
       />
     </Col>
   </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/input/DatatypeFormRow.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/input/DatatypeFormRow.jsx
@@ -5,7 +5,6 @@ import { FormControl, Checkbox } from 'react-bootstrap';
 import Select from 'react-select';
 
 export default createReactClass({
-
   propTypes: {
     columnName: PropTypes.string.isRequired,
     datatype: PropTypes.object.isRequired,
@@ -110,7 +109,7 @@ export default createReactClass({
               name={this.props.columnName + '_length'}
               type="text"
               size={15}
-              value={this.props.datatype.get('length')}
+              value={this.props.datatype.get('length') || ''}
               onChange={this.handleLengthChange}
               disabled={this.props.disabled || !this.lengthEnabled()}
               placeholder="Length, eg. 38,0"


### PR DESCRIPTION
Related #3032

React 15+ stěžuje pokud z uncontrolled komponenty najednou uděláme controlled.

Jde o to že někde jako default variantu třeba textového inputu máme `null` nebo `undefined` a až uživatel něco napíše, teprve to tam vložíme.

Nevím moc kolik takových věcí bude.

Upravil jsem nějaké inputu a nějaké checkboxy, tam by taky mělo být vždy false nebo true a ne null nebo tak. Plus jsem smazal props "standalone" u dvou checkboxů které tam byly navíc.