### PR TITLE
Use only one lib for sortable/draggable

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,6 @@
     "react-clipboard.js": "^2.0.3",
     "react-code-mirror": "^3.1.0",
     "react-datetime": "^2.16.3",
-    "react-dnd": "^3.0.2",
-    "react-dnd-html5-backend": "^3.0.2",
     "react-document-title": "^2.0.3",
     "react-dom": "^15.6.2",
     "react-dropbox-chooser": "^0.0.5",

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/OrchestrationTasks.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/OrchestrationTasks.jsx
@@ -17,9 +17,6 @@ import mergeTasksWithConfigurations from '../../../mergeTasksWithConfigruations'
 import TasksTable from './TasksTable';
 import TasksEditor from './TasksEditor';
 
-import HTML5Backend from 'react-dnd-html5-backend';
-import { DragDropContext } from 'react-dnd';
-
 const componentId = 'orchestrations';
 
 const OrchestrationTasks = createReactClass({
@@ -136,4 +133,4 @@ const OrchestrationTasks = createReactClass({
   }
 });
 
-export default DragDropContext(HTML5Backend)(OrchestrationTasks);
+export default OrchestrationTasks;

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
@@ -1,50 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { DragSource, DropTarget } from 'react-dnd';
 import Tooltip from '../../../../../react/common/Tooltip';
 
-const ItemType = 'PhaseRow';
-
-const phaseRowSource = {
-  beginDrag(props) {
-    return {
-      id: props.phase.get('id')
-    };
-  }
-};
-
-const phaseRowTarget = {
-  canDrop(props, monitor) {
-    const draggedId = monitor.getItem().id;
-    return draggedId === props.phase.get('id');
-  },
-  hover(props, monitor) {
-    const draggedId = monitor.getItem().id;
-    const hoverId = props.phase.get('id');
-
-    if (draggedId === hoverId) {
-      return;
-    }
-
-    props.onPhaseMove(hoverId, draggedId);
-  }
-};
-
-function collectForDragSource(connect, monitor) {
-  return {
-    connectDragSource: connect.dragSource(),
-    isDragging: monitor.isDragging()
-  };
-}
-
-function collectForDropTarget(connect) {
-  return {
-    connectDropTarget: connect.dropTarget()
-  };
-}
-
-let PhaseEditRow = createReactClass({
+export default createReactClass({
   propTypes: {
     toggleHide: PropTypes.func.isRequired,
     phase: PropTypes.object.isRequired,
@@ -55,38 +14,31 @@ let PhaseEditRow = createReactClass({
     toggleAddNewTask: PropTypes.func.isRequired,
     color: PropTypes.string,
     isPhaseHidden: PropTypes.bool,
-
-    // react-dnd
-    isDragging: PropTypes.bool.isRequired,
-    connectDragSource: PropTypes.func.isRequired,
-    connectDropTarget: PropTypes.func.isRequired
+    isDragging: PropTypes.bool
   },
 
   render() {
-    const { isDragging, connectDragSource, connectDropTarget } = this.props;
     let style = {
-      opacity: isDragging ? 0.5 : 1,
-      'backgroundColor': isDragging ? '#ffc' : this.props.color,
+      opacity: this.props.isDragging ? 0.5 : 1,
+      'backgroundColor': this.props.isDragging ? '#ffc' : this.props.color,
       cursor: 'move'
     };
     if (this.props.isPhaseHidden) {
       style.borderBottom = '2px groove';
     }
-    return connectDragSource(connectDropTarget(
-      <tr style={style} onClick={this.onRowClick}>
 
+    return (
+      <tr style={style} onClick={this.onRowClick}>
         <td>
           <div className="row">
             <div className="col-xs-3">
               <i  className="fa fa-bars"/>
-
             </div>
             <div className="col-xs-5">
               {this.renderSelectPhaseCheckbox()}
             </div>
           </div>
         </td>
-
         <td colSpan="5" className="kbc-cursor-pointer text-center">
           <div className="text-center form-group form-group-sm">
             <strong>
@@ -100,7 +52,6 @@ let PhaseEditRow = createReactClass({
             </Tooltip>
           </div>
         </td>
-
         <td>
           <div className="pull-right">
             <button
@@ -112,9 +63,8 @@ let PhaseEditRow = createReactClass({
             </button>
           </div>
         </td>
-
       </tr>
-    ));
+    );
   },
 
   renderSelectPhaseCheckbox() {
@@ -154,10 +104,4 @@ let PhaseEditRow = createReactClass({
     e.preventDefault();
     e.stopPropagation();
   }
-
 });
-
-PhaseEditRow = DragSource(ItemType, phaseRowSource, collectForDragSource)(PhaseEditRow);
-PhaseEditRow = DropTarget(ItemType, phaseRowTarget, collectForDropTarget)(PhaseEditRow);
-
-export default PhaseEditRow;

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
@@ -12,16 +12,12 @@ export default createReactClass({
     isMarked: PropTypes.bool.isRequired,
     toggleAddNewTask: PropTypes.func.isRequired,
     color: PropTypes.string,
-    isPhaseHidden: PropTypes.bool,
-    isDragging: PropTypes.bool
+    isPhaseHidden: PropTypes.bool
   },
 
   render() {
-    let style = {
-      opacity: this.props.isDragging ? 0.5 : 1,
-      'backgroundColor': this.props.isDragging ? '#ffc' : this.props.color,
-      cursor: 'move'
-    };
+    let style = {};
+
     if (this.props.isPhaseHidden) {
       style.borderBottom = '2px groove';
     }
@@ -30,8 +26,8 @@ export default createReactClass({
       <tr style={style} onClick={this.onRowClick}>
         <td>
           <div className="row">
-            <div className="col-xs-3">
-              <i  className="fa fa-bars"/>
+            <div className="col-xs-3 drag-handle">
+              <i className="fa fa-bars" />
             </div>
             <div className="col-xs-5">
               {this.renderSelectPhaseCheckbox()}

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/PhaseEditRow.jsx
@@ -7,7 +7,6 @@ export default createReactClass({
   propTypes: {
     toggleHide: PropTypes.func.isRequired,
     phase: PropTypes.object.isRequired,
-    onPhaseMove: PropTypes.func.isRequired,
     onMarkPhase: PropTypes.func.isRequired,
     togglePhaseIdChange: PropTypes.func.isRequired,
     isMarked: PropTypes.bool.isRequired,
@@ -48,7 +47,8 @@ export default createReactClass({
               tooltip="rename phase">
               <span
                 onClick={this.toggleTitleChange}
-                className="kbc-icon-pencil"/>
+                className="kbc-icon-pencil"
+              />
             </Tooltip>
           </div>
         </td>

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
@@ -30,6 +30,12 @@ export default createReactClass({
     handleAddTask: PropTypes.func.isRequired
   },
 
+  getInitialState() {
+    return {
+      draggingPhaseId: null
+    }
+  },
+
   render() {
     return (
       <span>
@@ -80,12 +86,18 @@ export default createReactClass({
           options={{
             filter: 'thead',
             handle: '.fa-bars',
-            animation: 100
+            animation: 100,
+            onStart: (event) => {
+              this.setState({ draggingPhaseId: this.props.tasks.getIn([event.oldIndex - 1, 'id']) })
+            },
+            onEnd: () => {
+              this.setState({ draggingPhaseId: null })
+            }
           }}
           onChange={(order, sortable, event) => {
-            console.log(order); // eslint-disable-line
-            console.log(sortable); // eslint-disable-line
-            console.log(event); // eslint-disable-line
+            const oldIndex = Math.max(1, event.oldIndex) - 1;
+            const newIndex = Math.max(1, event.newIndex) - 1;
+            this.props.handlePhaseMove(oldIndex, newIndex);
           }}
         >
           {head}
@@ -284,6 +296,7 @@ export default createReactClass({
           color={color}
           onMarkPhase={this.toggleMarkPhase}
           isMarked={this.props.localState.hasIn(['markedPhases', phaseId])}
+          isDragging={this.state.draggingPhaseId === phaseId}
           toggleHide={() => this.props.updateLocalState(['phases', phaseId, 'isHidden'], !isHidden)}
           togglePhaseIdChange={this.togglePhaseIdEdit}
           toggleAddNewTask={() => this.props.updateLocalState(['newTask', 'phaseId'], phase.get('id'))}

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
@@ -223,8 +223,12 @@ export default createReactClass({
         onConfigurationSelect={this.props.handleAddTask}
         phaseId={this.props.localState.getIn(['newTask', 'phaseId'])}
         show={!!this.props.localState.getIn(['newTask', 'phaseId'])}
-        onHide={() => this.props.updateLocalState(['newTask'], Map())}
-        onChangeSearchQuery={query => this.props.updateLocalState(['newTask', 'searchQuery'], query)}
+        onHide={() => {
+          return this.props.updateLocalState(['newTask'], Map());
+        }}
+        onChangeSearchQuery={query => {
+          return this.props.updateLocalState(['newTask', 'searchQuery'], query);
+        }}
         searchQuery={this.props.localState.getIn(['newTask', 'searchQuery'], '')}
       />
     );
@@ -235,7 +239,9 @@ export default createReactClass({
       <MoveTasksModal
         show={this.props.localState.getIn(['moveTasks', 'show'], false)}
         phases={this.props.tasks.map(phase => phase.get('id'))}
-        onHide={() => this.props.updateLocalState(['moveTasks', 'show'], false)}
+        onHide={() => {
+          return this.props.updateLocalState(['moveTasks', 'show'], false);
+        }}
         onMoveTasks={phaseId => {
           const markedTasks = this.props.localState.getIn(['moveTasks', 'marked']);
           this._moveTasks(phaseId, markedTasks);

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
@@ -30,12 +30,6 @@ export default createReactClass({
     handleAddTask: PropTypes.func.isRequired
   },
 
-  getInitialState() {
-    return {
-      draggingPhaseId: null
-    }
-  },
-
   render() {
     return (
       <span>
@@ -85,14 +79,8 @@ export default createReactClass({
           className="table table-striped"
           options={{
             filter: 'thead',
-            handle: '.fa-bars',
-            animation: 100,
-            onStart: (event) => {
-              this.setState({ draggingPhaseId: this.props.tasks.getIn([event.oldIndex - 1, 'id']) })
-            },
-            onEnd: () => {
-              this.setState({ draggingPhaseId: null })
-            }
+            handle: '.drag-handle',
+            animation: 100
           }}
           onChange={(order, sortable, event) => {
             const oldIndex = Math.max(1, event.oldIndex) - 1;
@@ -302,7 +290,6 @@ export default createReactClass({
           color={color}
           onMarkPhase={this.toggleMarkPhase}
           isMarked={this.props.localState.hasIn(['markedPhases', phaseId])}
-          isDragging={this.state.draggingPhaseId === phaseId}
           toggleHide={() => this.props.updateLocalState(['phases', phaseId, 'isHidden'], !isHidden)}
           togglePhaseIdChange={this.togglePhaseIdEdit}
           toggleAddNewTask={() => this.props.updateLocalState(['newTask', 'phaseId'], phase.get('id'))}

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditTable.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import { Map, List, fromJS } from 'immutable';
 import underscoreString from 'underscore.string';
+import Sortable from 'react-sortablejs';
 import TasksEditTableRow from './TasksEditTableRow';
 import PhaseEditRow from './PhaseEditRow';
 import PhaseModal from '../../modals/Phase';
@@ -32,36 +33,65 @@ export default createReactClass({
   render() {
     return (
       <span>
-        {this._renderPhaseModal()}
-        {this._renderMergePhaseModal()}
-        {this._renderMoveTasksModal()}
-        {this._renderAddTaskModal()}
-        <Table responsive striped>
-          <thead>
-            <tr>
-              <th style={{ width: '10%' }}>{this.renderHeaderActionButtons()}</th>
-              <th style={{ width: '26%' }}>Component</th>
-              <th style={{ width: '26%' }}>Configuration</th>
-              <th style={{ width: '12%' }}>Action</th>
-              <th style={{ width: '8%' }}>Active</th>
-              <th style={{ width: '8%' }}>Continue on Failure</th>
-              <th style={{ width: '10%' }} />
-            </tr>
-          </thead>
-          <tbody>
-            {this.props.tasks.count() ? (
-              this.renderPhasedTasksRows()
-            ) : (
-              <tr>
-                <td className="text-muted" colSpan="7">
-                  There are no tasks assigned yet. Please start by adding the first task.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </Table>
+        {this.renderPhaseModal()}
+        {this.renderMergePhaseModal()}
+        {this.renderMoveTasksModal()}
+        {this.renderAddTaskModal()}
+        {this.renderTable()}
       </span>
     );
+  },
+
+  renderTable() {
+    const head = (
+      <thead>
+        <tr>
+          <th style={{ width: '10%' }}>{this.renderHeaderActionButtons()}</th>
+          <th style={{ width: '26%' }}>Component</th>
+          <th style={{ width: '26%' }}>Configuration</th>
+          <th style={{ width: '12%' }}>Action</th>
+          <th style={{ width: '8%' }}>Active</th>
+          <th style={{ width: '8%' }}>Continue on Failure</th>
+          <th style={{ width: '10%' }} />
+        </tr>
+      </thead>
+    );
+
+    if (!this.props.tasks.count()) {
+      return (
+        <Table responsive striped>
+          {head}
+          <tbody>
+            <tr>
+              <td className="text-muted" colSpan="7">
+                There are no tasks assigned yet. Please start by adding the first task.
+              </td>
+            </tr>
+          </tbody>
+        </Table>
+      )
+    }
+
+    return (
+      <Sortable
+        tag="table"
+        className="table table-striped table-responsive"
+        options={{
+          filter: 'thead',
+          handle: '.fa-bars',
+          animation: 100
+        }}
+        onChange={(order, sortable, event) => {
+          console.log(order); // eslint-disable-line
+          console.log(sortable); // eslint-disable-line
+          console.log(event); // eslint-disable-line
+        }}
+      >
+        {head}
+        {this.renderPhasedTasksRows()}
+      </Sortable>
+    );
+
   },
 
   renderHeaderActionButtons() {
@@ -143,45 +173,14 @@ export default createReactClass({
   },
 
   renderPhasedTasksRows() {
-    let result = List();
     let idx = 0;
-    this.props.tasks.map(phase => {
-      idx++;
-      const isPhaseHidden = this.isPhaseHidden(phase);
-      const color = idx % 2 > 0 ? '#fff' : '#f9f9f9'; // 'rgb(227, 248, 255)'
-      const tasksRows = phase.get('tasks').map((task, index) => {
-        const taskId = task.get('id');
-
-        return (
-          <TasksEditTableRow
-            task={task}
-            color={color}
-            component={this.props.components.get(task.get('component'))}
-            disabled={this.props.disabled}
-            key={`${index}-${taskId}`}
-            onTaskDelete={this.props.onTaskDelete}
-            onTaskUpdate={this.props.onTaskUpdate}
-            isMarked={this.props.localState.hasIn(['moveTasks', 'marked', taskId])}
-            toggleMarkTask={() => {
-              return this._toggleMarkTask(task);
-            }}
-            onMoveSingleTask={() => {
-              return this._toggleMoveSingleTask(task, phase.get('id'));
-            }}
-          />
-        );
-      });
-      const phaseRow = this.renderPhaseRow(phase, color);
-      result = result.push(phaseRow);
-      if (!isPhaseHidden) {
-        if (tasksRows.count() > 0) {
-          return (result = result.concat(tasksRows));
-        } else {
-          return (result = result.concat(this._renderEmptyTasksRow(phase.get('id'), color)));
-        }
-      }
-    });
-    return result.toArray();
+    return this.props.tasks
+      .map(phase => {
+        idx++;
+        const color = idx % 2 > 0 ? '#fff' : '#f9f9f9';
+        return this.renderPhaseRow(phase, color);
+      })
+      .toArray();
   },
 
   _renderEmptyTasksRow(phaseId, color) {
@@ -208,7 +207,7 @@ export default createReactClass({
     );
   },
 
-  _renderAddTaskModal() {
+  renderAddTaskModal() {
     return (
       <AddTaskModal
         onConfigurationSelect={this.props.handleAddTask}
@@ -225,7 +224,7 @@ export default createReactClass({
     );
   },
 
-  _renderMoveTasksModal() {
+  renderMoveTasksModal() {
     return (
       <MoveTasksModal
         show={this.props.localState.getIn(['moveTasks', 'show'], false)}
@@ -284,27 +283,65 @@ export default createReactClass({
   renderPhaseRow(phase, color) {
     const phaseId = phase.get('id');
     const isHidden = this.isPhaseHidden(phase);
+
     return (
-      <PhaseEditRow
-        isPhaseHidden={isHidden}
-        key={phaseId}
-        onPhaseMove={this.onPhaseMove}
-        phase={phase}
-        color={color}
-        toggleHide={() => {
-          return this.props.updateLocalState(['phases', phaseId, 'isHidden'], !isHidden);
-        }}
-        togglePhaseIdChange={this.togglePhaseIdEdit}
-        isMarked={this.props.localState.hasIn(['markedPhases', phaseId])}
-        onMarkPhase={this.toggleMarkPhase}
-        toggleAddNewTask={() => {
-          return this.props.updateLocalState(['newTask', 'phaseId'], phase.get('id'));
-        }}
-      />
+      <tbody key={phaseId} data-id={phaseId}>
+        <PhaseEditRow
+          isPhaseHidden={isHidden}
+          onPhaseMove={this.onPhaseMove}
+          phase={phase}
+          color={color}
+          toggleHide={() => {
+            return this.props.updateLocalState(['phases', phaseId, 'isHidden'], !isHidden);
+          }}
+          togglePhaseIdChange={this.togglePhaseIdEdit}
+          isMarked={this.props.localState.hasIn(['markedPhases', phaseId])}
+          onMarkPhase={this.toggleMarkPhase}
+          toggleAddNewTask={() => {
+            return this.props.updateLocalState(['newTask', 'phaseId'], phase.get('id'));
+          }}
+        />
+        {this._renderTasksRows(phase, color)}
+      </tbody>
     );
   },
 
-  _renderPhaseModal() {
+  _renderTasksRows(phase, color) {
+    if (this.isPhaseHidden(phase)) {
+      return null;
+    }
+
+    const tasksRows = phase.get('tasks').map((task, index) => {
+      const taskId = task.get('id');
+
+      return (
+        <TasksEditTableRow
+          task={task}
+          color={color}
+          component={this.props.components.get(task.get('component'))}
+          disabled={this.props.disabled}
+          key={`${index}-${taskId}`}
+          onTaskDelete={this.props.onTaskDelete}
+          onTaskUpdate={this.props.onTaskUpdate}
+          isMarked={this.props.localState.hasIn(['moveTasks', 'marked', taskId])}
+          toggleMarkTask={() => {
+            return this._toggleMarkTask(task);
+          }}
+          onMoveSingleTask={() => {
+            return this._toggleMoveSingleTask(task, phase.get('id'));
+          }}
+        />
+      );
+    });
+
+    if (!tasksRows.count()) {
+      return this._renderEmptyTasksRow(phase.get('id'), color);
+    }
+
+    return tasksRows;
+  },
+
+  renderPhaseModal() {
     let phaseId = this.props.localState.get('editingPhaseId');
     const existingIds = this.props.tasks.map(phase => phase.get('id')).filter(pId => pId !== phaseId);
     return (
@@ -331,7 +368,7 @@ export default createReactClass({
     return this.props.updateLocalState('mergePhases', true);
   },
 
-  _renderMergePhaseModal() {
+  renderMergePhaseModal() {
     return (
       <MergePhasesModal
         show={this.props.localState.get('mergePhases', false)}

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditor.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksEditor.jsx
@@ -64,11 +64,9 @@ export default createReactClass({
     return this.props.onChange(newTasks);
   },
 
-  _handlePhaseMove(id, afterId) {
-    const phase = this.props.tasks.find(item => item.get('id') === id);
-    const currentIndex = this.props.tasks.findIndex(item => item.get('id') === id);
-    const afterIndex = this.props.tasks.findIndex(item => item.get('id') === afterId);
-    return this.props.onChange(this.props.tasks.splice(currentIndex, 1).splice(afterIndex, 0, phase));
+  _handlePhaseMove(oldIndex, newIndex) {
+    const phase = this.props.tasks.get(oldIndex);
+    return this.props.onChange(this.props.tasks.splice(oldIndex, 1).splice(newIndex, 0, phase));
   },
 
   _handleTaskAdd(component, configuration, phaseId) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,36 +882,14 @@
   resolved "https://registry.yarnpkg.com/@types/clipboard/-/clipboard-2.0.1.tgz#75a74086c293d75b12bc93ff13bc7797fef05a40"
   integrity sha512-gJJX9Jjdt3bIAePQRRjYWG20dIhAgEqonguyHxXuqALxsoDsDLimihqrSg8fXgVTJ4KZCzkfglKtwsh/8dLfbA==
 
-"@types/invariant@^2.2.29":
-  version "2.2.29"
-  resolved "https://registry.yarnpkg.com/@types/invariant/-/invariant-2.2.29.tgz#aa845204cd0a289f65d47e0de63a6a815e30cc66"
-  integrity sha512-lRVw09gOvgviOfeUrKc/pmTiRZ7g7oDOU6OAutyuSHpm1/o2RaBQvRhgK8QEdu+FFuw/wnWb29A/iuxv9i8OpQ==
-
 "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
   integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
 
-"@types/lodash@^4.14.107":
-  version "4.14.123"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
-  integrity sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==
-
 "@types/node@*":
   version "10.3.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.3.4.tgz#c74e8aec19e555df44609b8057311052a2c84d9e"
-
-"@types/node@^8.10.11":
-  version "8.10.45"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.45.tgz#4c49ba34106bc7dced77ff6bae8eb6543cde8351"
-  integrity sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==
-
-"@types/redux@^3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@types/redux/-/redux-3.6.0.tgz#f1ebe1e5411518072e4fdfca5c76e16e74c1399a"
-  integrity sha1-8evh5UEVGAcuT9/KXHbhbnTBOZo=
-  dependencies:
-    redux "*"
 
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
@@ -1318,7 +1296,7 @@ arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@^2.0.6, asap@~2.0.3:
+asap@~2.0.3:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
 
@@ -1388,11 +1366,6 @@ atob@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
-
-autobind-decorator@^2.1.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/autobind-decorator/-/autobind-decorator-2.4.0.tgz#ea9e1c98708cf3b5b356f7cf9f10f265ff18239c"
-  integrity sha512-OGYhWUO72V6DafbF8PM8rm3EPbfuyMZcJhtm5/n26IDwO18pohE4eNazLoCGhPiXOCD0gEGmrbU3849QvM8bbw==
 
 autolinker@~0.15.0:
   version "0.15.3"
@@ -3247,24 +3220,6 @@ discontinuous-range@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
 
-disposables@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/disposables/-/disposables-1.0.1.tgz#064727a25b54f502bd82b89aa2dfb8df9f1b39e3"
-
-dnd-core@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/dnd-core/-/dnd-core-3.0.2.tgz#e947577620531c7ee37a518cd5dde17d0efdf0f3"
-  integrity sha1-6UdXdiBTHH7jelGM1d3hfQ798PM=
-  dependencies:
-    "@types/invariant" "^2.2.29"
-    "@types/lodash" "^4.14.107"
-    "@types/node" "^8.10.11"
-    "@types/redux" "^3.6.0"
-    asap "^2.0.6"
-    invariant "^2.0.0"
-    lodash "^4.2.0"
-    redux "^4.0.0"
-
 dns-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/dns-equal/-/dns-equal-1.0.0.tgz#b39e7f1da6eb0a75ba9c17324b34753c47e0654d"
@@ -4470,11 +4425,6 @@ hmac-drbg@^1.0.0:
     hash.js "^1.0.3"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
-
-hoist-non-react-statics@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -5857,10 +5807,6 @@ lodash@^4.17.11:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^4.2.0:
-  version "4.17.2"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.2.tgz#34a3055babe04ce42467b607d700072c7ff6bf42"
 
 lodash@~3.5.0:
   version "3.5.0"
@@ -7558,29 +7504,6 @@ react-datetime@^2.16.3:
     prop-types "^15.5.7"
     react-onclickoutside "^6.5.0"
 
-react-dnd-html5-backend@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-3.0.2.tgz#87172fd4be90e45353119b40e10f591ddf8661ed"
-  integrity sha1-hxcv1L6Q5FNTEZtA4Q9ZHd+GYe0=
-  dependencies:
-    autobind-decorator "^2.1.0"
-    dnd-core "^3.0.2"
-    lodash "^4.2.0"
-    shallowequal "^1.0.2"
-
-react-dnd@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-3.0.2.tgz#b0c23d8d82969f5b7be34cbc4f84fa1ffc5c7ddc"
-  integrity sha1-sMI9jYKWn1t740y8T4T6H/xcfdw=
-  dependencies:
-    disposables "^1.0.1"
-    dnd-core "^3.0.2"
-    hoist-non-react-statics "^2.5.0"
-    invariant "^2.1.0"
-    lodash "^4.2.0"
-    prop-types "^15.5.10"
-    shallowequal "^1.0.2"
-
 react-document-title@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-document-title/-/react-document-title-2.0.3.tgz#bbf922a0d71412fc948245e4283b2412df70f2b9"
@@ -7835,14 +7758,6 @@ reduce-css-calc@^2.0.0:
   dependencies:
     css-unit-converter "^1.1.1"
     postcss-value-parser "^3.3.0"
-
-redux@*, redux@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.1.tgz#436cae6cc40fbe4727689d7c8fae44808f1bfef5"
-  integrity sha512-R7bAtSkk7nY6O/OYMVR9RiBI+XghjF9rlbl5806HJbQph0LJVHZrU5oaO4q70eUKiqMRqm4y07KLTlMZ2BlVmg==
-  dependencies:
-    loose-envify "^1.4.0"
-    symbol-observable "^1.2.0"
 
 regenerate-unicode-properties@^8.0.2:
   version "8.0.2"
@@ -8304,7 +8219,7 @@ shallow-equal@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.0.0.tgz#508d1838b3de590ab8757b011b25e430900945f7"
 
-shallowequal@^1.0.1, shallowequal@^1.0.2:
+shallowequal@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
   integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
@@ -8794,11 +8709,6 @@ svgo@^1.0.0:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.2:
   version "3.2.2"


### PR DESCRIPTION
Fixes #3177

Změny:

- vymazaní knihoven react-dnd a react-dnd-html5-backend
- nahrazení knihovnou react-sortable

Přidal jsem tam na jednom místě `draggingPhaseId` state abych zachoval vzhled co byl při použití `react-dnd`, dává to tam žluté pozadí + pointer cursor, nevím zda je to nutné, klidně bych se bez toho obešel ale nechtěl jsem to sám mazat.

Jinak jsem to musel docela přeskládat, čekal jsem to jednoduší, ale byl tam problém ten, že tam je několik <tr> za sebou, ale přitom se to musí posouvat jako ve skupinách (jedno tr je phase, pod tím jsou jednotlivé konfigurace atd).
Takže jsem to předělal na několik `tbody`, což je v pohodě, jen tam pak zase zlobí `thead` aby se nedal přesouvat.. takže to se muselo taky vyřešit nějak no.

- jinak po staru se updatoval store při každém přesunu, aniž bych tam tu položku nechal, nově to prostě jen na konci upraví, což myslím neva, nebo spíše méně překreslení