### PR TITLE
Project limits - show some new limits if avaiable

### DIFF
--- a/src/scripts/modules/limits/LimitRow.jsx
+++ b/src/scripts/modules/limits/LimitRow.jsx
@@ -74,6 +74,15 @@ export default createReactClass({
       return <strong>{numericMetricFormatted(limit.get('metricValue'), limit.get('unit'))}</strong>;
     }
 
+    if (!limit.has('metricValue')) {
+      return (
+        <strong>
+          {limit.get('limitValue')} 
+          {limit.has('unit') && <span> {limit.get('unit')}</span>}
+        </strong>
+      );
+    }
+
     return (
       <span>
         <strong>{numericMetricFormatted(limit.get('metricValue'), limit.get('unit'))}</strong>

--- a/src/scripts/modules/limits/LimitRow.jsx
+++ b/src/scripts/modules/limits/LimitRow.jsx
@@ -136,7 +136,7 @@ export default createReactClass({
   renderActionButton() {
     const { limit } = this.props;
 
-    if (!limit.get('limitValue') && limit.get('limitValue') !== 0) {
+    if (!this.props.canEdit && !limit.get('limitValue') && limit.get('limitValue') !== 0) {
       return <span />;
     }
 

--- a/src/scripts/modules/limits/LimitsSection.jsx
+++ b/src/scripts/modules/limits/LimitsSection.jsx
@@ -45,7 +45,6 @@ export default createReactClass({
 
   limitsRow(limitsPart, index) {
     const tds = limitsPart
-      .filter((limit) => !!limit.get('name'))
       .map((limit) => {
         return (
           <LimitRow

--- a/src/scripts/modules/limits/LimitsSection.jsx
+++ b/src/scripts/modules/limits/LimitsSection.jsx
@@ -45,6 +45,7 @@ export default createReactClass({
 
   limitsRow(limitsPart, index) {
     const tds = limitsPart
+      .filter((limit) => !!limit.get('name'))
       .map((limit) => {
         return (
           <LimitRow

--- a/src/scripts/modules/limits/LimitsSection.jsx
+++ b/src/scripts/modules/limits/LimitsSection.jsx
@@ -22,11 +22,9 @@ export default createReactClass({
         return limit.get('showOnLimitsPage', true);
       })
       .filter(limit => {
-        if (this.props.canEdit) {
-          return true;
-        } else {
-          return limit.get('limitValue') !== null && limit.get('hideIfNull', false) !== true
-        }
+        return this.props.canEdit
+          || limit.get('limitValue') !== null
+          || limit.get('hideIfNull', false) !== true;
       })
     ;
 

--- a/src/scripts/modules/limits/LimitsSection.jsx
+++ b/src/scripts/modules/limits/LimitsSection.jsx
@@ -16,9 +16,19 @@ export default createReactClass({
   },
 
   render() {
-    const showOnLimitsPage = this.props.section.get('limits').filter(limit => {
-      return limit.get('showOnLimitsPage', true);
-    });
+    const showOnLimitsPage = this.props.section
+      .get('limits')
+      .filter(limit => {
+        return limit.get('showOnLimitsPage', true);
+      })
+      .filter(limit => {
+        if (this.props.canEdit) {
+          return true;
+        } else {
+          return limit.get('limitValue') !== null && limit.get('hideIfNull', false) !== true
+        }
+      })
+    ;
 
     const rows = limitsToRows(showOnLimitsPage)
       .map(this.limitsRow)

--- a/src/scripts/stores/composeLimits.js
+++ b/src/scripts/stores/composeLimits.js
@@ -81,13 +81,15 @@ function prepareConnectionData(limits, metrics, limitsMetadata) {
       id: 'sandbox.dockerMemoryReservationMBytes',
       limitValue: limits.getIn(['sandbox.dockerMemoryReservationMBytes', 'value']),
       name: limitsMetadata.getIn(['sandbox.dockerMemoryReservationMBytes', 'name']),
-      unit: 'MB'
+      unit: 'MB',
+      hideIfNull: true,
     },
     {
       id: 'sandbox.dockerMemoryLimitMBytes',
       limitValue: limits.getIn(['sandbox.dockerMemoryLimitMBytes', 'value']),
       name: limitsMetadata.getIn(['sandbox.dockerMemoryLimitMBytes', 'name']),
-      unit: 'MB'
+      unit: 'MB',
+      hideIfNull: true,
     }
   ];
 

--- a/src/scripts/stores/composeLimits.js
+++ b/src/scripts/stores/composeLimits.js
@@ -79,14 +79,14 @@ function prepareConnectionData(limits, metrics, limitsMetadata) {
     },
     {
       id: 'sandbox.dockerMemoryReservationMBytes',
-      limitValue: limits.getIn(['sandbox.dockerMemoryReservationMBytes', 'value']),
+      limitValue: limits.getIn(['sandbox.dockerMemoryReservationMBytes', 'value'], null),
       name: limitsMetadata.getIn(['sandbox.dockerMemoryReservationMBytes', 'name']),
       unit: 'MB',
       hideIfNull: true,
     },
     {
       id: 'sandbox.dockerMemoryLimitMBytes',
-      limitValue: limits.getIn(['sandbox.dockerMemoryLimitMBytes', 'value']),
+      limitValue: limits.getIn(['sandbox.dockerMemoryLimitMBytes', 'value'], null),
       name: limitsMetadata.getIn(['sandbox.dockerMemoryLimitMBytes', 'name']),
       unit: 'MB',
       hideIfNull: true,

--- a/src/scripts/stores/composeLimits.js
+++ b/src/scripts/stores/composeLimits.js
@@ -25,6 +25,12 @@ const LIMITS_METADATA = fromJS({
   },
   'orchestrations.count': {
     name: 'Orchestrations count'
+  },
+  'sandbox.dockerMemoryReservationMBytes': {
+    name: 'Docker memory reservation'
+  },
+  'sandbox.dockerMemoryLimitMBytes': {
+    name: 'Docker memory limit'
   }
 });
 
@@ -70,6 +76,18 @@ function prepareConnectionData(limits, metrics, limitsMetadata) {
       limitValue: limits.getIn(['orchestrations.count', 'value']),
       metricValue: metrics.getIn(['orchestrations.count', 'value']),
       name: limitsMetadata.getIn(['orchestrations.count', 'name'])
+    },
+    {
+      id: 'sandbox.dockerMemoryReservationMBytes',
+      limitValue: limits.getIn(['sandbox.dockerMemoryReservationMBytes', 'value']),
+      name: limitsMetadata.getIn(['sandbox.dockerMemoryReservationMBytes', 'name']),
+      unit: 'MB'
+    },
+    {
+      id: 'sandbox.dockerMemoryLimitMBytes',
+      limitValue: limits.getIn(['sandbox.dockerMemoryLimitMBytes', 'value']),
+      name: limitsMetadata.getIn(['sandbox.dockerMemoryLimitMBytes', 'name']),
+      unit: 'MB'
     }
   ];
 


### PR DESCRIPTION
Fixes #3174

V tomto jsme si teda vůbec nebyl jistý, tak snad jsem šel trochu správnou cestou a spíš nepřidám práci navíc.

- ~první co tak filtruji pryč filtry beze jména, beru to tak že teď tam byly jen takové filtry co tam byly vždy, což ale asi už nemusí být pravda, takže pokud nemám "name" nezobrazím to..~
- dále jsem přidal možnost zobrazit hodnotu pokud mám pouze "limit" ale žádný "metric", což by mělo sedět na ty dvě nové metriky, k tomu se tam rovnou vypisuje jednotka pokud ji mám, nejde to přes nějaké převody nebo tak
- pak jsem definoval ty dvě nové limity na zobrazí, právě tam vůbec nedávám "metricValue" aby to nezobrazovalo jako "0 of Limit"
- pod tím je tlačítko na edit což nevím zda má být u těchto limitů, případně by se přidal nějaký další flag nebo tak

Normal:

![Screenshot 2019-04-08 at 13 22 23](https://user-images.githubusercontent.com/419849/55720534-5e980900-5a01-11e9-9447-f9b5927a9521.png)

Normal, s limitom:

![Screenshot 2019-04-08 at 13 47 34](https://user-images.githubusercontent.com/419849/55721907-ed5a5500-5a04-11e9-9d86-e08c0a1db668.png)


Editacia:

![Screenshot 2019-04-08 at 13 49 49](https://user-images.githubusercontent.com/419849/55721996-33171d80-5a05-11e9-84c3-cbf302fc5f4f.png)

