### PR TITLE
Suggestion to schedule component in its configuration

### DIFF
--- a/src/scripts/modules/apify/react/Index/Index.jsx
+++ b/src/scripts/modules/apify/react/Index/Index.jsx
@@ -18,6 +18,7 @@ import SapiTableLinkEx from '../../../components/react/components/StorageApiTabl
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../../components/react/components/SidebarVersionsWrapper';
 import SetupModal from './SetupModal';
@@ -86,6 +87,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
+++ b/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
@@ -36,7 +36,6 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
-import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 
@@ -141,12 +140,6 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
-                componentId={componentId}
-                configId={this.state.configId}
-              />
-            </li>
-            <li>
-              <ScheduleConfigurationButton
                 componentId={componentId}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
+++ b/src/scripts/modules/app-geneea-nlp-analysis/react/Index.jsx
@@ -36,6 +36,7 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 
@@ -140,6 +141,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={componentId}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={componentId}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -80,7 +80,7 @@ export default createReactClass({
             onChange={this.handleName}
             value={this.state.name}
           />
-          <HelpBlock>Leave blank to use default name</HelpBlock>
+          <HelpBlock>Leave blank to use the default name</HelpBlock>
         </FormGroup>
         <FormGroup>
           <ControlLabel>Schedule</ControlLabel>

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -52,12 +52,13 @@ export default createReactClass({
 
     return (
       <Confirm
+        closeAfterResolve
         title={`Automate ${this.state.config.get('name')} config`}
+        onConfirm={this.handleSubmit}
+        isLoading={this.state.isLoading}
         text={this.renderBody()}
         buttonType="primary"
         buttonLabel="Automate"
-        onConfirm={this.handleSubmit}
-        isLoading={this.state.isLoading}
         childrenRootElement="a"
       >
         <i className="fa fa-clock-o fa-fw" /> Automate this config

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -20,7 +20,7 @@ const scheduleOptions = [
   { label: 'Once per 5 hours', value: '0 */5 * * *' },
   { label: 'Twice a day', value: '0 5,17 * * *' },
   { label: 'Once per day', value: '0 12 * * *' },
-  { label: 'Own schedule plan', value: CUSTOM_SCHEDULE_PLAN }
+  { label: 'Custom schedule plan', value: CUSTOM_SCHEDULE_PLAN }
 ];
 
 export default createReactClass({

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import Select from 'react-select';
 import ApplicationActionCreators from '../../../../actions/ApplicationActionCreators';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import CronScheduler from '../../../../react/common/CronScheduler';
@@ -80,18 +81,15 @@ export default createReactClass({
         </FormGroup>
         <FormGroup>
           <ControlLabel>How ofter do you want to run the configuration</ControlLabel>
-          <FormControl
+          <Select
             autoFocus
-            componentClass="select"
             onChange={this.handlePredefinedCrobtabRecord}
             value={this.state.predefinedCrontabRecord}
-          >
-            {scheduleOptions.map((option, index) => (
-              <option key={index} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </FormControl>
+            options={scheduleOptions}
+            deleteRemoves={false}
+            clearable={false}
+            backspaceRemoves={false}
+          />
         </FormGroup>
         {this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN && (
           <CronScheduler
@@ -107,8 +105,8 @@ export default createReactClass({
     this.setState({ name: event.target.value });
   },
 
-  handlePredefinedCrobtabRecord(event) {
-    this.setState({ predefinedCrontabRecord: event.target.value });
+  handlePredefinedCrobtabRecord(selected) {
+    this.setState({ predefinedCrontabRecord: selected.value });
   },
 
   handleCustomCrobtabRecord(crontabRecord) {

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -76,7 +76,7 @@ export default createReactClass({
           <ControlLabel>Orchestration name</ControlLabel>
           <FormControl
             type="text"
-            placeholder={`Automated ${this.state.config.get('name')}`}
+            placeholder={`Scheduled ${this.state.config.get('name')}`}
             onChange={this.handleName}
             value={this.state.name}
           />
@@ -121,7 +121,7 @@ export default createReactClass({
     this.setState({ isLoading: true });
     return OrchestrationActionCreators.createOrchestration(
       {
-        name: this.state.name || `Automated ${this.state.config.get('name')}`,
+        name: this.state.name || `Scheduled ${this.state.config.get('name')}`,
         crontabRecord:
           this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN
             ? this.state.customCrontabRecord

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -18,7 +18,7 @@ const scheduleOptions = [
   { label: 'Every 10 minutes', value: '*/10 * * * *' },
   { label: 'Twice per hour', value: '*/30 * * * *' },
   { label: 'Once per hour', value: '1 * * * *' },
-  { label: 'Once per 5 hours', value: '0 */5 * * *' },
+  { label: 'Once per 6 hours', value: '0 */6 * * *' },
   { label: 'Twice a day (5 am, 5 pm)', value: '0 5,17 * * *' },
   { label: 'Once a day (12 pm)', value: '0 12 * * *' }
 ];

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -16,9 +16,9 @@ const scheduleOptions = [
   { label: 'Every 10 minutes', value: '*/10 * * * *' },
   { label: 'Twice per hour', value: '*/30 * * * *' },
   { label: 'Once per hour', value: '1 * * * *' },
-  { label: 'Once per 5 hours', value: '* */5 * * *' },
-  { label: 'Twice a day', value: '* 5,17 * * *' },
-  { label: 'Once per day', value: '* 12 * * *' },
+  { label: 'Once per 5 hours', value: '0 */5 * * *' },
+  { label: 'Twice a day', value: '0 5,17 * * *' },
+  { label: 'Once per day', value: '0 12 * * *' },
   { label: 'Own schedule plan', value: CUSTOM_SCHEDULE_PLAN }
 ];
 

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import { FormGroup, FormControl, ControlLabel, HelpBlock } from 'react-bootstrap';
 import Select from 'react-select';
 import ApplicationActionCreators from '../../../../actions/ApplicationActionCreators';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
@@ -13,14 +13,14 @@ import configurationScheduled from './notifications/configurationScheduled';
 
 const CUSTOM_SCHEDULE_PLAN = 'custom';
 const scheduleOptions = [
+  { label: 'Custom schedule', value: CUSTOM_SCHEDULE_PLAN },
   { label: 'Every minute', value: '*/5 * * * *' },
   { label: 'Every 10 minutes', value: '*/10 * * * *' },
   { label: 'Twice per hour', value: '*/30 * * * *' },
   { label: 'Once per hour', value: '1 * * * *' },
   { label: 'Once per 5 hours', value: '0 */5 * * *' },
-  { label: 'Twice a day', value: '0 5,17 * * *' },
-  { label: 'Once per day', value: '0 12 * * *' },
-  { label: 'Custom schedule plan', value: CUSTOM_SCHEDULE_PLAN }
+  { label: 'Twice a day (5 am, 5 pm)', value: '0 5,17 * * *' },
+  { label: 'Once a day (12 pm)', value: '0 12 * * *' }
 ];
 
 export default createReactClass({
@@ -54,7 +54,7 @@ export default createReactClass({
     return (
       <Confirm
         closeAfterResolve
-        title={`Automate ${this.state.config.get('name')} config`}
+        title={`Automate ${this.state.config.get('name')}`}
         onConfirm={this.handleSubmit}
         isLoading={this.state.isLoading}
         text={this.renderBody()}
@@ -62,7 +62,7 @@ export default createReactClass({
         buttonLabel="Automate"
         childrenRootElement="a"
       >
-        <i className="fa fa-clock-o fa-fw" /> Automate this config
+        <i className="fa fa-clock-o fa-fw" /> Automate
       </Confirm>
     );
   },
@@ -70,17 +70,20 @@ export default createReactClass({
   renderBody() {
     return (
       <div className="form">
+        <p>You are about to create a single task orchestration with given name and schedule.</p>
+        <br />
         <FormGroup>
-          <ControlLabel>Orchestration name (leave blank to use default name)</ControlLabel>
+          <ControlLabel>Orchestration name</ControlLabel>
           <FormControl
             type="text"
-            placeholder={`Scheduled ${this.state.config.get('name')} configuration`}
+            placeholder={`Automated ${this.state.config.get('name')}`}
             onChange={this.handleName}
             value={this.state.name}
           />
+          <HelpBlock>Leave blank to use default name</HelpBlock>
         </FormGroup>
         <FormGroup>
-          <ControlLabel>How ofter do you want to run the configuration</ControlLabel>
+          <ControlLabel>Schedule</ControlLabel>
           <Select
             autoFocus
             onChange={this.handlePredefinedCrobtabRecord}
@@ -118,7 +121,7 @@ export default createReactClass({
     this.setState({ isLoading: true });
     return OrchestrationActionCreators.createOrchestration(
       {
-        name: this.state.name || `Scheduled ${this.state.config.get('name')} configuration`,
+        name: this.state.name || `Automated ${this.state.config.get('name')}`,
         crontabRecord:
           this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN
             ? this.state.customCrontabRecord

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -39,10 +39,9 @@ export default createReactClass({
   getInitialState() {
     return {
       name: '',
-      ownCrontabRecord: '0 0 * * *',
+      customCrontabRecord: '0 0 * * *',
       predefinedCrontabRecord: '1 * * * *',
-      isLoading: false,
-      redirect: false
+      isLoading: false
     };
   },
 
@@ -95,8 +94,8 @@ export default createReactClass({
         </FormGroup>
         {this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN && (
           <CronScheduler
-            crontabRecord={this.state.ownCrontabRecord}
-            onChange={this.handleOwnCrobtabRecord}
+            crontabRecord={this.state.customCrontabRecord}
+            onChange={this.handleCustomCrobtabRecord}
           />
         )}
       </div>
@@ -111,18 +110,18 @@ export default createReactClass({
     this.setState({ predefinedCrontabRecord: event.target.value });
   },
 
-  handleOwnCrobtabRecord(crontabRecord) {
-    this.setState({ ownCrontabRecord: crontabRecord });
+  handleCustomCrobtabRecord(crontabRecord) {
+    this.setState({ customCrontabRecord: crontabRecord });
   },
 
   handleSubmit() {
     this.setState({ isLoading: true });
-    OrchestrationActionCreators.createOrchestration(
+    return OrchestrationActionCreators.createOrchestration(
       {
         name: this.state.name || `Scheduled ${this.state.config.get('name')} configuration`,
         crontabRecord:
           this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN
-            ? this.state.ownCrontabRecord
+            ? this.state.customCrontabRecord
             : this.state.predefinedCrontabRecord,
         tasks: [
           {
@@ -136,7 +135,7 @@ export default createReactClass({
           }
         ]
       },
-      this.state.redirect
+      false
     )
       .then((orchestration) => {
         ApplicationActionCreators.sendNotification({

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -1,0 +1,150 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import ApplicationActionCreators from '../../../../actions/ApplicationActionCreators';
+import createStoreMixin from '../../../../react/mixins/createStoreMixin';
+import CronScheduler from '../../../../react/common/CronScheduler';
+import Confirm from '../../../../react/common/Confirm';
+import OrchestrationActionCreators from '../../../orchestrations/ActionCreators';
+import InstalledComponentsStore from '../../stores/InstalledComponentsStore';
+import configurationScheduled from './notifications/configurationScheduled';
+
+const CUSTOM_SCHEDULE_PLAN = 'custom';
+const scheduleOptions = [
+  { label: 'Every minute', value: '*/5 * * * *' },
+  { label: 'Every 10 minutes', value: '*/10 * * * *' },
+  { label: 'Twice per hour', value: '*/30 * * * *' },
+  { label: 'Once per hour', value: '1 * * * *' },
+  { label: 'Once per 5 hours', value: '* */5 * * *' },
+  { label: 'Twice a day', value: '* 5,17 * * *' },
+  { label: 'Once per day', value: '* 12 * * *' },
+  { label: 'Own schedule plan', value: CUSTOM_SCHEDULE_PLAN }
+];
+
+export default createReactClass({
+  mixins: [createStoreMixin(InstalledComponentsStore)],
+
+  propTypes: {
+    componentId: PropTypes.string.isRequired,
+    configId: PropTypes.string.isRequired
+  },
+
+  getStateFromStores() {
+    return {
+      config: InstalledComponentsStore.getConfig(this.props.componentId, this.props.configId)
+    };
+  },
+
+  getInitialState() {
+    return {
+      name: '',
+      ownCrontabRecord: '0 0 * * *',
+      predefinedCrontabRecord: '1 * * * *',
+      isLoading: false,
+      redirect: false
+    };
+  },
+
+  render() {
+    if (!this.state.config.count()) {
+      return null;
+    }
+
+    return (
+      <Confirm
+        title={`Automate ${this.state.config.get('name')} config`}
+        text={this.renderBody()}
+        buttonType="primary"
+        buttonLabel="Automate"
+        onConfirm={this.handleSubmit}
+        isLoading={this.state.isLoading}
+        childrenRootElement="a"
+      >
+        <i className="fa fa-clock-o fa-fw" /> Automate this config
+      </Confirm>
+    );
+  },
+
+  renderBody() {
+    return (
+      <div className="form">
+        <FormGroup>
+          <ControlLabel>Orchestration name (leave blank to use default name)</ControlLabel>
+          <FormControl
+            type="text"
+            placeholder={`Scheduled ${this.state.config.get('name')} configuration`}
+            onChange={this.handleName}
+            value={this.state.name}
+          />
+        </FormGroup>
+        <FormGroup>
+          <ControlLabel>How ofter do you want to run the configuration</ControlLabel>
+          <FormControl
+            autoFocus
+            componentClass="select"
+            onChange={this.handlePredefinedCrobtabRecord}
+            value={this.state.predefinedCrontabRecord}
+          >
+            {scheduleOptions.map((option, index) => (
+              <option key={index} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </FormControl>
+        </FormGroup>
+        {this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN && (
+          <CronScheduler
+            crontabRecord={this.state.ownCrontabRecord}
+            onChange={this.handleOwnCrobtabRecord}
+          />
+        )}
+      </div>
+    );
+  },
+
+  handleName(event) {
+    this.setState({ name: event.target.value });
+  },
+
+  handlePredefinedCrobtabRecord(event) {
+    this.setState({ predefinedCrontabRecord: event.target.value });
+  },
+
+  handleOwnCrobtabRecord(crontabRecord) {
+    this.setState({ ownCrontabRecord: crontabRecord });
+  },
+
+  handleSubmit() {
+    this.setState({ isLoading: true });
+    OrchestrationActionCreators.createOrchestration(
+      {
+        name: this.state.name || `Scheduled ${this.state.config.get('name')} configuration`,
+        crontabRecord:
+          this.state.predefinedCrontabRecord === CUSTOM_SCHEDULE_PLAN
+            ? this.state.ownCrontabRecord
+            : this.state.predefinedCrontabRecord,
+        tasks: [
+          {
+            component: this.props.componentId,
+            action: 'run',
+            actionParameters: {
+              config: this.props.configId.toString()
+            },
+            continueOnFailure: false,
+            active: true
+          }
+        ]
+      },
+      this.state.redirect
+    )
+      .then((orchestration) => {
+        ApplicationActionCreators.sendNotification({
+          message: configurationScheduled(this.state.config, orchestration.id)
+        });
+      })
+      .finally(() => {
+        this.setState({ isLoading: false });
+      });
+  }
+});

--- a/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
+++ b/src/scripts/modules/components/react/components/ScheduleConfigurationButton.jsx
@@ -115,6 +115,7 @@ export default createReactClass({
   },
 
   handleSubmit() {
+    const redirectToCreatedOrchestration = false;
     this.setState({ isLoading: true });
     return OrchestrationActionCreators.createOrchestration(
       {
@@ -135,7 +136,7 @@ export default createReactClass({
           }
         ]
       },
-      false
+      redirectToCreatedOrchestration
     )
       .then((orchestration) => {
         ApplicationActionCreators.sendNotification({

--- a/src/scripts/modules/components/react/components/notifications/configurationScheduled.js
+++ b/src/scripts/modules/components/react/components/notifications/configurationScheduled.js
@@ -1,0 +1,24 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import createReactClass from 'create-react-class';
+import { Link } from 'react-router';
+
+export default (configuration, orchestrationId) => {
+  return createReactClass({
+    propTypes: {
+      onClick: PropTypes.func.isRequired
+    },
+
+    render() {
+      return (
+        <span>
+          Configuration {configuration.get('name')} has been{' '}
+          <Link to="orchestration" params={{ orchestrationId }} onClick={this.props.onClick}>
+            scheduled
+          </Link>
+          .
+        </span>
+      );
+    }
+  });
+};

--- a/src/scripts/modules/components/react/components/notifications/configurationScheduled.js
+++ b/src/scripts/modules/components/react/components/notifications/configurationScheduled.js
@@ -14,7 +14,7 @@ export default (configuration, orchestrationId) => {
         <span>
           Configuration {configuration.get('name')} has been{' '}
           <Link to="orchestration" params={{ orchestrationId }} onClick={this.props.onClick}>
-            scheduled
+            automated
           </Link>
           .
         </span>

--- a/src/scripts/modules/components/react/pages/GenericDetailEditable.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDetailEditable.jsx
@@ -15,6 +15,7 @@ import ComponentMetadata from '../components/ComponentMetadata';
 import LastUpdateInfo from '../../../../react/common/LastUpdateInfo';
 import RunComponentButton from '../components/RunComponentButton';
 import DeleteConfigurationButton from '../components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../components/SidebarJobsContainer';
 import Configuration from '../components/Configuration';
 import InstalledComponentsActionCreators from '../../InstalledComponentsActionCreators';
@@ -102,6 +103,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.componentId}
+                configId={this.state.config.get('id')}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.componentId}
                 configId={this.state.config.get('id')}
               />

--- a/src/scripts/modules/components/react/pages/GenericDetailStatic.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDetailStatic.jsx
@@ -12,6 +12,7 @@ import ComponentDescription from '../components/ComponentDescription';
 import ComponentMetadata from '../components/ComponentMetadata';
 import RunComponentButton from '../components/RunComponentButton';
 import DeleteConfigurationButton from '../components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../components/SidebarJobsContainer';
 import contactSupport from '../../../../utils/contactSupport';
 import LastUpdateInfo from '../../../../react/common/LastUpdateInfo';
@@ -75,6 +76,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.componentId}
+                configId={this.state.config.get('id')}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.componentId}
                 configId={this.state.config.get('id')}
               />

--- a/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
+++ b/src/scripts/modules/components/react/pages/GenericDockerDetail.jsx
@@ -16,6 +16,7 @@ import ComponentDescription from '../components/ComponentDescription';
 import ComponentMetadata from '../components/ComponentMetadata';
 import RunComponentButton from '../components/RunComponentButton';
 import DeleteConfigurationButton from '../components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../components/SidebarJobsContainer';
 import Configuration from '../components/Configuration';
 import RuntimeConfiguration from '../components/RuntimeConfiguration';
@@ -263,6 +264,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.componentId}
+                configId={this.state.config.get('id')}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.componentId}
                 configId={this.state.config.get('id')}
               />

--- a/src/scripts/modules/configurations/react/pages/Index.jsx
+++ b/src/scripts/modules/configurations/react/pages/Index.jsx
@@ -21,6 +21,7 @@ import RunComponentButton from '../../../components/react/components/RunComponen
 import ComponentDescription from '../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import LatestVersions from '../../../components/react/components/SidebarVersionsWrapper';
 import SidebarJobsContainer from '../../../components/react/components/SidebarJobsContainer';
 import CreateConfigurationRowButton from '../components/CreateConfigurationRowButton';
@@ -196,6 +197,12 @@ export default createReactClass({
               })}
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.componentId}
+                configId={this.state.configurationId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.componentId}
                 configId={this.state.configurationId}
               />

--- a/src/scripts/modules/csv-import/react/Index/Index.jsx
+++ b/src/scripts/modules/csv-import/react/Index/Index.jsx
@@ -24,6 +24,7 @@ import SaveButtons from '../../../../react/common/SaveButtons';
 import ComponentDescription from '../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import LatestVersions from '../../../components/react/components/SidebarVersionsWrapper';
 
 // utils
@@ -156,6 +157,12 @@ export default createReactClass({
           <ul className="nav nav-stacked">
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/custom-science/react/Index.jsx
+++ b/src/scripts/modules/custom-science/react/Index.jsx
@@ -15,7 +15,6 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
-import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 
 import InstalledComponentsActions from '../../components/InstalledComponentsActionCreators';
 
@@ -165,12 +164,6 @@ export default createReactClass({
           </li>
           <li>
             <DeleteConfigurationButton
-              componentId={componentId}
-              configId={this.state.configId}
-            />
-          </li>
-          <li>
-            <ScheduleConfigurationButton
               componentId={componentId}
               configId={this.state.configId}
             />

--- a/src/scripts/modules/custom-science/react/Index.jsx
+++ b/src/scripts/modules/custom-science/react/Index.jsx
@@ -15,6 +15,7 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 
 import InstalledComponentsActions from '../../components/InstalledComponentsActionCreators';
 
@@ -164,6 +165,12 @@ export default createReactClass({
           </li>
           <li>
             <DeleteConfigurationButton
+              componentId={componentId}
+              configId={this.state.configId}
+            />
+          </li>
+          <li>
+            <ScheduleConfigurationButton
               componentId={componentId}
               configId={this.state.configId}
             />

--- a/src/scripts/modules/ex-adform/react/Index.jsx
+++ b/src/scripts/modules/ex-adform/react/Index.jsx
@@ -11,6 +11,7 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 import CredentialsModal from './CredentialsModal';
@@ -156,6 +157,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.componentId}
+                configId={this.state.config.get('id')}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.componentId}
                 configId={this.state.config.get('id')}
               />

--- a/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/index/Index.jsx
@@ -17,9 +17,9 @@ import ComponentDescription from '../../../../components/react/components/Compon
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import SidebarVersions from '../../../../components/react/components/SidebarVersionsWrapper';
 
-import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
-
 import SidebarJobsContainer from '../../../../components/react/components/SidebarJobsContainer';
+import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import RunComponentButton from '../../../../components/react/components/RunComponentButton';
 
 import {Loader} from '@keboola/indigo-ui';
@@ -299,6 +299,12 @@ export default function(componentId) {
               </li>
               <li>
                 <DeleteConfigurationButton
+                  componentId={componentId}
+                  configId={this.state.configId}
+                />
+              </li>
+              <li>
+                <ScheduleConfigurationButton
                   componentId={componentId}
                   configId={this.state.configId}
                 />

--- a/src/scripts/modules/ex-dropbox-v2/react/Index.jsx
+++ b/src/scripts/modules/ex-dropbox-v2/react/Index.jsx
@@ -9,6 +9,7 @@ import string from '../../../utils/string';
 import classnames from 'classnames';
 import ComponentDescription from '../../components/react/components/ComponentDescription';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 import getDefaultBucket from '../../../utils/getDefaultBucket';
 import SapiTableLinkEx from '../../components/react/components/StorageApiTableLinkEx';
@@ -232,6 +233,12 @@ export default createReactClass({
               componentId={componentId}
               configId={this.state.configId}
               customDeleteFn={() => {}}
+            />
+          </li>
+          <li>
+            <ScheduleConfigurationButton
+              componentId={componentId}
+              configId={this.state.configId}
             />
           </li>
         </ul>

--- a/src/scripts/modules/ex-email-attachments/react/Index.jsx
+++ b/src/scripts/modules/ex-email-attachments/react/Index.jsx
@@ -17,6 +17,7 @@ import {RefreshIcon} from '@keboola/indigo-ui';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import ConfigurationForm from './ConfigurationForm';
 import StorageTablesStore from '../../components/stores/StorageTablesStore';
@@ -157,6 +158,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/ex-facebook/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-facebook/react/Index/Index.jsx
@@ -20,6 +20,7 @@ import ComponentDescription from '../../../components/react/components/Component
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import QueriesTable from './QueriesTable';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import {ExternalLink} from '@keboola/indigo-ui';
@@ -134,6 +135,12 @@ export default function(COMPONENT_ID) {
               </li>
               <li>
                 <DeleteConfigurationButton
+                  componentId={COMPONENT_ID}
+                  configId={this.state.configId}
+                />
+              </li>
+              <li>
+                <ScheduleConfigurationButton
                   componentId={COMPONENT_ID}
                   configId={this.state.configId}
                 />

--- a/src/scripts/modules/ex-google-analytics-v4/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-analytics-v4/react/Index/Index.jsx
@@ -17,6 +17,7 @@ import ComponentDescription from '../../../components/react/components/Component
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import {Link} from 'react-router';
 import {ExternalLink} from '@keboola/indigo-ui';
@@ -124,6 +125,12 @@ export default function(componentId) {
               </li>
               <li>
                 <DeleteConfigurationButton
+                  componentId={componentId}
+                  configId={this.state.configId}
+                />
+              </li>
+              <li>
+                <ScheduleConfigurationButton
                   componentId={componentId}
                   configId={this.state.configId}
                 />

--- a/src/scripts/modules/ex-google-bigquery/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/Index/Index.jsx
@@ -20,6 +20,7 @@ import ComponentDescription from '../../../components/react/components/Component
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import {SearchBar, ExternalLink} from '@keboola/indigo-ui';
 import Confirm from '../../../../react/common/Confirm';
@@ -119,6 +120,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/ex-google-drive/react/Index/Index.jsx
+++ b/src/scripts/modules/ex-google-drive/react/Index/Index.jsx
@@ -18,6 +18,7 @@ import ComponentDescription from '../../../components/react/components/Component
 import ComponentMetadata from '../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../components/react/components/ScheduleConfigurationButton';
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 // import {Link} from 'react-router';
 import SidebarJobsContainer from '../../../components/react/components/SidebarJobsContainer';
@@ -95,6 +96,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/ex-mongodb/react/pages/index/Index.jsx
+++ b/src/scripts/modules/ex-mongodb/react/pages/index/Index.jsx
@@ -8,6 +8,7 @@ import RoutesStore from '../../../../../stores/RoutesStore';
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../../../components/react/components/SidebarJobsContainer';
 import RunExtractionButton from '../../../../components/react/components/RunComponentButton';
 import { SearchBar } from '@keboola/indigo-ui';
@@ -150,6 +151,9 @@ export default function(componentId) {
             </li>
             <li>
               <DeleteConfigurationButton componentId={componentId} configId={configurationId} />
+            </li>
+            <li>
+              <ScheduleConfigurationButton componentId={componentId} configId={configurationId} />
             </li>
           </ul>
           <SidebarJobsContainer

--- a/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/ex-s3/react/pages/Index/Index.jsx
@@ -23,6 +23,7 @@ import Advanced from '../../components/Advanced';
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import RunComponentButton from '../../../../components/react/components/RunComponentButton';
 import LatestVersions from '../../../../components/react/components/SidebarVersionsWrapper';
 import SidebarJobsContainer from '../../../../components/react/components/SidebarJobsContainer';
@@ -148,6 +149,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={COMPONENT_ID}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/ex-twitter/react/Index.jsx
+++ b/src/scripts/modules/ex-twitter/react/Index.jsx
@@ -20,6 +20,7 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 import {ExternalLink} from '@keboola/indigo-ui';
@@ -164,6 +165,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={this.state.component.get('id')}
+                configId={this.state.config.get('id')}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={this.state.component.get('id')}
                 configId={this.state.config.get('id')}
               />

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
@@ -39,6 +39,7 @@ import ComponentDescription from '../../components/react/components/ComponentDes
 import ComponentMetadata from '../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../components/react/components/ScheduleConfigurationButton';
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import LatestVersions from '../../components/react/components/SidebarVersionsWrapper';
 
@@ -151,6 +152,12 @@ export default createReactClass({
             </li>
             <li>
               <DeleteConfigurationButton
+                componentId={componentId}
+                configId={this.state.configId}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
                 componentId={componentId}
                 configId={this.state.configId}
               />

--- a/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/pages/index/Index.jsx
@@ -33,6 +33,7 @@ import DimensionsSection from '../../components/DimensionsSection';
 import CredentialsContainer from '../../components/CredentialsContainer';
 import TablesLoadSettings from '../../components/TablesLoadSettings';
 import DeleteGoodDataWriterButton from '../../components/DeleteGoodDataWriterButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 
 const COMPONENT_ID = 'keboola.gooddata-writer';
 
@@ -127,6 +128,12 @@ export default createReactClass({
                 getConfigDataFn={() => Promise.resolve(this.state.configProvisioning.configData)}
                 deleteConfigFn={() => InstalledComponentsActionCreators.deleteConfiguration(COMPONENT_ID, this.state.configurationId, true)}
                 isDeletingConfig={this.state.isDeletingConfig}
+              />
+            </li>
+            <li>
+              <ScheduleConfigurationButton
+                componentId={COMPONENT_ID}
+                configId={this.state.configurationId}
               />
             </li>
           </ul>

--- a/src/scripts/modules/orchestrations/ActionCreators.js
+++ b/src/scripts/modules/orchestrations/ActionCreators.js
@@ -190,7 +190,7 @@ export default {
       });
   },
 
-  createOrchestration(data) {
+  createOrchestration(data, redirect = true) {
     let newOrchestration = {};
     return orchestrationsApi
       .createOrchestration(data)
@@ -203,6 +203,10 @@ export default {
           type: constants.ActionTypes.ORCHESTRATION_CREATE_SUCCESS,
           orchestration: newOrchestration
         });
+
+        if (!redirect) {
+          return newOrchestration;
+        }
         return RoutesStore.getRouter().transitionTo('orchestration', { orchestrationId: newOrchestration.id });
       });
   },

--- a/src/scripts/modules/tde-exporter/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/tde-exporter/react/pages/Index/Index.jsx
@@ -19,6 +19,7 @@ import RunButtonModal from '../../../../components/react/components/RunComponent
 import ComponentDescription from '../../../../components/react/components/ComponentDescription';
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import TablesByBucketsPanel from '../../../../components/react/components/TablesByBucketsPanel';
 import InstalledComponentsActions from '../../../../components/InstalledComponentsActionCreators';
 import storageActionCreators from '../../../../components/StorageActionCreators';
@@ -124,6 +125,9 @@ export default createReactClass({
           <li>{this._renderSetupDestinationLink()}</li>
           <li>
             <DeleteConfigurationButton componentId={componentId} configId={this.state.configId} />
+          </li>
+          <li>
+            <ScheduleConfigurationButton componentId={componentId} configId={this.state.configId} />
           </li>
         </ul>
         <SidebarJobsContainer

--- a/src/scripts/modules/wr-db/react/pages/index/Index.jsx
+++ b/src/scripts/modules/wr-db/react/pages/index/Index.jsx
@@ -25,6 +25,7 @@ import InstalledComponentsStore from '../../../../components/stores/InstalledCom
 import WrDbStore from '../../../store';
 import WrDbActions from '../../../actionCreators';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import InstalledComponentsActions from '../../../../components/InstalledComponentsActionCreators';
 import StorageTablesStore from '../../../../components/stores/StorageTablesStore';
 import fieldsTemplate from '../../../templates/credentialsFields';
@@ -254,6 +255,9 @@ export default componentId => {
             </li>
             <li>
               <DeleteConfigurationButton componentId={componentId} configId={this.state.configId} />
+            </li>
+            <li>
+              <ScheduleConfigurationButton componentId={componentId} configId={this.state.configId} />
             </li>
           </ul>
           <SidebarJobsContainer

--- a/src/scripts/modules/wr-google-drive/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/wr-google-drive/react/pages/Index/Index.jsx
@@ -19,6 +19,7 @@ import ComponentDescription from '../../../../components/react/components/Compon
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import FilesList from '../../components/FilesList';
 import FileModal from '../../components/FileModal';
 import EmptyState from '../../../../components/react/components/ComponentEmptyState';
@@ -106,6 +107,12 @@ export default function(COMPONENT_ID) {
               </li>
               <li>
                 <DeleteConfigurationButton
+                  componentId={COMPONENT_ID}
+                  configId={this.state.configId}
+                />
+              </li>
+              <li>
+                <ScheduleConfigurationButton
                   componentId={COMPONENT_ID}
                   configId={this.state.configId}
                 />

--- a/src/scripts/modules/wr-google-sheets/react/pages/Index/Index.jsx
+++ b/src/scripts/modules/wr-google-sheets/react/pages/Index/Index.jsx
@@ -19,6 +19,7 @@ import ComponentDescription from '../../../../components/react/components/Compon
 import ComponentMetadata from '../../../../components/react/components/ComponentMetadata';
 import RunComponentButton from '../../../../components/react/components/RunComponentButton';
 import DeleteConfigurationButton from '../../../../components/react/components/DeleteConfigurationButton';
+import ScheduleConfigurationButton from '../../../../components/react/components/ScheduleConfigurationButton';
 import SheetsList from '../../components/SheetsList';
 import SheetModal from '../../components/SheetModal';
 import EmptyState from '../../../../components/react/components/ComponentEmptyState';
@@ -106,6 +107,12 @@ export default function(COMPONENT_ID) {
               </li>
               <li>
                 <DeleteConfigurationButton
+                  componentId={COMPONENT_ID}
+                  configId={this.state.configId}
+                />
+              </li>
+              <li>
+                <ScheduleConfigurationButton
                   componentId={COMPONENT_ID}
                   configId={this.state.configId}
                 />

--- a/src/scripts/react/common/Confirm.jsx
+++ b/src/scripts/react/common/Confirm.jsx
@@ -11,6 +11,7 @@ export default createReactClass({
     buttonLabel: PropTypes.string.isRequired,
     buttonType: PropTypes.string,
     isLoading: PropTypes.bool,
+    closeAfterResolve: PropTypes.bool,
     children: PropTypes.any,
     childrenRootElement: PropTypes.any
   },
@@ -50,6 +51,7 @@ export default createReactClass({
           title={this.props.title}
           text={this.props.text}
           isLoading={this.props.isLoading}
+          closeAfterResolve={this.props.closeAfterResolve}
           onConfirm={this.props.onConfirm}
           buttonLabel={this.props.buttonLabel}
           buttonType={this.props.buttonType}

--- a/src/scripts/react/common/ConfirmModal.jsx
+++ b/src/scripts/react/common/ConfirmModal.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import {Modal, ButtonToolbar, Button} from 'react-bootstrap';
+import { Modal, ButtonToolbar, Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 
 export default createReactClass({
@@ -13,12 +13,14 @@ export default createReactClass({
     onConfirm: PropTypes.func.isRequired,
     onHide: PropTypes.func.isRequired,
     show: PropTypes.bool.isRequired,
-    isLoading: PropTypes.bool
+    isLoading: PropTypes.bool,
+    closeAfterResolve: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
-      isLoading: false
+      isLoading: false,
+      closeAfterResolve: false
     };
   },
 
@@ -26,22 +28,22 @@ export default createReactClass({
     return (
       <Modal onHide={this.props.onHide} show={this.props.show}>
         <Modal.Header closeButton>
-          <Modal.Title>
-            {this.props.title}
-          </Modal.Title>
+          <Modal.Title>{this.props.title}</Modal.Title>
         </Modal.Header>
         <Modal.Body>
           <div>{this.props.text}</div>
         </Modal.Body>
         <Modal.Footer>
           <ButtonToolbar>
-            {this.props.isLoading && (
-              <Loader />
-            )}
+            {this.props.isLoading && <Loader />}
             <Button onClick={this.props.onHide} bsStyle="link">
               Cancel
             </Button>
-            <Button onClick={this.handleConfirm} bsStyle={this.props.buttonType}>
+            <Button
+              onClick={this.handleConfirm}
+              bsStyle={this.props.buttonType}
+              disabled={this.props.isLoading}
+            >
               {this.props.buttonLabel}
             </Button>
           </ButtonToolbar>
@@ -51,6 +53,10 @@ export default createReactClass({
   },
 
   handleConfirm() {
+    if (this.props.closeAfterResolve) {
+      return this.props.onConfirm().then(this.props.onHide);
+    }
+
     this.props.onHide();
     this.props.onConfirm();
   }


### PR DESCRIPTION
Resolve https://github.com/keboola/internal/issues/164

V konfiguraci máme teda nové tlačítko které vytvoří Single task orchestraci, s tím že jí rovnou nastaví jak často se má pouštět.

![sidebar](https://user-images.githubusercontent.com/12331181/55401808-1df84580-5552-11e9-9902-f2872f4fdb53.png)

V modalu by mělo být hlavní nastavení toho cronu, ale přidal jsem tam nakonec i název, nemusí se vyplnit ale říkal jsme si že často si to asi lidi budou chtít nějak pojmenovat tak se ušetří nějaký krok.
Autofocus je ale rovnou na ten cron.

![modal](https://user-images.githubusercontent.com/12331181/55401837-2fd9e880-5552-11e9-9f6a-bace13784f68.png)

Tam jsou tu možnosti které jsou zadné v úkolu.

Byl tam požadavek na to, aby když uživatel neví jak to chce, nebo mu nevyhovuje nějaká ta možnost, tak aby ho to pak nějak rovnou hodilo na scheduler. Ona to je ale hezká samostatné komponenta takže to šlo rovnou zabudovat sem. Což myslím že lepší. Vše nastavím na jednom místě a mám hotovo.

![custom](https://user-images.githubusercontent.com/12331181/55401859-41bb8b80-5552-11e9-9a0e-acf2e29cfb37.png)

Takto zvolím "custom" nastavení a mám tam tu stejnou komponentu jako v orchestraci. Nastavím a odešlu.

Redirect na orchestraci mi přisel docela "agresivní" tak jen zobrazuji notifikaci že to bylo vytvořeno kde je případně odkaz.

![notification](https://user-images.githubusercontent.com/12331181/55401893-5c8e0000-5552-11e9-85bd-fa7c89e9e776.png)

Snad to takto bude OK. Texty asi zase budou potřeba doladit.
