### PR TITLE
Fix unhandled promises warning & Remove useless returns in promise chain

### DIFF
--- a/src/scripts/Dispatcher.js
+++ b/src/scripts/Dispatcher.js
@@ -9,7 +9,7 @@ class KbcDispatcher extends Dispatcher {
       console.log('dispatch', action.type); // eslint-disable-line
     }
 
-    return this.dispatch({
+    this.dispatch({
       source: PayloadSources.VIEW_ACTION,
       action
     });

--- a/src/scripts/actions/ApplicationActionCreators.js
+++ b/src/scripts/actions/ApplicationActionCreators.js
@@ -4,7 +4,7 @@ import _ from 'underscore';
 
 export default {
   receiveApplicationData(data) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.APPLICATION_DATA_RECEIVED,
       applicationData: data
     });
@@ -42,7 +42,7 @@ export default {
   },
 
   deleteNotification(id, forceDelete) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.APPLICATION_DELETE_NOTIFICATION,
       notificationId: id,
       forceDelete
@@ -50,7 +50,7 @@ export default {
   },
 
   pauseNotificationAging(id) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.APPLICATION_SET_PAUSE_NOTIFICATION,
       notificationId: id,
       paused: true

--- a/src/scripts/actions/RouterActionCreators.js
+++ b/src/scripts/actions/RouterActionCreators.js
@@ -3,35 +3,35 @@ import * as constants from '../constants/KbcConstants';
 
 export default {
   routesConfigurationReceive(routes) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ROUTER_ROUTES_CONFIGURATION_RECEIVE,
       routes
     });
   },
 
   routeChangeStart(newRouterState) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ROUTER_ROUTE_CHANGE_START,
       routerState: newRouterState
     });
   },
 
   routeChangeSuccess(routerState) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ROUTER_ROUTE_CHANGE_SUCCESS,
       routerState
     });
   },
 
   routeChangeError(error) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ROUTER_ROUTE_CHANGE_ERROR,
       error
     });
   },
 
   routerCreated(router) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ROUTER_ROUTER_CREATED,
       router
     });

--- a/src/scripts/modules/components/ComponentsActionCreators.js
+++ b/src/scripts/modules/components/ComponentsActionCreators.js
@@ -5,7 +5,7 @@ import { ActionTypes } from './Constants';
 
 export default {
   setComponentsFilter(query, componentType) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: ActionTypes.COMPONENTS_SET_FILTER,
       query,
       componentType
@@ -13,7 +13,7 @@ export default {
   },
 
   receiveAllComponents(componentsRaw) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: ActionTypes.COMPONENTS_LOAD_SUCCESS,
       components: componentsRaw
     });

--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -57,7 +57,7 @@ export default {
       type: constants.ActionTypes.INSTALLED_COMPONENTS_LOAD
     });
     return installedComponentsApi.getComponents().then(function(components) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_LOAD_SUCCESS,
         components: components
       });
@@ -75,7 +75,7 @@ export default {
       type: constants.ActionTypes.DELETED_COMPONENTS_LOAD
     });
     return installedComponentsApi.getDeletedComponents().then(function(components) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.DELETED_COMPONENTS_LOAD_SUCCESS,
         components: components
       });
@@ -160,12 +160,13 @@ export default {
     }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update configuration').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATA_SAVE_SUCCESS,
         componentId: componentId,
         configId: configId,
         configData: response.configuration
       });
+      return null;
     }).catch(function(error) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATA_SAVE_ERROR,
@@ -193,12 +194,13 @@ export default {
     }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update parameters').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATAPARAMETERS_SAVE_SUCCESS,
         componentId: componentId,
         configId: configId,
         configData: response.configuration
       });
+      return null;
     }).catch(function(error) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATAPARAMETERS_SAVE_ERROR,
@@ -222,12 +224,13 @@ export default {
     }
     return storeEncodedConfig(componentId, configId, dataToSave, changeDescription).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_SAVE_SUCCESS,
         componentId: componentId,
         configId: configId,
         configData: response.configuration
       });
+      return null;
     }).catch(function(error) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_SAVE_ERROR,
@@ -238,7 +241,7 @@ export default {
     });
   },
   updateLocalState: function(componentId, configId, data, path) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_LOCAL_STATE_UPDATE,
       componentId: componentId,
       configId: configId,
@@ -247,7 +250,7 @@ export default {
     });
   },
   updateEditComponentConfigData: function(componentId, configId, newData) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_EDIT_UPDATE,
       componentId: componentId,
       configId: configId,
@@ -255,14 +258,14 @@ export default {
     });
   },
   cancelEditComponentConfigData: function(componentId, configId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGDATA_EDIT_CANCEL,
       componentId: componentId,
       configId: configId
     });
   },
   updateEditComponentRawConfigData: function(componentId, configId, newData) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATA_EDIT_UPDATE,
       componentId: componentId,
       configId: configId,
@@ -270,14 +273,14 @@ export default {
     });
   },
   cancelEditComponentRawConfigData: function(componentId, configId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATA_EDIT_CANCEL,
       componentId: componentId,
       configId: configId
     });
   },
   updateEditComponentRawConfigDataParameters: function(componentId, configId, newData) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATAPARAMETERS_EDIT_UPDATE,
       componentId: componentId,
       configId: configId,
@@ -285,7 +288,7 @@ export default {
     });
   },
   cancelEditComponentRawConfigDataParameters: function(componentId, configId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_RAWCONFIGDATAPARAMETERS_EDIT_CANCEL,
       componentId: componentId,
       configId: configId
@@ -304,13 +307,13 @@ export default {
     return this.loadDeletedComponentsForce();
   },
   receiveAllComponents: function(componentsRaw) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_LOAD_SUCCESS,
       components: componentsRaw
     });
   },
   startConfigurationEdit: function(componentId, configurationId, field) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_EDIT_START,
       componentId: componentId,
       configurationId: configurationId,
@@ -318,7 +321,7 @@ export default {
     });
   },
   updateEditingConfiguration: function(componentId, configurationId, field, newValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_EDIT_UPDATE,
       configurationId: configurationId,
       componentId: componentId,
@@ -327,7 +330,7 @@ export default {
     });
   },
   cancelConfigurationEdit: function(componentId, configurationId, field) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_EDIT_CANCEL,
       componentId: componentId,
       configurationId: configurationId,
@@ -355,13 +358,14 @@ export default {
     }
     return calledFunction(componentId, configurationId, data).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configurationId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_SUCCESS,
         componentId: componentId,
         configurationId: configurationId,
         field: field,
         data: response
       });
+      return null;
     }).catch(function(e) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ERROR,
@@ -418,7 +422,7 @@ export default {
     });
   },
   deletedConfigurationsFilterChange: function(query, filterType) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.DELETED_COMPONENTS_FILTER_CHANGE,
       filter: query,
       filterType: filterType
@@ -564,7 +568,7 @@ export default {
     });
   },
   toggleMapping: function(componentId, configId, index) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_TOGGLE_MAPPING,
       componentId: componentId,
       configId: configId,
@@ -572,7 +576,7 @@ export default {
     });
   },
   startEditingMapping: function(componentId, configId, type, storage, index) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_EDITING_START,
       componentId: componentId,
       configId: configId,
@@ -582,7 +586,7 @@ export default {
     });
   },
   cancelEditingMapping: function(componentId, configId, type, storage, index) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_EDITING_CANCEL,
       componentId: componentId,
       configId: configId,
@@ -592,7 +596,7 @@ export default {
     });
   },
   changeEditingMapping: function(componentId, configId, type, storage, index, value) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_EDITING_CHANGE,
       componentId: componentId,
       configId: configId,
@@ -627,7 +631,7 @@ export default {
     data = dataToSave.setIn(pathDestination, mappingData.getIn(pathSource)).toJSON();
     return storeEncodedConfig(componentId, configId, data, changeDescription).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_SAVE_SUCCESS,
         componentId: componentId,
         configId: configId,
@@ -636,6 +640,7 @@ export default {
         index: index,
         data: response
       });
+      return null;
     }).catch(function(e) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_SAVE_ERROR,
@@ -661,7 +666,7 @@ export default {
     data = dataToSave.deleteIn(path).toJSON();
     return storeEncodedConfig(componentId, configId, data, changeDescription).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_DELETE_SUCCESS,
         componentId: componentId,
         configId: configId,
@@ -670,6 +675,7 @@ export default {
         index: index,
         data: response
       });
+      return null;
     }).catch(function(e) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_MAPPING_DELETE_ERROR,
@@ -681,14 +687,14 @@ export default {
     });
   },
   cancelEditTemplatedComponentConfigData: function(componentId, configId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_CANCEL,
       componentId: componentId,
       configId: configId
     });
   },
   updateEditTemplatedComponentConfigDataTemplate: function(componentId, configId, template) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_UPDATE_TEMPLATE,
       componentId: componentId,
       configId: configId,
@@ -696,7 +702,7 @@ export default {
     });
   },
   updateEditTemplatedComponentConfigDataString: function(componentId, configId, value) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_UPDATE_STRING,
       componentId: componentId,
       configId: configId,
@@ -704,7 +710,7 @@ export default {
     });
   },
   updateEditTemplatedComponentConfigDataParams: function(componentId, configId, value) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_UPDATE_PARAMS,
       componentId: componentId,
       configId: configId,
@@ -724,12 +730,13 @@ export default {
     }
     return storeEncodedConfig(componentId, configId, dataToSave, 'Update parameters').then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_SAVE_SUCCESS,
         componentId: componentId,
         configId: configId,
         configData: response.configuration
       });
+      return null;
     }).catch(function(error) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_SAVE_ERROR,
@@ -740,7 +747,7 @@ export default {
     });
   },
   toggleEditTemplatedComponentConfigDataString: function(componentId, configId, isStringEditingMode) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_TEMPLATED_CONFIGURATION_EDIT_STRING_TOGGLE,
       componentId: componentId,
       configId: configId,
@@ -748,21 +755,21 @@ export default {
     });
   },
   setInstalledComponentsConfigurationFilter: function(componentType, query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_SEARCH_CONFIGURATION_FILTER_CHANGE,
       componentType: componentType,
       filter: query
     });
   },
   setInstalledComponentsComponentDetailFilter: function(componentId, query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_SEARCH_COMPONENT_DETAIL_FILTER_CHANGE,
       componentId: componentId,
       filter: query
     });
   },
   startConfigurationRowEdit: function(componentId, configurationId, rowId, field, fallbackValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_ROW_EDIT_START,
       componentId: componentId,
       configurationId: configurationId,
@@ -772,7 +779,7 @@ export default {
     });
   },
   updateEditingConfigurationRow: function(componentId, configurationId, rowId, field, newValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_ROW_EDIT_UPDATE,
       configurationId: configurationId,
       componentId: componentId,
@@ -782,7 +789,7 @@ export default {
     });
   },
   cancelConfigurationRowEdit: function(componentId, configurationId, rowId, field) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGURATION_ROW_EDIT_CANCEL,
       componentId: componentId,
       configurationId: configurationId,
@@ -813,7 +820,7 @@ export default {
     }
     return calledFunction(componentId, configurationId, rowId, data, changeDescription).then(function(response) {
       VersionActionCreators.loadVersionsForce(componentId, configurationId);
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_SUCCESS,
         componentId: componentId,
         configurationId: configurationId,
@@ -821,6 +828,7 @@ export default {
         field: field,
         data: response
       });
+      return null;
     }).catch(function(e) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_ERROR,
@@ -843,12 +851,13 @@ export default {
     return installedComponentsApi.createConfigurationRow(componentId, configurationId, data, changeDescription)
       .then(function(response) {
         VersionActionCreators.loadVersionsForce(componentId, configurationId);
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_SUCCESS,
           componentId: componentId,
           configurationId: configurationId,
           data: response
         });
+        return null;
       }).catch(function(e) {
         dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_CREATE_CONFIGURATION_ROW_ERROR,
@@ -875,6 +884,7 @@ export default {
           configurationId: configurationId,
           rowId: rowId
         });
+        return null;
       }).catch(function(e) {
         dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_DELETE_CONFIGURATION_ROW_ERROR,
@@ -897,13 +907,14 @@ export default {
     return installedComponentsApi.updateConfigurationRow(componentId, configurationId, rowId, data, changeDescription)
       .then(function(response) {
         VersionActionCreators.loadVersionsForce(componentId, configurationId);
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_SUCCESS,
           componentId: componentId,
           configurationId: configurationId,
           rowId: rowId,
           data: response
         });
+        return null;
       }).catch(function(e) {
         dispatcher.handleViewAction({
           type: constants.ActionTypes.INSTALLED_COMPONENTS_UPDATE_CONFIGURATION_ROW_ERROR,

--- a/src/scripts/modules/components/NewConfigurationsActionCreators.js
+++ b/src/scripts/modules/components/NewConfigurationsActionCreators.js
@@ -7,7 +7,7 @@ import ComponentsStore from './stores/ComponentsStore';
 
 export default {
   updateConfiguration(componentId, configuration) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: ActionTypes.COMPONENTS_NEW_CONFIGURATION_UPDATE,
       componentId,
       configuration
@@ -15,7 +15,7 @@ export default {
   },
 
   resetConfiguration(componentId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: ActionTypes.COMPONENTS_NEW_CONFIGURATION_CANCEL,
       componentId
     });

--- a/src/scripts/modules/components/OAuthActionCreators.js
+++ b/src/scripts/modules/components/OAuthActionCreators.js
@@ -23,7 +23,7 @@ export default {
       });
       return result;
     }).catch(function() {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: Constants.ActionTypes.OAUTH_LOAD_CREDENTIALS_ERROR,
         componentId: componentId,
         configId: configId
@@ -38,14 +38,14 @@ export default {
       configId: configId
     });
     return oauthApi.deleteCredentials(componentId, configId).then(function(result) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: Constants.ActionTypes.OAUTH_DELETE_CREDENTIALS_SUCCESS,
         componentId: componentId,
         configId: configId,
         credentials: result
       });
     }).catch(function() {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: Constants.ActionTypes.OAUTH_API_ERROR,
         componentId: componentId,
         configId: configId

--- a/src/scripts/modules/components/StorageActionCreators.js
+++ b/src/scripts/modules/components/StorageActionCreators.js
@@ -19,10 +19,11 @@ const AWS = window.AWS;
 export default {
   tokenVerify: function() {
     return storageApi.verifyToken().then((sapiToken) => {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: applicationConstants.ActionTypes.SAPI_TOKEN_RECEIVED,
         sapiToken
       });
+      return null;
     });
   },
 
@@ -31,7 +32,7 @@ export default {
       type: constants.ActionTypes.STORAGE_BUCKETS_LOAD
     });
     return storageApi.getBuckets().then(function(buckets) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_BUCKETS_LOAD_SUCCESS,
         buckets: buckets
       });
@@ -52,7 +53,7 @@ export default {
       bucketId: bucketId
     });
     return storageApi.getBucketCredentials(bucketId).then(function(credentials) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_BUCKET_CREDENTIALS_LOAD_SUCCESS,
         credentials: credentials,
         bucketId: bucketId
@@ -89,7 +90,7 @@ export default {
       credentialsId: credentialsId
     });
     return storageApi.deleteBucketCredentials(credentialsId).then(function() {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_BUCKET_CREDENTIALS_DELETE_SUCCESS,
         bucketId: bucketId,
         credentialsId: credentialsId
@@ -116,7 +117,7 @@ export default {
       type: constants.ActionTypes.STORAGE_TABLES_LOAD
     });
     return storageApi.getTables().then(function(tables) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_TABLES_LOAD_SUCCESS,
         tables: tables
       });
@@ -147,7 +148,7 @@ export default {
       type: constants.ActionTypes.STORAGE_FILES_LOAD
     });
     return storageApi.getFiles(params).then(function(files) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_FILES_LOAD_SUCCESS,
         files: files
       });
@@ -1010,7 +1011,7 @@ export default {
       type: constants.ActionTypes.STORAGE_JOBS_LOAD
     });
     return storageApi.getJobs(params).then(function(jobs) {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: constants.ActionTypes.STORAGE_JOBS_LOAD_SUCCESS,
         jobs: jobs
       });

--- a/src/scripts/modules/gooddata-writer/actionCreators.js
+++ b/src/scripts/modules/gooddata-writer/actionCreators.js
@@ -140,7 +140,7 @@ export default {
   },
 
   toggleBucket(configurationId, bucketId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_SET_BUCKET_TOGGLE,
       configurationId,
       bucketId
@@ -310,7 +310,7 @@ export default {
   },
 
   startTableFieldEdit(configurationId, tableId, field) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_TABLE_FIELD_EDIT_START,
       tableId,
       configurationId,
@@ -319,7 +319,7 @@ export default {
   },
 
   updateTableFieldEdit(configurationId, tableId, field, newValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_TABLE_FIELD_EDIT_UPDATE,
       configurationId,
       tableId,
@@ -329,7 +329,7 @@ export default {
   },
 
   cancelTableFieldEdit(configurationId, tableId, field) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_TABLE_FIELD_EDIT_CANCEL,
       tableId,
       configurationId,
@@ -338,7 +338,7 @@ export default {
   },
 
   startTableColumnsEdit(configurationId, tableId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_COLUMNS_EDIT_START,
       configurationId,
       tableId
@@ -346,7 +346,7 @@ export default {
   },
 
   cancelTableColumnsEdit(configurationId, tableId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_COLUMNS_EDIT_CANCEL,
       configurationId,
       tableId
@@ -354,7 +354,7 @@ export default {
   },
 
   updateTableColumnsEdit(configurationId, tableId, column) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_COLUMNS_EDIT_UPDATE,
       configurationId,
       tableId,
@@ -377,12 +377,13 @@ export default {
       .updateTable(configurationId, tableId, { columns })
       .then(() => {
         this.loadReferencableTablesForce(configurationId);
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.GOOD_DATA_WRITER_COLUMNS_EDIT_SAVE_SUCCESS,
           configurationId,
           tableId,
           columns: columns.toJS()
         });
+        return null;
       })
       .catch(function(e) {
         dispatcher.handleViewAction({
@@ -588,7 +589,7 @@ export default {
   },
 
   updateNewDateDimension(configurationId, newDimension) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_NEW_DATE_DIMENSION_UPDATE,
       configurationId,
       dimension: newDimension
@@ -659,7 +660,7 @@ export default {
   },
 
   setWriterTablesFilter(configurationId, query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.GOOD_DATA_WRITER_TABLES_FILTER_CHANGE,
       filter: query,
       configurationId

--- a/src/scripts/modules/jobs/ActionCreators.js
+++ b/src/scripts/modules/jobs/ActionCreators.js
@@ -87,7 +87,7 @@ export default {
   },
 
   setQuery(query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.JOBS_SET_QUERY,
       query
     });
@@ -113,7 +113,7 @@ export default {
   },
 
   recieveJobs(jobs, newOffset, resetJobs) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.JOBS_LOAD_SUCCESS,
       jobs,
       newOffset,
@@ -122,7 +122,7 @@ export default {
   },
 
   recieveJobDetail(jobDetail) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.JOB_LOAD_SUCCESS,
       job: jobDetail
     });
@@ -165,13 +165,13 @@ export default {
       .getJobsParametrized(query, 30, 0)
       .then(jobs => {
         this.reloadSapiTablesTrigger(jobs);
-
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.JOBS_LATEST_LOAD_SUCCESS,
           componentId,
           configurationId,
           jobs
         });
+        return null;
       })
       .catch(e => {
         dispatcher.handleViewAction({

--- a/src/scripts/modules/oauth-v2/ActionCreators.js
+++ b/src/scripts/modules/oauth-v2/ActionCreators.js
@@ -26,7 +26,7 @@ export default {
         return result;
       })
       .catch(() => {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: Constants.ActionTypes.OAUTHV2_LOAD_CREDENTIALS_ERROR,
           componentId,
           id
@@ -52,7 +52,7 @@ export default {
         })
       )
       .catch(() => {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: Constants.ActionTypes.OAUTHV2_API_ERROR,
           componentId,
           id
@@ -78,7 +78,7 @@ export default {
         })
       )
       .catch(() => {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: Constants.ActionTypes.OAUTHV2_API_ERROR,
           componentId,
           id

--- a/src/scripts/modules/orchestrations/ActionCreators.js
+++ b/src/scripts/modules/orchestrations/ActionCreators.js
@@ -89,7 +89,7 @@ export default {
   },
 
   receiveAllOrchestrations(orchestrations) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATIONS_LOAD_SUCCESS,
       orchestrations
     });
@@ -133,7 +133,7 @@ export default {
 
   receiveOrchestration(orchestration) {
     orchestration.tasks = rephaseTasks(orchestration.tasks);
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_LOAD_SUCCESS,
       orchestration
     });
@@ -273,7 +273,7 @@ export default {
     Filter orchestrations
   */
   setOrchestrationsFilter(query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATIONS_SET_FILTER,
       query
     });
@@ -319,7 +319,7 @@ export default {
     Editing orchestration field
   */
   startOrchestrationFieldEdit(orchestrationId, fieldName) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_FIELD_EDIT_START,
       orchestrationId,
       field: fieldName
@@ -327,7 +327,7 @@ export default {
   },
 
   cancelOrchestrationFieldEdit(orchestrationId, fieldName) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_FIELD_EDIT_CANCEL,
       orchestrationId,
       field: fieldName
@@ -335,7 +335,7 @@ export default {
   },
 
   updateOrchestrationFieldEdit(orchestrationId, fieldName, newValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_FIELD_EDIT_UPDATE,
       orchestrationId,
       field: fieldName,
@@ -381,21 +381,21 @@ export default {
     Editing orchestration tasks
   */
   startOrchestrationTasksEdit(orchestrationId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_TASKS_EDIT_START,
       orchestrationId
     });
   },
 
   cancelOrchestrationTasksEdit(orchestrationId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_TASKS_EDIT_CANCEL,
       orchestrationId
     });
   },
 
   updateOrchestrationsTasksEdit(orchestrationId, tasks) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_TASKS_EDIT_UPDATE,
       orchestrationId,
       tasks
@@ -414,7 +414,7 @@ export default {
       .saveOrchestrationTasks(orchestrationId, tasks.toJS())
       .then(data => {
         // update tasks from server
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.ORCHESTRATION_TASKS_SAVE_SUCCESS,
           orchestrationId,
           tasks: rephaseTasks(data)
@@ -434,14 +434,14 @@ export default {
     Editing tasks on job retry
   */
   startJobRetryTasksEdit(jobId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_JOB_RETRY_EDIT_START,
       jobId
     });
   },
 
   updateJobRetryTasksEdit(jobId, tasks) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_JOB_RETRY_EDIT_UPDATE,
       jobId,
       tasks
@@ -452,21 +452,21 @@ export default {
     Editing tasks on manulal run
   */
   startOrchestrationRunTasksEdit(orchestrationId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_RUN_TASK_EDIT_START,
       orchestrationId
     });
   },
 
   cancelOrchestrationRunTasksEdit(orchestrationId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_RUN_TASK_EDIT_CANCEL,
       orchestrationId
     });
   },
 
   updateOrchestrationRunTasksEdit(orchestrationId, tasks) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.ORCHESTRATION_RUN_TASK_EDIT_UPDATE,
       orchestrationId,
       tasks

--- a/src/scripts/modules/provisioning/ActionCreators.js
+++ b/src/scripts/modules/provisioning/ActionCreators.js
@@ -30,7 +30,7 @@ export default {
       });
     }).catch(HttpError, function(error) {
       if (error.response.status === 404) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.CREDENTIALS_REDSHIFT_SANDBOX_LOAD_SUCCESS,
           credentials: {
             id: null
@@ -131,7 +131,7 @@ export default {
       });
     }).catch(HttpError, function(error) {
       if (error.response.status === 404) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.CREDENTIALS_WRDB_LOAD_SUCCESS,
           credentials: null,
           permission: permissionType,
@@ -228,7 +228,7 @@ export default {
       });
     }).catch(HttpError, function(error) {
       if (error.response.status === 404) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.CREDENTIALS_SNOWFLAKE_SANDBOX_LOAD_SUCCESS,
           credentials: {
             id: null
@@ -314,7 +314,7 @@ export default {
       });
     }).catch(HttpError, function(error) {
       if (error.response.status === 404) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.CREDENTIALS_RSTUDIO_SANDBOX_LOAD_SUCCESS,
           credentials: {
             id: null
@@ -409,7 +409,7 @@ export default {
       });
     }).catch(HttpError, function(error) {
       if (error.response.status === 404) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.CREDENTIALS_JUPYTER_SANDBOX_LOAD_SUCCESS,
           credentials: {
             id: null

--- a/src/scripts/modules/services/ActionCreators.js
+++ b/src/scripts/modules/services/ActionCreators.js
@@ -3,7 +3,7 @@ import constants from './Constants';
 
 export default {
   receive(servicesRaw) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.SERVICES_LOAD_SUCCESS,
       services: servicesRaw
     });

--- a/src/scripts/modules/storage-explorer/Actions.js
+++ b/src/scripts/modules/storage-explorer/Actions.js
@@ -275,21 +275,21 @@ const filterFiles = query => {
 };
 
 const updateSearchQuery = query => {
-  return dispatcher.handleViewAction({
+  dispatcher.handleViewAction({
     type: localConstants.ActionTypes.UPDATE_SEARCH_QUERY,
     query
   });
 };
 
 const updateFilesSearchQuery = query => {
-  return dispatcher.handleViewAction({
+  dispatcher.handleViewAction({
     type: localConstants.ActionTypes.UPDATE_FILES_SEARCH_QUERY,
     query
   });
 };
 
 const setOpenedBuckets = buckets => {
-  return dispatcher.handleViewAction({
+  dispatcher.handleViewAction({
     type: localConstants.ActionTypes.SET_OPENED_BUCKETS,
     buckets
   });

--- a/src/scripts/modules/tokens/actionCreators.js
+++ b/src/scripts/modules/tokens/actionCreators.js
@@ -23,7 +23,7 @@ export default {
       tokenId: tokenId
     });
     return storageApi.deleteToken(tokenId).then(() => {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: ActionTypes.STORAGE_TOKEN_DELETE_SUCCESS,
         tokenId: tokenId
       });
@@ -88,7 +88,7 @@ export default {
       type: ActionTypes.STORAGE_TOKENS_LOAD
     });
     return storageApi.getTokens().then((tokens) => {
-      return dispatcher.handleViewAction({
+      dispatcher.handleViewAction({
         type: ActionTypes.STORAGE_TOKENS_LOAD_SUCCESS,
         tokens: tokens
       });

--- a/src/scripts/modules/transformations/ActionCreators.js
+++ b/src/scripts/modules/transformations/ActionCreators.js
@@ -27,14 +27,14 @@ const updateTransformationEditingFieldQueriesStringDebouncer = _.debounce(functi
     transformationId: transformationId
   });
   return parseQueries(queriesString).then(function(splitQueries) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_UPDATE_PARSE_QUERIES_SUCCESS,
       bucketId: bucketId,
       transformationId: transformationId,
       splitQueries: splitQueries
     });
   }).catch(function() {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_UPDATE_PARSE_QUERIES_ERROR,
       bucketId: bucketId,
       transformationId: transformationId
@@ -202,7 +202,7 @@ export default {
           sys: [bucketId]
         }
       }).then(function(graphData) {
-        return dispatcher.handleViewAction({
+        dispatcher.handleViewAction({
           type: constants.ActionTypes.TRANSFORMATION_OVERVIEW_LOAD_SUCCESS,
           transformationId: transformationId,
           bucketId: bucketId,
@@ -228,7 +228,7 @@ export default {
     return this.loadTransformationOverview(bucketId, transformationId, showDisabled);
   },
   toggleOpenInputMapping: function(bucketId, transformationId, index) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_INPUT_MAPPING_OPEN_TOGGLE,
       transformationId: transformationId,
       bucketId: bucketId,
@@ -236,7 +236,7 @@ export default {
     });
   },
   toggleOpenOutputMapping: function(bucketId, transformationId, index) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_OUTPUT_MAPPING_OPEN_TOGGLE,
       transformationId: transformationId,
       bucketId: bucketId,
@@ -317,19 +317,19 @@ export default {
     });
   },
   setTransformationBucketsFilter: function(query) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_BUCKETS_FILTER_CHANGE,
       filter: query
     });
   },
   toggleBucket: function(bucketId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_BUCKETS_TOGGLE,
       bucketId: bucketId
     });
   },
   startTransformationFieldEdit: function(bucketId, transformationId, fieldId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_START_EDIT_FIELD,
       bucketId: bucketId,
       transformationId: transformationId,
@@ -337,7 +337,7 @@ export default {
     });
   },
   updateTransformationEditingField: function(bucketId, transformationId, fieldId, newValue) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_UPDATE_EDITING_FIELD,
       bucketId: bucketId,
       transformationId: transformationId,
@@ -355,7 +355,7 @@ export default {
     return updateTransformationEditingFieldQueriesStringDebouncer(bucketId, transformationId, queriesString);
   },
   cancelTransformationEditingField: function(bucketId, transformationId, fieldId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_CANCEL_EDITING_FIELD,
       bucketId: bucketId,
       transformationId: transformationId,

--- a/src/scripts/modules/wr-db/actionCreators.js
+++ b/src/scripts/modules/wr-db/actionCreators.js
@@ -37,7 +37,7 @@ export default {
         .getCredentials(isReadOnly, driver, componentId, configId)
         .then(result => {
           if (isReadOnly) {
-            return dispatcher.handleViewAction({
+            dispatcher.handleViewAction({
               type: constants.ActionTypes.WR_DB_LOAD_PROVISIONING_SUCCESS,
               componentId,
               configId,
@@ -98,7 +98,7 @@ export default {
   },
 
   resetCredentials(componentId, configId) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.WR_DB_SAVE_CREDENTIALS_SUCCESS,
       componentId,
       configId,
@@ -107,7 +107,7 @@ export default {
   },
 
   setEditingData(componentId, configId, path, data) {
-    return dispatcher.handleViewAction({
+    dispatcher.handleViewAction({
       type: constants.ActionTypes.WR_DB_SET_EDITING,
       componentId,
       configId,


### PR DESCRIPTION
Jde o ty varování (bluebird žlutý text) že máme nějaké unhandled promise. Tady nebylo cíl projít všechny akce a vše otestovat, ale i tak by to mělo dost případů opravit.

Postup byl jednoduchý - hledal jsem výskyt textu `return dispatcher.handleViewAction`:
- tato funkce vrací `undefined` takže return je zbytečný
- pokud je v daném bloku nový promise (třeba reload verzí) vracím nově `null`, to signulizuje `bluebirdu` že vím že tam je nějaká promise, ale nečekám na ní. Narozdíl když tam promise je a já nevrátím nic, nebo vrátím právě `dispatcher.handleViewAction` (`undefined`), pak z toho jsou ty varování.

