### PR TITLE
set default fb api version from v3.1 to v3.2

### DIFF
--- a/src/scripts/modules/ex-facebook/storeProvisioning.js
+++ b/src/scripts/modules/ex-facebook/storeProvisioning.js
@@ -7,9 +7,9 @@ import OauthStore from '../oauth-v2/Store';
 export const storeMixins = [InstalledComponentStore, OauthStore];
 
 const DEFAULT_VERSIONS_MAP = {
-  'keboola.ex-instagram': 'v3.1',
-  'keboola.ex-facebook-ads': 'v3.1',
-  'keboola.ex-facebook': 'v3.1'
+  'keboola.ex-instagram': 'v3.2',
+  'keboola.ex-facebook-ads': 'v3.2',
+  'keboola.ex-facebook': 'v3.2'
 };
 
 const DEFAULT_BACKEND_VERSION = 'v2.12';


### PR DESCRIPTION
Tato uprava dvihne default fb api version na `v3.2`. Default fb api version sa uklada pri prvom update konfigu ak je ulozena fb api version prazdna/neexistuje takze to tato uprava nema vplyv na existujuce konfigy.
Podobna uprava sa urobila aj na komponente https://github.com/keboola/ex-facebook-graph-api/pull/71
