### PR TITLE
Geneea Nlp Analysis: Cannot read property 'value' of null

### DIFF
--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
@@ -203,6 +203,8 @@ export default createReactClass({
             name="language"
             placeholder="autodetect"
             clearable={false}
+            backspaceRemoves={false}
+            deleteRemoves={false}
             value={this.getEditingValue(params.LANGUAGE)}
             valueRenderer={(op) => {
               return op.label;
@@ -398,6 +400,8 @@ export default createReactClass({
       <Select
         key={prop}
         clearable={false}
+        backspaceRemoves={false}
+        deleteRemoves={false}
         value={this.getEditingValue(prop)}
         onChange= {({value}) => this.updateEditingValue(prop, value)}
         options= {selectOptions}/>


### PR DESCRIPTION
Fixes #3216
