### PR TITLE
feat: adaptive input mapping

### DIFF
--- a/src/scripts/constants/KbcConstants.js
+++ b/src/scripts/constants/KbcConstants.js
@@ -31,6 +31,7 @@ const ActionTypes = keyMirror({
 const FEATURE_UI_DEVEL_PREVIEW = 'ui-devel-preview';
 const FEATURE_EARLY_ADOPTER_PREVIEW = 'early-adopter-preview';
 const FEATURE_UI_LOOKER_PREVIEW = 'ui-looker-preview';
+const FEATURE_ADAPTIVE_INPUT_MAPPING = 'ui-adaptive-input-mapping';
 
 const lookerPreviewHideComponents = [
   'cleveranalytics.wr-clever-analytics',
@@ -51,5 +52,6 @@ export {
   FEATURE_UI_DEVEL_PREVIEW,
   FEATURE_EARLY_ADOPTER_PREVIEW,
   FEATURE_UI_LOOKER_PREVIEW,
+  FEATURE_ADAPTIVE_INPUT_MAPPING,
   lookerPreviewHideComponents
 };

--- a/src/scripts/modules/components/react/components/generic/AddTableInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/AddTableInputMapping.jsx
@@ -9,6 +9,7 @@ export default createReactClass({
     tables: PropTypes.object.isRequired,
     mapping: PropTypes.object.isRequired,
     componentId: PropTypes.string.isRequired,
+    componentType: PropTypes.string.isRequired,
     configId: PropTypes.string.isRequired,
     otherDestinations: PropTypes.object.isRequired
   },
@@ -23,6 +24,7 @@ export default createReactClass({
         onCancel={this.handleCancel}
         onSave={this.handleSave}
         otherDestinations={this.props.otherDestinations}
+        componentType={this.props.componentType}
       />
     );
   },

--- a/src/scripts/modules/components/react/components/generic/ChangedSinceFilterInput.jsx
+++ b/src/scripts/modules/components/react/components/generic/ChangedSinceFilterInput.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import ChangedSinceInput from '../../../../../react/common/ChangedSinceInput';
+
 export default createReactClass({
   propTypes: {
     mapping: PropTypes.object.isRequired,

--- a/src/scripts/modules/components/react/components/generic/ChangedSinceFilterInput.jsx
+++ b/src/scripts/modules/components/react/components/generic/ChangedSinceFilterInput.jsx
@@ -11,7 +11,8 @@ export default createReactClass({
     wrapperClassName: PropTypes.string,
     helpBlock: PropTypes.string,
     label: PropTypes.string,
-    groupClassName: PropTypes.string
+    groupClassName: PropTypes.string,
+    allowAdaptive: PropTypes.bool
   },
 
   getDefaultProps() {
@@ -35,6 +36,7 @@ export default createReactClass({
             disabled={this.props.disabled}
             onChange={this.handleChangeChangedSince}
             helpBlock={this.props.helpBlock}
+            allowAdaptive={this.props.allowAdaptive}
           />
         </div>
       </div>

--- a/src/scripts/modules/components/react/components/generic/FiltersDescription.jsx
+++ b/src/scripts/modules/components/react/components/generic/FiltersDescription.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { List } from 'immutable';
 import WhereOperator from '../../../../../react/common/WhereOperator';
+import changedSinceConstants from '../../../../../react/common/changedSinceConstants';
 
 export default createReactClass({
   propTypes: {
@@ -42,7 +43,14 @@ export default createReactClass({
           this.props.value.get('where_column') &&
           this.props.value.get('where_column') &&
           ' and '}
-        {this.props.value.get('changed_since') && (
+        {this.props.value.get('changed_since') === changedSinceConstants.ADAPTIVE_VALUE && (
+          <span>
+            {this.props.value.get('where_column') && this.props.value.get('where_values')
+              ? changedSinceConstants.ADAPTIVE_LABEL_DESCRIPTION.toLowerCase()
+              : changedSinceConstants.ADAPTIVE_LABEL_DESCRIPTION}
+          </span>
+        )}
+        {this.props.value.get('changed_since') && this.props.value.get('changed_since') !== changedSinceConstants.ADAPTIVE_VALUE && (
           <span>
             {this.props.value.get('where_column') && this.props.value.get('where_values')
               ? 'changed in last '

--- a/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMapping.jsx
@@ -15,6 +15,7 @@ export default createReactClass({
 
   propTypes: {
     componentId: PropTypes.string.isRequired,
+    componentType: PropTypes.string.isRequired,
     configId: PropTypes.string.isRequired,
     editingValue: PropTypes.object.isRequired,
     value: PropTypes.object.isRequired,
@@ -49,6 +50,7 @@ export default createReactClass({
         <Add
           tables={this.props.tables}
           componentId={this.props.componentId}
+          componentType={this.props.componentType}
           configId={this.props.configId}
           mapping={this.props.editingValue.get('new-mapping', Map())}
           otherDestinations={this.inputMappingDestinations()}
@@ -72,6 +74,7 @@ export default createReactClass({
         <Add
           tables={this.props.tables}
           componentId={this.props.componentId}
+          componentType={this.props.componentType}
           configId={this.props.configId}
           mapping={this.props.editingValue.get('new-mapping', Map())}
           otherDestinations={this.inputMappingDestinations()}
@@ -119,6 +122,7 @@ export default createReactClass({
           onSave={() => this.onSaveMapping(key)}
           onCancel={() => this.onCancelEditMapping(key)}
           onDelete={() => this.onDeleteMapping(key)}
+          componentType={this.props.componentType}
         />
       </div>
     );

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingEditor.jsx
@@ -19,6 +19,7 @@ export default createReactClass({
     initialShowDetails: PropTypes.bool.isRequired,
     showFileHint: PropTypes.bool,
     isDestinationDuplicate: PropTypes.bool.isRequired,
+    componentType: PropTypes.string.isRequired,
     definition: PropTypes.object
   },
 
@@ -86,6 +87,7 @@ export default createReactClass({
             mapping={this.props.value}
             disabled={this.props.disabled}
             onChange={this.props.onChange}
+            allowAdaptive={(this.props.componentType === 'writer' ? true : false)}
           />
           <DataFilterRow
             value={this.props.value}

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
@@ -19,6 +19,7 @@ export default createReactClass({
     pendingActions: PropTypes.object.isRequired,
     onEditStart: PropTypes.func.isRequired,
     otherDestinations: PropTypes.object.isRequired,
+    componentType: PropTypes.string.isRequired,
     definition: PropTypes.object
   },
 
@@ -88,6 +89,7 @@ export default createReactClass({
                 onEditStart={this.props.onEditStart}
                 otherDestinations={this.props.otherDestinations}
                 definition={this.props.definition}
+                componentType={this.props.componentType}
               />
             </span>
           </span>

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
@@ -19,6 +19,7 @@ export default createReactClass({
     onCancel: PropTypes.func.isRequired,
     onSave: PropTypes.func.isRequired,
     otherDestinations: PropTypes.object.isRequired,
+    componentType: PropTypes.string.isRequired,
     onEditStart: PropTypes.func,
     definition: PropTypes.object,
     showFileHint: PropTypes.bool,
@@ -136,6 +137,7 @@ export default createReactClass({
         showFileHint={this.props.showFileHint}
         definition={this.props.definition}
         editingNonExistentTable={this.editingNonExistentTable()}
+        componentType={this.props.componentType}
       />
     );
   },

--- a/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
@@ -98,6 +98,7 @@ export default createReactClass({
       return (
         <TableInputMapping
           componentId={this.state.componentId}
+          componentType={this.state.component.get('type')}
           configId={this.state.config.get('id')}
           value={this.state.configData.getIn(['storage', 'input', 'tables'], List())}
           editingValue={this.state.editingConfigData.getIn(['storage', 'input', 'tables'], Map())}

--- a/src/scripts/modules/custom-science/react/Index.jsx
+++ b/src/scripts/modules/custom-science/react/Index.jsx
@@ -68,6 +68,7 @@ export default createReactClass({
           <div className="col-md-12">
             <TableInputMapping
               componentId={componentId}
+              componentType="application"
               tables={this.state.tables}
               pendingActions={this.state.pendingActions}
               openMappings={this.state.openMappings}

--- a/src/scripts/modules/gooddata-writer-v3/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/LoadTypeSection.jsx
@@ -63,6 +63,7 @@ export default createReactClass({
                value={value.changedSince}
                onChange={(newValue) => this.props.onChange({changedSince: newValue})}
                disabled={disabled}
+               allowAdaptive={true}
              />
            </Col>
          </FormGroup>

--- a/src/scripts/modules/gooddata-writer-v3/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/LoadTypeSection.jsx
@@ -63,7 +63,7 @@ export default createReactClass({
                value={value.changedSince}
                onChange={(newValue) => this.props.onChange({changedSince: newValue})}
                disabled={disabled}
-               allowAdaptive={true}
+               allowAdaptive
              />
            </Col>
          </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
+++ b/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
@@ -187,6 +187,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
           sm={10}
         >
           <ChangedSinceInput
+            allowAdaptive={false}
             disabled={false}
             onChange={[Function]}
             value={null}
@@ -537,6 +538,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
           sm={10}
         >
           <ChangedSinceInput
+            allowAdaptive={false}
             disabled={false}
             onChange={[Function]}
             value={null}
@@ -887,6 +889,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
           sm={10}
         >
           <ChangedSinceInput
+            allowAdaptive={false}
             disabled={false}
             onChange={[Function]}
             value={null}
@@ -1257,6 +1260,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
           sm={10}
         >
           <ChangedSinceInput
+            allowAdaptive={false}
             disabled={false}
             onChange={[Function]}
             value={null}

--- a/src/scripts/modules/wr-db/react/pages/table/IncrementalSetupModal.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/IncrementalSetupModal.jsx
@@ -112,7 +112,7 @@ export default createReactClass({
               onChange={(value) => this.setState({mapping: value})}
               mapping={this.state.mapping}
               helpBlock="When specified, only rows changed or created within the selected time period will be loaded."
-              allowAdaptive={true}
+              allowAdaptive
             />
             <DataFilterRow
               value={this.state.mapping}

--- a/src/scripts/modules/wr-db/react/pages/table/IncrementalSetupModal.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/IncrementalSetupModal.jsx
@@ -112,6 +112,7 @@ export default createReactClass({
               onChange={(value) => this.setState({mapping: value})}
               mapping={this.state.mapping}
               helpBlock="When specified, only rows changed or created within the selected time period will be loaded."
+              allowAdaptive={true}
             />
             <DataFilterRow
               value={this.state.mapping}

--- a/src/scripts/modules/wr-google-bigquery-v2/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/wr-google-bigquery-v2/react/components/LoadTypeSection.jsx
@@ -27,7 +27,7 @@ export default createReactClass({
               value={this.props.value.changedSince}
               onChange={(newValue) => this.props.onChange({changedSince: newValue})}
               disabled={this.props.disabled || this.props.value.incremental === false}
-              allowAdaptive={true}
+              allowAdaptive
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/wr-google-bigquery-v2/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/wr-google-bigquery-v2/react/components/LoadTypeSection.jsx
@@ -27,6 +27,7 @@ export default createReactClass({
               value={this.props.value.changedSince}
               onChange={(newValue) => this.props.onChange({changedSince: newValue})}
               disabled={this.props.disabled || this.props.value.incremental === false}
+              allowAdaptive={true}
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/wr-google-bigquery/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/wr-google-bigquery/react/components/LoadTypeSection.jsx
@@ -27,7 +27,7 @@ export default createReactClass({
               value={this.props.value.changedSince}
               onChange={(newValue) => this.props.onChange({changedSince: newValue})}
               disabled={this.props.disabled || this.props.value.incremental === false}
-              allowAdaptive={true}
+              allowAdaptive
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/wr-google-bigquery/react/components/LoadTypeSection.jsx
+++ b/src/scripts/modules/wr-google-bigquery/react/components/LoadTypeSection.jsx
@@ -27,6 +27,7 @@ export default createReactClass({
               value={this.props.value.changedSince}
               onChange={(newValue) => this.props.onChange({changedSince: newValue})}
               disabled={this.props.disabled || this.props.value.incremental === false}
+              allowAdaptive={true}
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
+++ b/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
@@ -83,6 +83,7 @@ export default createReactClass({
           mapping={this.props.mapping}
           disabled={this.props.disabled}
           onChange={this.props.onChange}
+          allowAdaptive={true}
         />
       );
     }

--- a/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
+++ b/src/scripts/modules/wr-google-drive/react/components/InputTab.jsx
@@ -83,7 +83,7 @@ export default createReactClass({
           mapping={this.props.mapping}
           disabled={this.props.disabled}
           onChange={this.props.onChange}
-          allowAdaptive={true}
+          allowAdaptive
         />
       );
     }

--- a/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
+++ b/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
@@ -83,6 +83,7 @@ export default createReactClass({
           mapping={this.props.mapping}
           disabled={this.props.disabled}
           onChange={this.props.onChange}
+          allowAdaptive={true}
         />
       );
     }

--- a/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
+++ b/src/scripts/modules/wr-google-sheets/react/components/InputMapping.jsx
@@ -83,7 +83,7 @@ export default createReactClass({
           mapping={this.props.mapping}
           disabled={this.props.disabled}
           onChange={this.props.onChange}
-          allowAdaptive={true}
+          allowAdaptive
         />
       );
     }

--- a/src/scripts/modules/wr-storage/react/components/InputMapping.jsx
+++ b/src/scripts/modules/wr-storage/react/components/InputMapping.jsx
@@ -52,7 +52,7 @@ export default createReactClass({
                 value={this.props.value.changedSince}
                 onChange={value => this.props.onChange({changedSince: value})}
                 disabled={this.props.disabled}
-                allowAdaptive={true}
+                allowAdaptive
               />
             </Col>
           </FormGroup>

--- a/src/scripts/modules/wr-storage/react/components/InputMapping.jsx
+++ b/src/scripts/modules/wr-storage/react/components/InputMapping.jsx
@@ -52,6 +52,7 @@ export default createReactClass({
                 value={this.props.value.changedSince}
                 onChange={value => this.props.onChange({changedSince: value})}
                 disabled={this.props.disabled}
+                allowAdaptive={true}
               />
             </Col>
           </FormGroup>

--- a/src/scripts/react/common/ChangedSinceInput.jsx
+++ b/src/scripts/react/common/ChangedSinceInput.jsx
@@ -3,8 +3,10 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { Creatable } from 'react-select';
 import changedSinceOptionCreator from './changedSinceOptionCreator';
+import changedSinceConstants from './changedSinceConstants';
 
 const selectOptions = [
+  { label: changedSinceConstants.ADAPTIVE_LABEL, value: changedSinceConstants.ADAPTIVE_VALUE },
   { label: '10 minutes', value: '-10 minutes' },
   { label: '15 minutes', value: '-15 minutes' },
   { label: '30 minutes', value: '-30 minutes' },

--- a/src/scripts/react/common/ChangedSinceInput.jsx
+++ b/src/scripts/react/common/ChangedSinceInput.jsx
@@ -4,6 +4,7 @@ import createReactClass from 'create-react-class';
 import { Creatable } from 'react-select';
 import changedSinceOptionCreator from './changedSinceOptionCreator';
 import changedSinceConstants from './changedSinceConstants';
+import ApplicationStore from '../../stores/ApplicationStore';
 
 const selectOptions = [
   { label: '10 minutes', value: '-10 minutes' },
@@ -41,7 +42,8 @@ export default createReactClass({
 
   getSelectOptions() {
     const options = [...selectOptions];
-    if (this.props.allowAdaptive || this.props.value === changedSinceConstants.ADAPTIVE_VALUE) {
+
+    if (ApplicationStore.hasCurrentProjectFeature(changedSinceConstants.ADAPTIVE_FEATURE) && this.props.allowAdaptive || this.props.value === changedSinceConstants.ADAPTIVE_VALUE) {
       options.unshift({
         label: changedSinceConstants.ADAPTIVE_LABEL,
         value: changedSinceConstants.ADAPTIVE_VALUE

--- a/src/scripts/react/common/ChangedSinceInput.jsx
+++ b/src/scripts/react/common/ChangedSinceInput.jsx
@@ -6,7 +6,6 @@ import changedSinceOptionCreator from './changedSinceOptionCreator';
 import changedSinceConstants from './changedSinceConstants';
 
 const selectOptions = [
-  { label: changedSinceConstants.ADAPTIVE_LABEL, value: changedSinceConstants.ADAPTIVE_VALUE },
   { label: '10 minutes', value: '-10 minutes' },
   { label: '15 minutes', value: '-15 minutes' },
   { label: '30 minutes', value: '-30 minutes' },
@@ -30,15 +29,29 @@ export default createReactClass({
     onChange: PropTypes.func.isRequired,
     value: PropTypes.string,
     disabled: PropTypes.bool.isRequired,
-    helpBlock: PropTypes.string
+    helpBlock: PropTypes.string,
+    allowAdaptive: PropTypes.bool
+  },
+
+  getDefaultProps() {
+    return {
+      allowAdaptive: false
+    }
   },
 
   getSelectOptions() {
-    if (!this.props.value) {
-      return selectOptions;
+    const options = [...selectOptions];
+    if (this.props.allowAdaptive || this.props.value === changedSinceConstants.ADAPTIVE_VALUE) {
+      options.unshift({
+        label: changedSinceConstants.ADAPTIVE_LABEL,
+        value: changedSinceConstants.ADAPTIVE_VALUE
+      })
     }
 
-    const options = [...selectOptions];
+    if (!this.props.value) {
+      return options;
+    }
+
     if (options.filter((item) => item.value === this.props.value).length === 0) {
       options.push({
         label: this.props.value.replace('-', ''),

--- a/src/scripts/react/common/ChangedSinceInput.jsx
+++ b/src/scripts/react/common/ChangedSinceInput.jsx
@@ -5,6 +5,7 @@ import { Creatable } from 'react-select';
 import changedSinceOptionCreator from './changedSinceOptionCreator';
 import changedSinceConstants from './changedSinceConstants';
 import ApplicationStore from '../../stores/ApplicationStore';
+import { FEATURE_ADAPTIVE_INPUT_MAPPING } from '../../constants/KbcConstants';
 
 const selectOptions = [
   { label: '10 minutes', value: '-10 minutes' },
@@ -43,7 +44,7 @@ export default createReactClass({
   getSelectOptions() {
     const options = [...selectOptions];
 
-    if (ApplicationStore.hasCurrentProjectFeature(changedSinceConstants.ADAPTIVE_FEATURE) && this.props.allowAdaptive || this.props.value === changedSinceConstants.ADAPTIVE_VALUE) {
+    if (ApplicationStore.hasCurrentProjectFeature(FEATURE_ADAPTIVE_INPUT_MAPPING) && this.props.allowAdaptive || this.props.value === changedSinceConstants.ADAPTIVE_VALUE) {
       options.unshift({
         label: changedSinceConstants.ADAPTIVE_LABEL,
         value: changedSinceConstants.ADAPTIVE_VALUE

--- a/src/scripts/react/common/changedSinceConstants.js
+++ b/src/scripts/react/common/changedSinceConstants.js
@@ -1,5 +1,6 @@
 export default {
   ADAPTIVE_VALUE: 'adaptive',
   ADAPTIVE_LABEL: 'Since last successful run',
-  ADAPTIVE_LABEL_DESCRIPTION: 'Changed since last successful run'
+  ADAPTIVE_LABEL_DESCRIPTION: 'Changed since last successful run',
+  ADAPTIVE_FEATURE: 'ui-adaptive-input-mapping'
 }

--- a/src/scripts/react/common/changedSinceConstants.js
+++ b/src/scripts/react/common/changedSinceConstants.js
@@ -1,6 +1,5 @@
 export default {
   ADAPTIVE_VALUE: 'adaptive',
   ADAPTIVE_LABEL: 'Since last successful run',
-  ADAPTIVE_LABEL_DESCRIPTION: 'Changed since last successful run',
-  ADAPTIVE_FEATURE: 'ui-adaptive-input-mapping'
+  ADAPTIVE_LABEL_DESCRIPTION: 'Changed since last successful run'
 }

--- a/src/scripts/react/common/changedSinceConstants.js
+++ b/src/scripts/react/common/changedSinceConstants.js
@@ -1,0 +1,4 @@
+export default {
+  ADAPTIVE_VALUE: 'adaptive',
+  ADAPTIVE_LABEL: 'Since last successful run'
+}

--- a/src/scripts/react/common/changedSinceConstants.js
+++ b/src/scripts/react/common/changedSinceConstants.js
@@ -1,4 +1,5 @@
 export default {
   ADAPTIVE_VALUE: 'adaptive',
-  ADAPTIVE_LABEL: 'Since last successful run'
+  ADAPTIVE_LABEL: 'Since last successful run',
+  ADAPTIVE_LABEL_DESCRIPTION: 'Changed since last successful run'
 }


### PR DESCRIPTION
Přidal jsem do Data filteru možnost `Since last successful run`.

![image](https://user-images.githubusercontent.com/497675/55232898-29343400-5227-11e9-9031-1a60bc35107d.png)

![image](https://user-images.githubusercontent.com/497675/55232893-220d2600-5227-11e9-8e7e-b68b51cb6c37.png)

Je to zatím povolené pro writery - probublal jsem `componentType` až do `TableInputMappingEditor`, kde se to mění na `allowAdaptive`, co už přijímá `ChangedSinceFilterInput` a `ChangedSinceInput`. To tam je kvůli tomu, aby se ta možnost nezobrazovala pouze writerům a ne třeba i extraktorům nebo v transformacích.

Celé se to ještě v projektu zapíná přes featuru `ui-adaptive-input-mapping`, to tam je přidané jedním commitem a až to půjde úplně ven, revertne se jeden commit (https://github.com/keboola/kbc-ui/pull/3160/commits/474c3b65678b62866fa6cd13eb63d113d8f2ebb5)

Nemám vyřešený help block tady, ale to bych řešil až s dokumentací. Jak je to přes featuru, tak bych to takhle ven asi klidně pustil. 

![image](https://user-images.githubusercontent.com/497675/55233065-a8c20300-5227-11e9-9275-424ea402fed4.png)



