### PR TITLE
ex fb/ads/ig: set default backend version to v3.2

### DIFF
--- a/src/scripts/modules/ex-facebook/storeProvisioning.js
+++ b/src/scripts/modules/ex-facebook/storeProvisioning.js
@@ -12,7 +12,7 @@ const DEFAULT_VERSIONS_MAP = {
   'keboola.ex-facebook': 'v3.2'
 };
 
-const DEFAULT_BACKEND_VERSION = 'v2.12';
+const DEFAULT_BACKEND_VERSION = 'v3.2';
 
 export default function(COMPONENT_ID, configId) {
   const DEFAULT_API_VERSION = DEFAULT_VERSIONS_MAP[COMPONENT_ID];


### PR DESCRIPTION
tak este jeden mini update facebook api version, malo to byt uz v https://github.com/keboola/kbc-ui/pull/3151 no mi to nejak uslo.