### PR TITLE
Formát čísla kreditů

### DIFF
--- a/src/scripts/modules/billing/react/GraphVisualization.jsx
+++ b/src/scripts/modules/billing/react/GraphVisualization.jsx
@@ -1,81 +1,56 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import {fromJS} from 'immutable';
+import { fromJS } from 'immutable';
 
-function format(unit) {
-  switch (unit) {
-    case 'credits':
-      return '#,### credits';
-    default:
-      return '#,###';
-  }
-}
-
-function getConversion(unit) {
-  switch (unit) {
-    case 'credits':
-      return function(val) {
-        return Number((val / (1000 * 1000 * 1000)).toFixed(3));
-      };
-    default:
-      return function(val) {
-        return val;
-      };
-  }
-}
-
-function createChartOptions(options) {
-  return fromJS({
-    colors: [
-      /* teal      red        yellow     purple     orange     mint       blue       green      lavender */
-      '#0bbcfa', '#fb4f61', '#eeb058', '#8a8ad6', '#ff855c', '#00cfbb', '#5a9eed', '#73d483', '#c879bb',
-      '#0099b6', '#d74d58', '#cb9141', '#6b6bb6', '#d86945', '#00aa99', '#4281c9', '#57b566', '#ac5c9e',
-      '#27cceb', '#ff818b', '#f6bf71', '#9b9be1', '#ff9b79', '#26dfcd', '#73aff4', '#87e096', '#d88bcb'
-    ],
-    legend: {
-      position: 'none'
+const chartOptions = {
+  colors: [
+    /* teal      red        yellow     purple     orange     mint       blue       green      lavender */
+    '#0bbcfa', '#fb4f61', '#eeb058', '#8a8ad6', '#ff855c', '#00cfbb', '#5a9eed', '#73d483', '#c879bb',
+    '#0099b6', '#d74d58', '#cb9141', '#6b6bb6', '#d86945', '#00aa99', '#4281c9', '#57b566', '#ac5c9e',
+    '#27cceb', '#ff818b', '#f6bf71', '#9b9be1', '#ff9b79', '#26dfcd', '#73aff4', '#87e096', '#d88bcb'
+  ],
+  legend: {
+    position: 'none'
+  },
+  hAxis: {
+    gridlines: {
+      color: 'none'
     },
-    hAxis: {
-      gridlines: {
-        color: 'none'
-      },
-      textStyle: {
-        color: '#98a2b5'
-      },
-      format: 'd.M.'
+    textStyle: {
+      color: '#98a2b5'
     },
-    vAxis: {
-      gridlines: {
-        count: 4,
-        color: '#e8e8ef'
-      },
-      baseline: 0,
-      baselineColor: '#CCC',
-      minValue: 0,
-      textPosition: 'in',
-      textStyle: {
-        color: '#98a2b5'
-      },
-      viewWindow: {
-        min: 0
-      },
-      format: options.vAxisFormat
+    format: 'd.M.'
+  },
+  vAxis: {
+    gridlines: {
+      count: 4,
+      color: '#e8e8ef'
     },
-    lineWidth: 3,
-    areaOpacity: 0.1,
-    seriesType: 'area',
-    series: {
-      1: {
-        type: 'line',
-        lineWidth: 1
-      }
+    baseline: 0,
+    baselineColor: '#CCC',
+    minValue: 0,
+    textPosition: 'in',
+    textStyle: {
+      color: '#98a2b5'
+    },
+    viewWindow: {
+      min: 0
+    },
+    format: '#.### credits'
+  },
+  lineWidth: 3,
+  areaOpacity: 0.1,
+  seriesType: 'area',
+  series: {
+    1: {
+      type: 'line',
+      lineWidth: 1
     }
-  });
-}
+  }
+};
 
 export default createReactClass({
-
   propTypes: {
     data: PropTypes.object.isRequired
   },
@@ -86,51 +61,53 @@ export default createReactClass({
     };
   },
 
-  componentDidMount: function() {
+  componentDidMount() {
     this.drawGraph();
   },
 
   prepareGraphData() {
-    if (!this.props.data.isEmpty()) {
-      let conversion = getConversion('credits');
-      let converted = [
-        [
-          'Date',
-          'Value',
-          {'type': 'string', 'role': 'style'}
-        ]
-      ];
-
-      this.props.data.forEach(function(item) {
-        converted.push([
-          new Date(item.get('date')),
-          conversion(item.get('value')),
-          null
-        ]);
-      });
-
-      return converted;
-    } else {
+    if (this.props.data.isEmpty()) {
       return [];
     }
+
+    const converted = [
+      [
+        'Date',
+        'Value',
+        {'type': 'string', 'role': 'style'}
+      ]
+    ];
+
+    this.props.data.forEach((item) => {
+      converted.push([
+        new Date(item.get('date')),
+        Number((item.get('value') / (10)).toFixed(3)),
+        null
+      ]);
+    });
+
+    return converted;
   },
 
   drawGraph() {
-    const chartOptions = createChartOptions({
-      vAxisFormat: format('credits')
-    });
     const graphData = this.prepareGraphData();
 
     /* global google */
-    const ds = new google.visualization.arrayToDataTable(graphData);
+    const data = new google.visualization.arrayToDataTable(graphData);
+    const formatter = new google.visualization.NumberFormat({ 
+      suffix: ' credits',
+      fractionDigits: 3,
+      decimalSymbol: '.', 
+      groupingSymbol: '' 
+    });
+    formatter.format(data, 1);
     const combo = new google.visualization.ComboChart(this.refs.lastMonthUsage);
-    combo.draw(ds, chartOptions.toJS());
+    combo.draw(data, chartOptions);
   },
 
-  render: function() {
+  render() {
     return (
       <div ref="lastMonthUsage"/>
     );
   }
-
 });

--- a/src/scripts/modules/billing/react/GraphVisualization.jsx
+++ b/src/scripts/modules/billing/react/GraphVisualization.jsx
@@ -81,7 +81,7 @@ export default createReactClass({
     this.props.data.forEach((item) => {
       converted.push([
         new Date(item.get('date')),
-        Number((item.get('value') / (10)).toFixed(3)),
+        Number((item.get('value') / (1000 * 1000 * 1000)).toFixed(3)),
         null
       ]);
     });

--- a/src/scripts/modules/billing/react/ProjectPowerLimit.jsx
+++ b/src/scripts/modules/billing/react/ProjectPowerLimit.jsx
@@ -7,7 +7,6 @@ import LimitProgress from './../../limits/LimitProgress';
 import {Button} from 'react-bootstrap';
 import contactSupport from '../../../utils/contactSupport';
 import classnames from 'classnames';
-import {numericMetricFormatted} from '../../../utils/numbers';
 import MetricsApi from '../MetricsApi';
 import {fromJS} from 'immutable';
 import Loader from './Loader';
@@ -130,11 +129,11 @@ export default createReactClass({
         <span>
           {'Project consumed '}
           <strong style={{fontSize: '24px'}}>
-            {numericMetricFormatted(limit.get('metricValue'), limit.get('unit'))}
+            {limit.get('metricValue')}
           </strong>
           {' of '}
           <strong style={{fontSize: '24px'}}>
-            {numericMetricFormatted(limit.get('limitValue'), limit.get('unit'))}
+            {limit.get('limitValue')}
           </strong>
           {' credits this month'}
         </span>
@@ -144,7 +143,7 @@ export default createReactClass({
         <span>
           {'Project consumed '}
           <strong style={{fontSize: '24px'}}>
-            {numericMetricFormatted(limit.get('metricValue'), limit.get('unit'))}
+            {limit.get('metricValue')}
           </strong>
           {' credits this month'}
         </span>


### PR DESCRIPTION
Fixes #2934

Tady jsem koukal na různý možnosti:
- první jsem oddělal ty desetinná místa ale pak třeba u mě (malinko použitých kreditů) tam mám samé nuly. Navíc to sedí s tím součtem pod tím kde je total 0.007 ale v grafu není nic. Což se mi moc nezdálo tak jsem zkoušel dále. Ale určo se k tomu jde vrátit.

- druhá varianta mi přišla lepší a to zobrazit to přesně tak, jak to zobrazuji na dalších místech stránky. Teda desetinná místa oddělit tečkou, a tisíce neoddělovat vůbec. Původně jsem na tisíce měl mezeru, ale myslím že je lepší nic (V USA atd se asi často používá čárka, v Evropě často tečka - takže je to takové nestálé). Když tam není mezera tak se to trošku hůře čte, ale zase je tam jasně vidět co jsou desetinná místa a co ne.

Jinak když já zkusím vypsat něco velikého, tak i v současné implementaci tam čárky nemám. Číslo vypadá třeba (100 230). Je možné že to google nějak sám upraví podle jazyku prohlížeče nebo tak. Když tam přidám nějaký formát napevno (v tomto PR) tak pak už to budou mít asi všichni stejně.

Ještě jsem to tam nějak projížděl a trochu tu komponentu zjednodušil. Byly tam funkce se switchy, které se ale nevyužily, vždy se to používalo pouze na ty kredity.

Jinak teda místo 1,222.207 by mělo být 1222.207. Což jsem koukal právě sedí s tím co je psáno i pod jako "Total ..."