### PR TITLE
Update StorageApiFileUploadLink component

### DIFF
--- a/src/scripts/modules/components/react/components/StorageApiFileUploadsLink.jsx
+++ b/src/scripts/modules/components/react/components/StorageApiFileUploadsLink.jsx
@@ -1,23 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import ApplicationStore from '../../../../stores/ApplicationStore';
-import { ExternalLink } from '@keboola/indigo-ui';
+import { Link } from 'react-router';
 
 export default createReactClass({
   propTypes: {
     children: PropTypes.any.isRequired
   },
 
-  fileUploadsUrl() {
-    return ApplicationStore.getSapiFileUploadsUrl();
-  },
-
   render() {
-    return (
-      <ExternalLink
-        href={this.fileUploadsUrl()}
-      >{this.props.children}</ExternalLink>
-    );
+    return <Link to="storage-explorer-files">{this.props.children}</Link>;
   }
 });

--- a/src/scripts/stores/ApplicationStore.js
+++ b/src/scripts/stores/ApplicationStore.js
@@ -100,18 +100,6 @@ const ApplicationStore = StoreUtils.createStore({
     return this.getProjectBaseUrl() + '/' + path;
   },
 
-  getSapiTableUrl(tableId) {
-    return this.getProjectBaseUrl() + `/storage#/tables/${tableId}`;
-  },
-
-  getSapiBucketUrl(bucketId) {
-    return this.getProjectBaseUrl() + `/storage#/buckets/${bucketId}`;
-  },
-
-  getSapiFileUploadsUrl() {
-    return this.getProjectBaseUrl() + '/storage#/file-uploads';
-  },
-
   getUrlTemplates() {
     return _store.getIn(['kbc', 'urlTemplates']);
   },


### PR DESCRIPTION
Ještě jsem radši kontroloval zda někde odkazujeme na starou storage.

Tři věci byly ve `ApplicationStore` ale dvě z toho nebyly použity a ta další jen na jednom místě takže jsem vše vymazal.
To jediné použití ve `StorageApiFileUploadsLink` jsem vyhodil a upravil, již to není external link.