### PR TITLE
External Bucket Link - link to new storage console

### DIFF
--- a/src/scripts/modules/components/react/components/ExternalBucketLink.jsx
+++ b/src/scripts/modules/components/react/components/ExternalBucketLink.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { trim, rtrim } from 'underscore.string';
 import ApplicationStore from '../../../../stores/ApplicationStore';
 import { ExternalLink } from '@keboola/indigo-ui';
 import _ from 'underscore';
@@ -14,10 +15,10 @@ export default createReactClass({
   },
 
   getBucketUrl() {
-    const projectPath = _.template(ApplicationStore.getProjectUrlTemplate())({
-      projectId: this.props.projectId
-    });
-    return this.props.stackUrl + projectPath.substring(1, projectPath.length - 1) + '/storage#/buckets/' + this.props.bucketId;
+    const projectUrlTemplate = ApplicationStore.getProjectUrlTemplate();
+    const projectPath = _.template(projectUrlTemplate)({ projectId: this.props.projectId });
+
+    return `${rtrim(this.props.stackUrl, '/')}/${trim(projectPath, '/')}/storage-explorer/${this.props.bucketId}`;
   },
 
   render() {
@@ -27,9 +28,9 @@ export default createReactClass({
           {this.props.children}
         </ExternalLink>
       );
-    } else {
-      return this.props.children;
     }
+
+    return this.props.children;
   }
 
 });

--- a/src/scripts/modules/wr-storage/react/components/TargetProject.jsx
+++ b/src/scripts/modules/wr-storage/react/components/TargetProject.jsx
@@ -64,7 +64,7 @@ export default createReactClass({
             Project
           </Col>
           <Col sm={8}>
-            <FormControl.Static>
+            <FormControl.Static className="kbc-break-all kbc-break-word">
               <ExternalProjectLink
                 stackUrl={infoAction.getIn(['request', 'configData', 'parameters', 'url'])}
                 projectId={infoAction.getIn(['data', 'projectId'])}
@@ -82,7 +82,7 @@ export default createReactClass({
             Bucket
           </Col>
           <Col sm={8}>
-            <FormControl.Static>
+            <FormControl.Static className="kbc-break-all kbc-break-word">
               <ExternalBucketLink
                 stackUrl={infoAction.getIn(['request', 'configData', 'parameters', 'url'])}
                 projectId={infoAction.getIn(['data', 'projectId'])}


### PR DESCRIPTION
Fixes #3146

- odkazovalo to na starou storage
- místo `substring` jsem radši použit `trim` respektive `rtrim` abych mazal jen to co chci (mažu toho asi více než je nutné ale je to proto abych si sám tam přidat ty "/")

btw: Úprava ve `TargetProject.jsx` by tu asi neměl být ale je to super drobnost, když jsem zadal špatný token a dostal jsme tam dlouhou chybovou hlášku, místo aby se to hezky zalomilo tak to bylo v jednom dlouhém řádku se scrollbarem.