### PR TITLE
Sliced Files Downloader - break long file name to multiple lines

### DIFF
--- a/src/scripts/modules/sapi-events/sliced-files-downloader/Modal.jsx
+++ b/src/scripts/modules/sapi-events/sliced-files-downloader/Modal.jsx
@@ -27,8 +27,17 @@ export default createReactClass({
           </Modal.Title>
         </Modal.Header>
         <Modal.Body>
-          <p>File <strong>{this.props.file.get('name')} (<FileSize size={this.props.file.get('sizeBytes')} />)</strong> is sliced into multiple chunks.</p>
-          <p>All chunks will be packed into a <code>ZIP</code> file, you will be given link to download the file.</p>
+          <p>
+            File{' '}
+            <strong className="kbc-break-all kbc-break-word">
+              {this.props.file.get('name')} (<FileSize size={this.props.file.get('sizeBytes')} />)
+            </strong>{' '}
+            is sliced into multiple chunks.
+          </p>
+          <p>
+            All chunks will be packed into a <code>ZIP</code> file, you will be given link to
+            download the file.
+          </p>
         </Modal.Body>
         <Modal.Footer>
           {this.renderStatusBar()}


### PR DESCRIPTION
Fixes #3148

Přidané pouze třídy: "kbc-break-all kbc-break-word".