### PR TITLE
Ex-Db - snowflake: can not autogenerate query from fetched tables

### DIFF
--- a/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/Quickstart.jsx
@@ -51,7 +51,7 @@ export default createReactClass({
           });
         return options;
       }
-      return options.set(`${item.value.schema}.${item.value.tableName}`, item.value);
+      return options.set(`${item.value.schema}.${item.value.tableName}`, Map(item.value));
     }, Map());
 
     this.props.onChange(this.props.configId, selectedTables.toList());


### PR DESCRIPTION
Fixes #3202

Posílal se tam "obyč" objekt místo immutable Map.