### PR TITLE
Tde Exporter - Tooltips

### DIFF
--- a/src/scripts/modules/tde-exporter/react/pages/Index/TableRow.jsx
+++ b/src/scripts/modules/tde-exporter/react/pages/Index/TableRow.jsx
@@ -89,17 +89,15 @@ export default createReactClass({
 
   _renderRunButton() {
     return (
-      <OverlayTrigger overlay={<Tooltip id="export_tooltip">Export to TDE File</Tooltip>} placement="top">
-        <RunButtonModal
-          title={`Export ${this.props.table.get('id')} to TDE`}
-          tooltip={`Export ${this.props.table.get('id')} to TDE`}
-          mode="button"
-          component="tde-exporter"
-          runParams={() => this.props.prepareRunDataFn()}
-        >
-          {`You are about export ${this.props.table.get('id')} to TDE.`}
-        </RunButtonModal>
-      </OverlayTrigger>
+      <RunButtonModal
+        title={`Export ${this.props.table.get('id')} to TDE`}
+        tooltip={`Export ${this.props.table.get('id')} to TDE`}
+        mode="button"
+        component="tde-exporter"
+        runParams={() => this.props.prepareRunDataFn()}
+      >
+        {`You are about export ${this.props.table.get('id')} to TDE.`}
+      </RunButtonModal>
     );
   }
 });


### PR DESCRIPTION
Related #3139

Jak píši v issue, tak `ExternalLink` nemůže být přímo jako child pro Tooltip. Nepřímá totiž žádné nové props.
Myslím že nejlepší by asi bylo tu komponentu v Indigu-UI upravit aby příjmala všechny. Pro odkaz se to může hodit. Ať už nějaký style, nebo title, nebo právě tyto props na kontrolu tooltipu.
Prozatím takový fix. Ještě v nějakém PR co je připraveno je to stejně, tam jsme na to poprvé narazil.

Druhá věc je nadbytečné použití `OverlayTrigger` nad `RunButtonModal`. Ten má pak svůj tooltip, tak není potřeba další nad tím. Narazil jsem na to když jsem zkoumal tooltipy v aplikaci zda tam není nějaká naše komponenta co nepřijme ty nové props. 

Čekal jsme že toho najdu více ale nakonec je toto + něco v nějakém tom novém PR, teď přesně nevím jaké to bylo. 
