### PR TITLE
React-sortablejs

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,11 @@
     "react-remarkable": "^1.1.3",
     "react-router": "~0.13.6",
     "react-select": "^1.2.1",
+    "react-sortablejs": "^1.5.1",
     "react-textarea-autosize": "^7.1.0",
     "react-transition-group": "^2.6.0",
     "remove-markdown": "^0.3.0",
-    "sortablejs": "^1.7.0",
+    "sortablejs": "^1.8.4",
     "superagent": "^4.1.0",
     "underscore": "^1.9.0",
     "underscore.string": "^3.3.5"

--- a/src/scripts/modules/configurations/react/components/ConfigurationRowsTable.jsx
+++ b/src/scripts/modules/configurations/react/components/ConfigurationRowsTable.jsx
@@ -1,10 +1,10 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
+import classnames from 'classnames';
+import Sortable from 'react-sortablejs';
 import immutableMixin from 'react-immutable-render-mixin';
 import Row from './ConfigurationRowsTableRow';
-import classnames from 'classnames';
-import Sortable from 'sortablejs';
 
 export default createReactClass({
   mixins: [immutableMixin],
@@ -27,55 +27,45 @@ export default createReactClass({
 
   getInitialState() {
     return {
-      dragging: false,
-      draggedIndex: null,
-      sortableKeyPrefix: Math.random()
+      dragging: false
     };
   },
 
-  componentDidMount() {
-    const component = this;
-    const sortableOptions = {
-      sort: true,
-      disabled: this.props.disabledMove || this.props.orderPending.count() > 0,
-      handle: '.drag-handle',
-      forceFallback: true,
-      animation: 100,
-      onStart: function() {
-        component.setState({
-          dragging: true,
-          draggedIndex: null
-        });
-      },
-      onEnd: function(e) {
-        component.setState({
-          dragging: false,
-          draggedIndex: e.newIndex
-        });
-      },
-      store: {
-        get: function() {
-          return component.props.rows.map(function(row) {
-            return row.get('id');
-          }).toJS();
-        },
-        set: function(sortable) {
-          const orderedIds = sortable.toArray();
-          component.props.onOrder(orderedIds, orderedIds[component.state.draggedIndex]);
-          // to avoid resorting after re-render
-          // https://github.com/RubaXa/Sortable/issues/844#issuecomment-219180426
-          component.setState({
-            sortableKeyPrefix: Math.random(),
-            draggedIndex: null
-          });
-        }
-      }
-    };
-    Sortable.create(this.refs.list, sortableOptions);
+  render() {
+    return (
+      <div
+        className={classnames('table-config-rows', 'table', 'table-striped', {
+          'no-hover': this.state.dragging
+        })}
+      >
+        <div className="thead">
+          <div className="tr">
+            <span className="th" />
+            <span className="th">
+              #
+            </span>
+            {this.renderHeader()}
+          </div>
+        </div>
+        <Sortable
+          className="tbody"
+          options={{
+            disabled: this.props.disabledMove || this.props.orderPending.count() > 0,
+            handle: '.drag-handle',
+            animation: 100,
+            onStart: () => this.setState({ dragging: true }),
+            onEnd: () => this.setState({ dragging: false })
+          }}
+          onChange={(order, sortable, event) => this.props.onOrder(order, order[event.newIndex])}
+        >
+          {this.renderTableRows()}
+        </Sortable>
+      </div>
+    );
   },
 
   renderHeader() {
-    return this.props.columns.map(function(columnDefinition, index) {
+    return this.props.columns.map((columnDefinition, index) => {
       return (
         <span className="th" key={index}>
           <strong>{columnDefinition.get('name')}</strong>
@@ -85,63 +75,38 @@ export default createReactClass({
   },
 
   renderTableRows() {
-    const state = this.state;
-    return this.props.rows.map((row, rowIndex) => {
-      const thisRowOrderPending = this.props.orderPending.get(row.get('id'), false);
-      const rowsOrderPending = this.props.orderPending.count() > 0;
-      let disabledMoveLabel;
-      if (rowsOrderPending) {
-        disabledMoveLabel = 'Order saving';
-      } else {
-        disabledMoveLabel = 'Clear search query to allow changing order';
-      }
-      return (
-        <Row
-          columns={this.props.columns}
-          row={row}
-          componentId={this.props.componentId}
-          component={this.props.component}
-          configurationId={this.props.configurationId}
-          key={state.sortableKeyPrefix + '_' + row.get('id')}
-          rowNumber={rowIndex + 1}
-          linkTo={this.props.rowLinkTo}
-          isDeletePending={this.props.rowDeletePending(row.get('id'))}
-          onDelete={() => {
-            return this.props.rowDelete(row.get('id'));
-          }}
-          isEnableDisablePending={this.props.rowEnableDisablePending(row.get('id'))}
-          onEnableDisable={() => {
-            return this.props.rowEnableDisable(row.get('id'));
-          }}
-          disabledMove={this.props.disabledMove || rowsOrderPending}
-          disabledMoveLabel={disabledMoveLabel}
-          orderPending={thisRowOrderPending}
-        />
-      );
-    }).toList().toJS();
-  },
-
-  render() {
-    return (
-      <div className={classnames(
-        'table-config-rows',
-        'table',
-        'table-striped',
-        {
-          'table-hover': !this.state.dragging
+    return this.props.rows
+      .map((row, rowIndex) => {
+        const thisRowOrderPending = this.props.orderPending.get(row.get('id'), false);
+        const rowsOrderPending = this.props.orderPending.count() > 0;
+        let disabledMoveLabel;
+        if (rowsOrderPending) {
+          disabledMoveLabel = 'Order saving';
+        } else {
+          disabledMoveLabel = 'Clear search query to allow changing order';
         }
-      )}>
-        <div className="thead" key="table-header">
-          <div className="tr">
-            <span className="th" key="dummy" />
-            <span className="th" key="row-number">#</span>
-            {this.renderHeader()}
-          </div>
-        </div>
-        <div className="tbody" ref="list">
-          {this.renderTableRows()}
-        </div>
-      </div>
-    );
+
+        return (
+          <Row
+            key={row.get('id')}
+            columns={this.props.columns}
+            row={row}
+            componentId={this.props.componentId}
+            component={this.props.component}
+            configurationId={this.props.configurationId}
+            rowNumber={rowIndex + 1}
+            linkTo={this.props.rowLinkTo}
+            isDeletePending={this.props.rowDeletePending(row.get('id'))}
+            onDelete={() => this.props.rowDelete(row.get('id'))}
+            isEnableDisablePending={this.props.rowEnableDisablePending(row.get('id'))}
+            onEnableDisable={() => this.props.rowEnableDisable(row.get('id'))}
+            disabledMove={this.props.disabledMove || rowsOrderPending}
+            disabledMoveLabel={disabledMoveLabel}
+            orderPending={thisRowOrderPending}
+          />
+        );
+      })
+      .toList()
+      .toJS();
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6718,7 +6718,7 @@ prop-types-extra@^1.0.1:
   dependencies:
     warning "^3.0.0"
 
-prop-types@^15.5.0, prop-types@^15.5.6, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@>=15.0.0, prop-types@^15.5.0, prop-types@^15.5.6, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7116,6 +7116,13 @@ react-side-effect@^1.0.2:
   dependencies:
     exenv "^1.2.1"
     shallowequal "^1.0.1"
+
+react-sortablejs@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/react-sortablejs/-/react-sortablejs-1.5.1.tgz#ba05a554548cf9733cc2d5411ece9b97f911b63e"
+  integrity sha512-bKIc1UVhjZt55Nb6WZFxZ8Jwyngg8CTt+w+iG1pA5k9LQsg1J0X6nLppHatSSDZDECtRZKp2z47tmmhPRJNj4g==
+  dependencies:
+    prop-types ">=15.0.0"
 
 react-test-renderer@^15.6.2:
   version "15.6.2"
@@ -7818,9 +7825,10 @@ sockjs@0.3.19:
     faye-websocket "^0.10.0"
     uuid "^3.0.1"
 
-sortablejs@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.7.0.tgz#80a2b2370abd568e1cec8c271131ef30a904fa28"
+sortablejs@^1.8.4:
+  version "1.8.4"
+  resolved "https://registry.yarnpkg.com/sortablejs/-/sortablejs-1.8.4.tgz#1bbfeafa96d399b83f28e25d8e49d4fbfd867f30"
+  integrity sha512-Brqnzelu1AhFuc0Fn3N/qFex1tlIiuQIUsfu2J8luJ4cRgXYkWrByxa+y5mWEBlj8A0YoABukflIJwvHyrwJ6Q==
 
 source-list-map@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Do teď jsem používali Sortable napřímo, takto to je obaleno knihovnou což by mělo být testováno komunitou, takže snad spolehlivější. Navíc hlavně syntaxe je jednoduší pak pro nás.

Myslím že všechno funguje, jediné kde vidím změnu je že nemá vliv když odeberu "table-hover", respektive to nefunguje stopro. Jsem koukal že to tam je beztak udělané přes "table-config-rows" 

```less
.table.table-config-rows > .tbody > .tr:hover {
    background-color: #e5f4f7;
    text-decoration: none;
}
```

takže i když to vyhodím tak to nefunguje. Přidal jsem teda třídu "no-hover" a upravím Indigo aby v takovém případě ten hover efekt neudělala. Tím by se to mělo vyřešit.

```less
.table.table-config-rows:not(.no-hover) > .tbody > .tr:hover {
    background-color: #e5f4f7;
    text-decoration: none;
}
```

Related PR https://github.com/keboola/indigo-ui/pull/362

Jinak jednou tam máme react-dnd, jednou sortable. Nevím zda by to nešlo sjednodit, ale to by se vidělo, prozatím myslím toto dobrý update.