### PR TITLE
Prevent delete unrelated configs in RowsStore

### DIFF
--- a/src/scripts/modules/configurations/ConfigurationRowsStore.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsStore.js
@@ -95,9 +95,11 @@ Dispatcher.register(function(payload) {
     case InstalledComponentsConstants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_LOAD_SUCCESS:
       _store = _store.withMutations((store) => {
         store.deleteIn(['rows', action.componentId, action.configId]);
+        let orderedRows = Immutable.OrderedMap();
         action.data.rows.forEach((row) => {
-          store.setIn(['rows', action.componentId, action.configId, row.id], fromJSOrdered(row));
+          orderedRows = orderedRows.set(row.id, Immutable.fromJS(row));
         });
+        store.setIn(['rows', action.componentId, action.configId], orderedRows);
       });
       return ConfigurationRowsStore.emitChange();
 
@@ -105,9 +107,11 @@ Dispatcher.register(function(payload) {
       _store = _store.withMutations((store) => {
         action.configData.forEach((configuration) => {
           store.deleteIn(['rows', action.componentId, configuration.id]);
+          let orderedRows = Immutable.OrderedMap();
           configuration.rows.forEach((row) => {
-            store.setIn(['rows', action.componentId, configuration.id, row.id], fromJSOrdered(row));
+            orderedRows = orderedRows.set(row.id, Immutable.fromJS(row));
           });
+          store.setIn(['rows', action.componentId, configuration.id], orderedRows);
         });
       });
       return ConfigurationRowsStore.emitChange();

--- a/src/scripts/modules/configurations/ConfigurationRowsStore.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsStore.js
@@ -93,33 +93,24 @@ Dispatcher.register(function(payload) {
   const action = payload.action;
   switch (action.type) {
     case InstalledComponentsConstants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_LOAD_SUCCESS:
-      _store = _store.withMutations(function(store) {
-        let retVal = store;
-        retVal = retVal.deleteIn(['rows', action.componentId, action.configId]);
-        let orderedRows = Immutable.OrderedMap();
-        action.data.rows.forEach(function(row) {
-          orderedRows = orderedRows.set(row.id, Immutable.fromJS(row));
+      _store = _store.withMutations((store) => {
+        store.deleteIn(['rows', action.componentId, action.configId]);
+        action.data.rows.forEach((row) => {
+          store.setIn(['rows', action.componentId, action.configId, row.id], fromJSOrdered(row));
         });
-        retVal = retVal.setIn(['rows', action.componentId, action.configId], orderedRows);
-        return retVal;
       });
       return ConfigurationRowsStore.emitChange();
 
     case InstalledComponentsConstants.ActionTypes.INSTALLED_COMPONENTS_CONFIGSDATA_LOAD_SUCCESS:
-      _store = _store.withMutations(function(store) {
-        let retVal = store;
-        action.configData.forEach(function(config) {
-          retVal = retVal.deleteIn(['rows', action.componentId]);
-          let orderedRows = Immutable.OrderedMap();
-          config.rows.forEach(function(row) {
-            orderedRows = orderedRows.set(row.id, Immutable.fromJS(row));
+      _store = _store.withMutations((store) => {
+        action.configData.forEach((configuration) => {
+          store.deleteIn(['rows', action.componentId, configuration.id]);
+          configuration.rows.forEach((row) => {
+            store.setIn(['rows', action.componentId, configuration.id, row.id], fromJSOrdered(row));
           });
-          retVal = retVal.setIn(['rows', action.componentId, config.id], orderedRows);
         });
-        return retVal;
       });
       return ConfigurationRowsStore.emitChange();
-
 
     case constants.ActionTypes.CONFIGURATION_ROWS_CREATE_START:
       _store = _store.setIn(['creating', action.componentId, action.configurationId], true);


### PR DESCRIPTION
Fixes #3138

Jaký je vůbec rozdíl mezi ConfigurationRowsStore a třeba InstalledComponentsStore. Koukám že "configRows" či "configRowsData" se ukládá právě i do InstalledComponentsStore. Asi aby v tom byl lepší přehled že. Je mě to zajíma :)

K bugu:
- jde o smazaný řádek 112, kde chybí parametr `configuration.id`, takže pokud má nějaká komponenta více konfigurací tak první se uloží, druhá smaže vše a uloží sebe, třetí smaže vše a uloží sama sebe. Nakonec tam zbude jen data poslední konfigurace dané komponenty.