### PR TITLE
Dimple - fix redraw

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dagre-d3": " ^0.6.3",
     "deep-equal": "^1.0.1",
     "diff": "^4.0.1",
-    "dimple": "https://github.com/PMSI-AlignAlytics/dimple.git",
+    "dimple": "https://github.com/taguchimail/dimple.git",
     "filesize": "^3.6.1",
     "flux": "^2.0.0",
     "fuzzaldrin": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dagre-d3": " ^0.6.3",
     "deep-equal": "^1.0.1",
     "diff": "^4.0.1",
-    "dimple": "https://github.com/taguchimail/dimple.git",
+    "dimple": "https://github.com/keboola/dimple.git",
     "filesize": "^3.6.1",
     "flux": "^2.0.0",
     "fuzzaldrin": "^2.1.0",

--- a/src/scripts/utils/dimple.js
+++ b/src/scripts/utils/dimple.js
@@ -1,4 +1,4 @@
 import 'd3-selection';
-import dimple from 'dimple/dist/dimple.v2.3.0.js';
+import dimple from 'dimple/dist/dimple.v2.3.1-pre.js';
 
 export default dimple;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,9 +3239,9 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-"dimple@https://github.com/taguchimail/dimple.git":
+"dimple@https://github.com/keboola/dimple.git":
   version "2.3.1-pre"
-  resolved "https://github.com/taguchimail/dimple.git#dc1249dec3856b54b511decb51f3dbee1b039907"
+  resolved "https://github.com/keboola/dimple.git#dc1249dec3856b54b511decb51f3dbee1b039907"
 
 discontinuous-range@1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3239,9 +3239,9 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
-"dimple@https://github.com/PMSI-AlignAlytics/dimple.git":
-  version "2.3.0"
-  resolved "https://github.com/PMSI-AlignAlytics/dimple.git#65f69857f5e64f3a49f0898fa00799a530607a41"
+"dimple@https://github.com/taguchimail/dimple.git":
+  version "2.3.1-pre"
+  resolved "https://github.com/taguchimail/dimple.git#dc1249dec3856b54b511decb51f3dbee1b039907"
 
 discontinuous-range@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #3179

Vypadá že v poslední verzi "dimple" je chyba. Ono mi přišlo divné že vysla pouze 1 verze na nový D3 v4 a pak ani žádný patch, asi pak už skončil vývoj. Tuto knihovnu by to chtělo pak někdy nahradit za něco kde jede vývoj. Myslím že když jedem na D3 v4 tak už bude výběr větší.

Prozatímní fix:
- zkusil jsem patchou verzi co tam měl někde v issue a funguje to dobře
- je to vydané jako nová pre verze takže to šlo lehce použít

Asi bych byl pro to mít spíše vlastní fork s tou samou změnou. Toto je jen ukázka že to zabere pak.

Původní error se vyskytl při znovu vykreslení grafu, ať už při nových datech, nebo třeba jen při "rezise" eventu který tam máme navěšený na znovu vykreslení.