### PR TITLE
MetadataStore - handle only editing and saving, remove duplicity

### DIFF
--- a/src/scripts/modules/components/MetadataActionCreators.js
+++ b/src/scripts/modules/components/MetadataActionCreators.js
@@ -1,113 +1,103 @@
 
 import dispatcher from '../../Dispatcher';
 import storageApi from './StorageApi';
-import MetadataStore from './stores/MetadataStore';
 import { ActionTypes } from './MetadataConstants';
 import Immutable from 'immutable';
 
 var Map = Immutable.Map;
 
 export default {
-  startMetadataEdit: function(objectType, objectId, metadataKey) {
-    dispatcher.handleViewAction({
-      type: ActionTypes.METADATA_EDIT_START,
-      objectType: objectType,
-      objectId: objectId,
-      metadataKey: metadataKey
-    });
-  },
-
-  cancelMetadataEdit: function(objectType, objectId, metadataKey) {
-    dispatcher.handleViewAction({
-      type: ActionTypes.METADATA_EDIT_CANCEL,
-      objectType: objectType,
-      objectId: objectId,
-      metadataKey: metadataKey
-    });
-  },
-
-  updateEditingMetadata: function(objectType, objectId, metadataKey, value) {
+  updateEditingMetadata(objectType, objectId, metadataKey, value) {
     dispatcher.handleViewAction({
       type: ActionTypes.METADATA_EDIT_UPDATE,
-      objectType: objectType,
-      objectId: objectId,
-      metadataKey: metadataKey,
-      value: value
+      objectType,
+      objectId,
+      metadataKey,
+      value
     });
   },
 
-  saveMetadata: function(objectType, objectId, metadataKey) {
+  cancelMetadataEdit(objectType, objectId, metadataKey) {
     dispatcher.handleViewAction({
-      objectType: objectType,
-      objectId: objectId,
-      metadataKey: metadataKey,
-      type: ActionTypes.METADATA_SAVE_START
-    });
-    var newValue = MetadataStore.getEditingMetadataValue(objectType, objectId, metadataKey);
-    return storageApi.saveMetadata(objectType, objectId, Map([[metadataKey, newValue]])).then(function(result) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_SAVE_SUCCESS,
-        objectType: objectType,
-        objectId: objectId,
-        metadataKey: metadataKey,
-        metadata: result
-      });
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_EDIT_STOP,
-        objectType: objectType,
-        objectId: objectId,
-        metadataKey: metadataKey
-      });
-      return result;
-    }).catch(function(error) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_SAVE_ERROR,
-        objectType: objectType,
-        objectId: objectId,
-        metadataKey: metadataKey,
-        value: newValue
-      });
-      throw error;
+      type: ActionTypes.METADATA_EDIT_CANCEL,
+      objectType,
+      objectId,
+      metadataKey
     });
   },
 
-  saveMetadataSet: function(objectType, objectId, metadata) {
-    return storageApi.saveMetadata(objectType, objectId, metadata).then(function(result) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_SAVE_SUCCESS,
-        objectType: objectType,
-        objectId: objectId,
-        metadata: result
-      });
-      return result;
-    }).catch(function(error) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_SAVE_ERROR,
-        objectType: objectType,
-        objectId: objectId,
-        metadata: metadata
-      });
-      throw error;
+  saveMetadata(objectType, objectId, metadataKey, newValue) {
+    dispatcher.handleViewAction({
+      type: ActionTypes.METADATA_SAVE,
+      objectType,
+      objectId,
+      metadataKey
     });
+    return storageApi
+      .saveMetadata(objectType, objectId, Map([[metadataKey, newValue]]))
+      .then((metadata) => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_SAVE_SUCCESS,
+          objectType,
+          objectId,
+          metadataKey,
+          metadata
+        });
+        return metadata;
+      })
+      .catch((error) => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_SAVE_ERROR,
+          objectType,
+          objectId,
+          metadataKey
+        });
+        throw error;
+      });
   },
 
-  deleteMetadata: function(objectType, objectId, metadataId) {
-    return storageApi.deleteMetadata(objectType, objectId, metadataId).then(function(result) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_DELETE_SUCCESS,
-        objectType: objectType,
-        objectId: objectId,
-        metadataId: metadataId
+  saveMetadataSet(objectType, objectId, metadata) {
+    return storageApi
+      .saveMetadata(objectType, objectId, metadata)
+      .then((metadata) => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_SAVE_SUCCESS,
+          objectType,
+          objectId,
+          metadata
+        });
+        return metadata;
+      })
+      .catch((error) => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_SAVE_ERROR,
+          objectType,
+          objectId,
+          metadata
+        });
+        throw error;
       });
-      return result;
-    }).catch(function(error) {
-      dispatcher.handleViewAction({
-        type: ActionTypes.METADATA_DELETE_ERROR,
-        objectType: objectType,
-        objectId: objectId,
-        metadataId: metadataId
+  },
+
+  deleteMetadata(objectType, objectId, metadataKey) {
+    return storageApi
+      .deleteMetadata(objectType, objectId, metadataKey)
+      .then(() => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_DELETE_SUCCESS,
+          objectType,
+          objectId,
+          metadataKey
+        });
+      })
+      .catch((error) => {
+        dispatcher.handleViewAction({
+          type: ActionTypes.METADATA_DELETE_ERROR,
+          objectType,
+          objectId,
+          metadataKey
+        });
+        throw error;
       });
-      throw error;
-    });
   }
 };

--- a/src/scripts/modules/components/MetadataConstants.js
+++ b/src/scripts/modules/components/MetadataConstants.js
@@ -1,12 +1,10 @@
 import keyMirror from 'fbjs/lib/keyMirror';
 
 const ActionTypes = keyMirror({
-  METADATA_EDIT_START: null,
   METADATA_EDIT_UPDATE: null,
   METADATA_EDIT_CANCEL: null,
-  METADATA_EDIT_STOP: null,
 
-  METADATA_SAVE_START: null,
+  METADATA_SAVE: null,
   METADATA_SAVE_SUCCESS: null,
   METADATA_SAVE_ERROR: null,
 

--- a/src/scripts/modules/components/stores/MetadataStore.js
+++ b/src/scripts/modules/components/stores/MetadataStore.js
@@ -1,221 +1,51 @@
 import StoreUtils from '../../../utils/StoreUtils';
-import { Map, List, fromJS } from 'immutable';
+import { Map } from 'immutable';
 import dispatcher from '../../../Dispatcher';
 import { ActionTypes } from '../MetadataConstants';
-import * as Constants from '../Constants';
-import _ from 'underscore';
 
 var _store = Map({
-  savingMetadata: Map(),
-  editingMetadata: Map(),
-  metadata: Map(),
-  filters: Map()
+  editing: Map(),
+  isSaving: Map()
 });
 
 var MetadataStore = StoreUtils.createStore({
-
-  getColumnMetadata: function(tableId, column, provider, metadataKey) {
-    const columnId = tableId + '.' + column;
-    return this.getMetadata('column', columnId, provider, metadataKey);
+  getEditingValue(objectType, objectId, metadataKey) {
+    return _store.getIn(['editing', objectType, objectId, metadataKey]);
   },
 
-  getAllColumnMetadata: function(tableId, column) {
-    return this.getMetadataAll('column', tableId + '.' + column);
+  isEditing(objectType, objectId, metadataKey) {
+    return _store.hasIn(['editing', objectType, objectId, metadataKey]);
   },
 
-  getAllTableMetadata: function(tableId) {
-    return this.getMetadataAll('table', tableId);
-  },
-
-  getTableMetadata: function(tableId, provider, metadataKey) {
-    return this.getMetadata('table', tableId, provider, metadataKey);
-  },
-
-  getTableColumnsMetadata: function(tableId) {
-    return _store.getIn(['metadata', 'tableColumns', tableId], Map());
-  },
-
-  getAllTableColumnsMetadataByProvider: function(tableId, provider) {
-    return this.getTableColumnsMetadata(tableId).map(
-      (metadata) => metadata.filter(data => data.get('provider') === provider)
-    );
-  },
-
-  getTableMetadataValue: function(tableId, provider, metadataKey) {
-    return this.getTableMetadata(tableId, provider, metadataKey).get('value');
-  },
-
-  getMetadata: function(objectType, objectId, provider, metadataKey) {
-    if (this.hasMetadata(objectType, objectId)) {
-      var metadataList = this.getMetadataAll(objectType, objectId);
-      return metadataList.find(
-        metadata =>  (metadata.get('provider') === provider && metadata.get('key') === metadataKey)
-      );
-    }
-    return false;
-  },
-
-  hasMetadata: function(objectType, objectId) {
-    return _store.hasIn(['metadata', objectType, objectId]);
-  },
-
-  hasMetadataKey: function(objectType, objectId, metadataKey) {
-    return _store.getIn(['metadata', objectType, objectId]).hasIn(['key', metadataKey]);
-  },
-
-  getMetadataAll: function(objectType, objectId) {
-    return _store.getIn(['metadata', objectType, objectId], List());
-  },
-
-  hasProviderMetadata: function(objectType, objectId, provider, metadataKey) {
-    var objectMetadata = this.getMetadata(objectType, objectId);
-    var foundMetadata = objectMetadata.find(
-      metadata =>  metadata.get('provider') === provider && metadata.get('key') === metadataKey
-    );
-    return !(typeof foundMetadata === 'undefined' || foundMetadata === null);
-  },
-
-  getMetadataValue: function(objectType, objectId, provider, metadataKey) {
-    var metadata = this.getMetadata(objectType, objectId, provider, metadataKey);
-    if (metadata) {
-      return metadata.get('value');
-    }
-    return '';
-  },
-
-  getEditingMetadataValue: function(objectType, objectId, metadataKey) {
-    return _store.getIn(['editingMetadata', objectType, objectId, metadataKey]);
-  },
-
-  isEditingMetadata: function(objectType, objectId, metadataKey) {
-    return _store.hasIn(['editingMetadata', objectType, objectId, metadataKey]);
-  },
-
-  isSavingMetadata: function(objectType, objectId, metadataKey) {
-    return _store.hasIn(['savingMetadata', objectType, objectId, metadataKey]);
-  },
-
-  getTableLastUpdatedInfo: function(tableId) {
-    let componentFound = this.getTableMetadata(tableId, 'system', 'KBC.lastUpdatedBy.component.id');
-    let configFound = this.getTableMetadata(tableId, 'system', 'KBC.lastUpdatedBy.configuration.id');
-    if (!componentFound || !configFound) {
-      componentFound = this.getTableMetadata(tableId, 'system', 'KBC.createdBy.component.id');
-      configFound = this.getTableMetadata(tableId, 'system', 'KBC.createdBy.configuration.id');
-    }
-    const componentId = componentFound && componentFound.get('value');
-    const configId = configFound && configFound.get('value');
-    const timestamp = configFound && configFound.get('timestamp');
-    if (!componentFound || !configFound) {
-      return null;
-    }
-    return {
-      'component': componentId,
-      'config': configId,
-      'timestamp': timestamp
-    };
-  },
-
-  tableHasMetadataDatatypes: function(tableId) {
-    const lastUpdateInfo = this.getTableLastUpdatedInfo(tableId);
-    const tableColumnsMetadata = this.getTableColumnsMetadata(tableId);
-    if (!tableColumnsMetadata || !lastUpdateInfo) {
-      return false;
-    }
-    const columnsWithBaseTypes = tableColumnsMetadata.filter((metadataList) => {
-      const columnHasDatatype = metadataList.filter((metadata) => {
-        return metadata.get('provider') === lastUpdateInfo.component && metadata.get('key') === 'KBC.datatype.basetype';
-      });
-      return columnHasDatatype.count() > 0;
-    });
-    return columnsWithBaseTypes.count() > 0;
-  },
-
-  getLastUpdatedByColumnMetadata: function(tableId) {
-    const lastUpdateInfo = this.getTableLastUpdatedInfo(tableId);
-    if (!lastUpdateInfo) {
-      return Map();
-    }
-    return this.getAllTableColumnsMetadataByProvider(tableId, lastUpdateInfo.component);
-  },
-
-  getUserProvidedColumnMetadata: function (tableId) {
-    return this.getAllTableColumnsMetadataByProvider(tableId, 'user');
+  isSaving(objectType, objectId, metadataKey) {
+    return _store.getIn(['isSaving', objectType, objectId, metadataKey], false);
   }
 });
 
-dispatcher.register(function(payload) {
-  var action;
-  action = payload.action;
+dispatcher.register((payload) => {
+  const action = payload.action;
 
   switch (action.type) {
-    case ActionTypes.METADATA_EDIT_START:
-      _store = _store.setIn(
-        ['editingMetadata', action.objectType, action.objectId, action.metadataKey],
-        MetadataStore.getMetadataValue(action.objectType, action.objectId, 'user', action.metadataKey)
-      );
-      return MetadataStore.emitChange();
-
     case ActionTypes.METADATA_EDIT_UPDATE:
-      _store = _store.setIn(
-        ['editingMetadata', action.objectType, action.objectId, action.metadataKey],
-        action.value
-      );
-      return MetadataStore.emitChange();
-    case ActionTypes.METADATA_EDIT_STOP:
-      _store = _store.deleteIn(['editingMetadata', action.objectType, action.objectId, action.metadataKey]);
+      _store = _store.setIn(['editing', action.objectType, action.objectId, action.metadataKey], action.value);
       return MetadataStore.emitChange();
 
     case ActionTypes.METADATA_EDIT_CANCEL:
-      _store = _store.deleteIn(['editingMetadata', action.objectType, action.objectId, action.metadataKey]);
+      _store = _store.deleteIn(['editing', action.objectType, action.objectId, action.metadataKey]);
       return MetadataStore.emitChange();
-
-    case ActionTypes.METADATA_SAVE_START:
-      _store = _store.setIn(['savingMetadata', action.objectType, action.objectId, action.metadataKey], action.value);
-      return MetadataStore.emitChange();
-
-    case ActionTypes.METADATA_SAVE_ERROR:
-    case ActionTypes.METADATA_DELETE_ERROR:
+    
+    case ActionTypes.METADATA_SAVE:
+      _store = _store.setIn(['isSaving', action.objectType, action.objectId, action.metadataKey], true);
       return MetadataStore.emitChange();
 
     case ActionTypes.METADATA_SAVE_SUCCESS:
-      _store = _store.setIn(['metadata', action.objectType, action.objectId], fromJS(action.metadata));
-      _store = _store.deleteIn(['savingMetadata', action.objectType, action.objectId, action.metadataKey]);
-      if (action.objectType === 'column') {
-        const [ tableId, columnName ] = action.objectId.split(/\.(?=[^.]+$)/);
-        _store = _store.setIn(['metadata', 'tableColumns', tableId, columnName], fromJS(action.metadata));
-      }
-      return MetadataStore.emitChange();
-
+    case ActionTypes.METADATA_SAVE_ERROR:
     case ActionTypes.METADATA_DELETE_SUCCESS:
-      const index = _store.getIn(['metadata', action.objectType, action.objectId]).findIndex((metadata) => {
-        return metadata.get('id') === action.metadataId;
-      });
-      _store = _store.deleteIn(['metadata', action.objectType, action.objectId, index]);
-      if (action.objectType === 'column') {
-        const [ tableId, columnName ] = action.objectId.split(/\.(?=[^.]+$)/);
-        _store = _store.deleteIn(['metadata', 'tableColumns', tableId, columnName, index]);
-      }
+    case ActionTypes.METADATA_DELETE_ERROR:
+      _store = _store.deleteIn(['editing', action.objectType, action.objectId, action.metadataKey]);
+      _store = _store.deleteIn(['isSaving', action.objectType, action.objectId, action.metadataKey]);
       return MetadataStore.emitChange();
 
-    case Constants.ActionTypes.STORAGE_BUCKETS_LOAD_SUCCESS:
-      _.each(action.buckets, function(bucket) {
-        _store = _store.setIn(['metadata', 'bucket', bucket.id], fromJS(bucket.metadata));
-      });
-      return MetadataStore.emitChange();
-
-    case Constants.ActionTypes.STORAGE_TABLES_LOAD_SUCCESS:
-      _.each(action.tables, function(table) {
-        const tableMetadata = fromJS(table.metadata);
-        _store = _store.setIn(
-          ['metadata', 'table', table.id], tableMetadata
-        );
-        _.each(table.columnMetadata, function(metadata, columnName) {
-          _store = _store
-            .setIn(['metadata', 'column', table.id + '.' + columnName], fromJS(metadata))
-            .setIn(['metadata', 'tableColumns', table.id, columnName], fromJS(metadata));
-        });
-      });
-      return MetadataStore.emitChange();
     default:
   }
 });

--- a/src/scripts/modules/components/stores/StorageTablesStore.js
+++ b/src/scripts/modules/components/stores/StorageTablesStore.js
@@ -281,6 +281,7 @@ Dispatcher.register(function(payload) {
       }
       if (action.objectType === 'column') {
         const [ tableId, columnName ] = action.objectId.split(/\.(?=[^.]+$)/);
+        _store = _store.updateIn(['tables', tableId, 'columnMetadata'], (metadata) => metadata.toMap());
         _store = _store.setIn(['tables', tableId, 'columnMetadata', columnName], fromJS(action.metadata));
         return StorageTablesStore.emitChange();
       }

--- a/src/scripts/modules/components/utils/tableMetadataHelper.js
+++ b/src/scripts/modules/components/utils/tableMetadataHelper.js
@@ -1,0 +1,65 @@
+
+import { Map, List } from 'immutable';
+
+const hasTableColumnMetadataDatatypes = table => {
+  const lastUpdateInfo = getTableLastUpdatedInfo(table);
+
+  if (!lastUpdateInfo) {
+    return false;
+  }
+
+  return table.get('columnMetadata').filter((metadataList) => {
+    return metadataList.filter((metadata) => {
+      return metadata.get('provider') === lastUpdateInfo.component && metadata.get('key') === 'KBC.datatype.basetype';
+    }).count() > 0;
+  }).count() > 0;
+};
+
+const getTableLastUpdatedInfo = (table) => {
+  const metadata = table.get('metadata', List()).filter(row => row.get('provider') === 'system', null, Map());
+  let componentFound = metadata.find(row => row.get('key') === 'KBC.lastUpdatedBy.component.id');
+  let configFound = metadata.find(row => row.get('key') === 'KBC.lastUpdatedBy.configuration.id');
+
+  if (!componentFound || !configFound) {
+    componentFound = metadata.find(row => row.get('key') === 'KBC.createdBy.component.id');
+    configFound = metadata.find(row => row.get('key') === 'KBC.createdBy.configuration.id');
+  }
+
+  if (!componentFound || !configFound) {
+    return null;
+  }
+
+  return {
+    'component': componentFound.get('value'),
+    'config': configFound.get('value'),
+    'timestamp': configFound.get('timestamp')
+  };
+};
+
+const getColumnMetadataByProvider = (table, provider) => {
+  return table.get('columnMetadata', Map()).map((metadata) => {
+    return metadata.filter(data => data.get('provider') === provider);
+  }) 
+};
+
+const getMachineColumnMetadata = (table) => {
+  const lastUpdateInfo = getTableLastUpdatedInfo(table);
+
+  if (!lastUpdateInfo || !lastUpdateInfo.component) {
+    return Map();
+  }
+
+  return getColumnMetadataByProvider(table, lastUpdateInfo.component);
+};
+
+const getUserColumnMetadata = (table) => {
+  return getColumnMetadataByProvider(table, 'user');
+};
+
+export {
+  hasTableColumnMetadataDatatypes,
+  getTableLastUpdatedInfo,
+  getColumnMetadataByProvider,
+  getMachineColumnMetadata,
+  getUserColumnMetadata
+};

--- a/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
+++ b/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
@@ -1,0 +1,149 @@
+import {
+  hasTableColumnMetadataDatatypes,
+  getTableLastUpdatedInfo,
+  getColumnMetadataByProvider,
+  getMachineColumnMetadata,
+  getUserColumnMetadata
+} from './tableMetadataHelper';
+import { Map, fromJS } from 'immutable';
+
+const table = fromJS({
+  columnMetadata: {
+    country: [
+      {
+        key: 'KBC.datatype.basetype',
+        value: 'STRING',
+        provider: 'keboola.ex-db-snowflake',
+        timestamp: '2018-12-12T08:17:37+0100'
+      }
+    ]
+  },
+  metadata: [
+    {
+      key: 'KBC.createdBy.component.id',
+      value: 'keboola.ex-db-snowflake',
+      provider: 'system',
+      timestamp: '2018-12-12T08:17:37+0100'
+    },
+    {
+      key: 'KBC.createdBy.configuration.id',
+      value: '469551086',
+      provider: 'system',
+      timestamp: '2018-12-12T08:17:37+0100'
+    },
+    {
+      key: 'KBC.lastUpdatedBy.component.id',
+      value: 'keboola.ex-db-snowflake',
+      provider: 'system',
+      timestamp: '2018-12-12T08:19:05+0100'
+    },
+    {
+      key: 'KBC.lastUpdatedBy.configuration.id',
+      value: '469551086',
+      provider: 'system',
+      timestamp: '2018-12-12T08:19:05+0100'
+    }
+  ]
+});
+
+describe('tableMetadataHelper', function() {
+  describe('getTableLastUpdatedInfo', function() {
+    it('should return valid object if table has KBC.lastUpdatedBy.component.id and KBC.lastUpdatedBy.configuration.id metadata', function() {
+      expect({
+        component: 'keboola.ex-db-snowflake',
+        config: '469551086',
+        timestamp: '2018-12-12T08:19:05+0100'
+      }).toEqual(getTableLastUpdatedInfo(table));
+    });
+
+    it('should return valid object if table has KBC.createdBy.component.id and KBC.createdBy.configuration.id metadata', function() {
+      expect({
+        component: 'keboola.ex-db-snowflake',
+        config: '469551086',
+        timestamp: '2018-12-12T08:17:37+0100'
+      }).toEqual(getTableLastUpdatedInfo(table.deleteIn(['metadata', 3])));
+    });
+
+    it('should return null if table has no KBC.lastUpdatedBy.component.id and KBC.lastUpdatedBy.configuration.id or KBC.createdBy.component.id and KBC.createdBy.configuration.id metadata', function() {
+      expect(null).toEqual(
+        getTableLastUpdatedInfo(table.deleteIn(['metadata', 1]).deleteIn(['metadata', 2]))
+      );
+    });
+  });
+
+  describe('hasTableColumnMetadataDatatypes', function() {
+    it('return true if table has any valid column metadata (any column has defined KBC.datatype.basetype)', function() {
+      expect(true).toEqual(hasTableColumnMetadataDatatypes(table));
+    });
+
+    it('return false if table has no valid column metadata (no column has defined KBC.datatype.basetype', function() {
+      expect(false).toEqual(
+        hasTableColumnMetadataDatatypes(table.deleteIn(['columnMetadata', 'country']))
+      );
+    });
+  });
+
+  describe('getColumnMetadataByProvider', function() {
+    it('return empty Map when table has no column metadata field', function() {
+      expect(Map()).toEqual(
+        getColumnMetadataByProvider(table.delete('columnMetadata'), 'keboola.ex-db-snowflake')
+      );
+    });
+
+    it('return filtered metadata by provider', function() {
+      expect(
+        fromJS({
+          country: []
+        })
+      ).toEqual(getColumnMetadataByProvider(table, 'user'));
+    });
+
+    it('return filtered metadata by provider', function() {
+      expect(
+        fromJS({
+          country: [
+            {
+              key: 'KBC.datatype.basetype',
+              value: 'STRING',
+              provider: 'keboola.ex-db-snowflake',
+              timestamp: '2018-12-12T08:17:37+0100'
+            }
+          ]
+        })
+      ).toEqual(getColumnMetadataByProvider(table, 'keboola.ex-db-snowflake'));
+    });
+  });
+
+  describe('getMachineColumnMetadata', function() {
+    it('return empty Map when table has no valid metadata - KBC.lastUpdatedBy.* or KBC.createdBy.*', function() {
+      expect(Map()).toEqual(getMachineColumnMetadata(table.delete('metadata')));
+    });
+
+    it('return filtered column metadata by component - has KBC.lastUpdatedBy.* or KBC.createdBy.*', function() {
+      expect(table.get('columnMetadata')).toEqual(getMachineColumnMetadata(table));
+    });
+  });
+
+  describe('getUserColumnMetadata', function() {
+    it('return only column metadata created by user', function() {
+      expect(fromJS({ country: [] })).toEqual(getUserColumnMetadata(table));
+    });
+
+    it('return only column metadata created by user', function() {
+      const userMetadata = {
+        key: 'KBC.description',
+        value: 'popis',
+        provider: 'user',
+        timestamp: '2019-02-02T08:00:00+0100'
+      };
+
+      expect(fromJS({ country: [userMetadata] })).toEqual(
+        getUserColumnMetadata(
+          table.updateIn(['columnMetadata', 'country'], (metadata) => {
+            return metadata.push(fromJS(userMetadata));
+          })
+        )
+      );
+    });
+  });
+});

--- a/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Bucket/BucketOverview.jsx
@@ -98,9 +98,10 @@ export default createReactClass({
     return (
       <MetadataEditField
         objectType="bucket"
+        objectId={this.props.bucket.get('id')}
+        metadata={this.props.bucket.get('metadata')}
         metadataKey="KBC.description"
         placeholder="Describe bucket"
-        objectId={this.props.bucket.get('id')}
         editElement={InlineEditArea}
       />
     );

--- a/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import { Map } from 'immutable';
+import { Map, List } from 'immutable';
 import { FormControl, Checkbox, Button } from 'react-bootstrap';
 import Select from 'react-select';
 import MetadataEditField from '../../../../components/react/components/MetadataEditField';
@@ -49,7 +49,7 @@ export default createReactClass({
         <MetadataEditField
           objectType="column"
           objectId={this.props.columnId}
-          metadata={this.props.table.getIn(['columnMetadata', this.props.columnName], Map())}
+          metadata={this.props.table.getIn(['columnMetadata', this.props.columnName], List())}
           metadataKey="KBC.description"
           placeholder="Describe column"
           editElement={InlineEditArea}

--- a/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import { Map } from 'immutable';
-import { Table, FormControl, Checkbox, Button } from 'react-bootstrap';
+import { FormControl, Checkbox, Button } from 'react-bootstrap';
 import Select from 'react-select';
 import MetadataEditField from '../../../../components/react/components/MetadataEditField';
 import InlineEditArea from '../../../../../react/common/InlineEditArea';
@@ -68,7 +68,7 @@ export default createReactClass({
           system fill the form below. Saving a blank type will remove the
           previously set user-defined type.
         </p>
-        <Table striped hover responsive>
+        <table className="table table-striped table-hover">
           <thead>
             <tr>
               <th><strong>Provider</strong></th>
@@ -116,7 +116,7 @@ export default createReactClass({
               </td>
             </tr>
           </tfoot>
-        </Table>
+        </table>
       </div>
     );
   },

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableColumn.jsx
@@ -152,6 +152,7 @@ export default createReactClass({
         onSelect={() => this.onSelectColumn(this.getColumnId(column))}
       >
         <ColumnDetails
+          table={this.props.table}
           columnId={this.getColumnId(column)}
           columnName={column}
           machineDataType={getDataType(this.props.machineColumnMetadata.get(column, Map()))}

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableDetail.jsx
@@ -15,6 +15,7 @@ import MetadataStore from '../../../../components/stores/MetadataStore';
 import ColumnsLocalStore from '../../../ColumnsLocalStore';
 import StorageApi from '../../../../components/StorageApi';
 import { factory as eventsFactory } from '../../../../sapi-events/TableEventsService';
+import { getMachineColumnMetadata, getUserColumnMetadata } from '../../../../components/utils/tableMetadataHelper';
 import { createAliasTable, deleteTable, truncateTable, exportTable, uploadFile, loadTable } from '../../../Actions';
 
 import FastFade from '../../../../../react/common/FastFade';
@@ -72,9 +73,9 @@ export default createReactClass({
       exportingTable: TablesStore.getIsExportingTable(table.get('id')),
       tableLinks: this.getTableLinks(table, bucket),
       tableAliases: this.getTableAliases(table, tables, sapiToken),
-      machineColumnMetadata: MetadataStore.getLastUpdatedByColumnMetadata(table.get('id')),
-      userColumnMetadata: MetadataStore.getUserProvidedColumnMetadata(table.get('id')),
       openColumns: ColumnsLocalStore.getOpenedColumns(),
+      machineColumnMetadata: getMachineColumnMetadata(table),
+      userColumnMetadata: getUserColumnMetadata(table)
     };
   },
 

--- a/src/scripts/modules/storage-explorer/react/pages/Table/TableOverview.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/TableOverview.jsx
@@ -164,9 +164,10 @@ export default createReactClass({
     return (
       <MetadataEditField
         objectType="table"
+        objectId={this.props.table.get('id')}
+        metadata={this.props.table.get('metadata')}
         metadataKey="KBC.description"
         placeholder="Describe table"
-        objectId={this.props.table.get('id')}
         editElement={InlineEditArea}
       />
     );

--- a/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
+++ b/src/scripts/modules/table-browser/react/components/ModalDialog.jsx
@@ -159,7 +159,7 @@ export default createReactClass({
     return (
       <TableDescriptionTab
         isLoading={this.props.isLoading}
-        tableId={this.props.tableId}
+        table={this.props.table}
         tableExists={this.props.tableExists}
       />
     );
@@ -179,9 +179,7 @@ export default createReactClass({
         onFilterIOEvents={this.props.onFilterIOEvents}
         onShowEventDetail={this.props.onShowEventDetail}
         detailEventId={this.props.detailEventId}
-
       />
-
     );
   },
 

--- a/src/scripts/modules/table-browser/react/components/TableDescriptionEditor.jsx
+++ b/src/scripts/modules/table-browser/react/components/TableDescriptionEditor.jsx
@@ -5,10 +5,8 @@ import InlineEditArea  from '../../../../react/common/InlineEditArea';
 import MetadataEditField from '../../../components/react/components/MetadataEditField';
 
 export default createReactClass({
-  displayName: 'TableDescriptionEditor',
-
   propTypes: {
-    tableId: PropTypes.string.isRequired,
+    table: PropTypes.object.isRequired,
     placeholder: PropTypes.string
   },
 
@@ -23,10 +21,11 @@ export default createReactClass({
       <div className="kbc-metadata-description">
         <MetadataEditField
           objectType="table"
-          objectId={this.props.tableId}
+          objectId={this.props.table.get('id')}
+          metadata={this.props.table.get('metadata')}
           metadataKey="KBC.description"
-          editElement={InlineEditArea}
           placeholder={this.props.placeholder}
+          editElement={InlineEditArea}
         />
       </div>
     );

--- a/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
+++ b/src/scripts/modules/table-browser/react/components/TableDescriptionTab.jsx
@@ -1,17 +1,14 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-
 import EmptyState from '../../../components/react/components/ComponentEmptyState';
 import TableDescriptionEditor from './TableDescriptionEditor';
 
 export default createReactClass({
-
   propTypes: {
-    isLoading: PropTypes.bool,
-    tableId: PropTypes.string.isRequired,
-    tableExists: PropTypes.bool.isRequired
+    table: PropTypes.object.isRequired,
+    tableExists: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool
   },
 
   render() {
@@ -26,10 +23,10 @@ export default createReactClass({
         </EmptyState>
       );
     }
-    const tableId = this.props.tableId;
+
     return (
       <div style={{maxHeight: '80vh', overflow: 'auto'}}>
-        <TableDescriptionEditor tableId={tableId}/>
+        <TableDescriptionEditor table={this.props.table} />
       </div>
     );
   }


### PR DESCRIPTION
Fixes #2439 - or at least most of it

I removed everything except storing editing value and information about saving metadata. (bucket, table, column description)

Metadata is taken direct from a bucket or a table. Updated metadata is stored back to a bucket or a table (StorageBucketsStore, StorageTablesStore). Updating or deleting column metadata is stored back to table (StorageTablesStore)

MetadataStore was used when editing description (bucket, table, column).
In transformation input mapping (snowflake) - metadata is read direct from table.
In storage-explorer column metadata is read direct from table.