### PR TITLE
Billing module - remove unused title prop

### DIFF
--- a/src/scripts/modules/billing/react/Graph.jsx
+++ b/src/scripts/modules/billing/react/Graph.jsx
@@ -69,7 +69,6 @@ export default createReactClass({
           </h3>
           <GraphVisualization data={this.state.metricsData}/>
           <GraphLegend
-            title="Project Power"
             value={this.state.metricsData.reduce(function(monthSummary, day) {
               return monthSummary + day.get('value');
             }, 0)}

--- a/src/scripts/modules/billing/react/GraphLegend.jsx
+++ b/src/scripts/modules/billing/react/GraphLegend.jsx
@@ -4,13 +4,11 @@ import createReactClass from 'create-react-class';
 import CreditSize from '../../../react/common/CreditSize';
 
 export default createReactClass({
-
   propTypes: {
-    title: PropTypes.string.isRequired,
     value: PropTypes.number.isRequired
   },
 
-  render: function() {
+  render() {
     return (
       <div className="text-center">
         <h4>
@@ -19,5 +17,4 @@ export default createReactClass({
       </div>
     );
   }
-
 });


### PR DESCRIPTION
Jen jsem koukal co je zač ten Keen a kde ho máme použitý. Tu vypadá že to je navíc, nebo to nějak špatně chápu? V billing se `loadMetricsData` volá asi na třech místech a jen tu je to obalené tím `Keen.ready`.

Plus jsem vyhodil jednu prop která se nepoužívala.