### PR TITLE
Alias Filter Modal - catch and show error

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/AliasFilterModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/AliasFilterModal.jsx
@@ -27,10 +27,15 @@ export default createReactClass({
             <Modal.Title>Update filter</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            <Alert bsStyle="info">
+            {this.renderError()}
+
+            <p>
               You can specify one column to filter by, and comma separated values you&apos;re looking for. The alias table
               will contain only the matching rows.
-            </Alert>
+            </p>
+
+            <br />
+
             <FormGroup>
               <Col sm={3} componentClass={ControlLabel}>
                 Column
@@ -81,11 +86,20 @@ export default createReactClass({
     );
   },
 
+  renderError() {
+    if (!this.state.error) {
+      return null;
+    }
+
+    return <Alert bsStyle="danger">{this.state.error}</Alert>;
+  },
+
   defaultValues() {
     return {
       operator: this.props.table.getIn(['aliasFilter', 'operator'], 'eq'),
       column: this.props.table.getIn(['aliasFilter', 'column'], ''),
-      values: this.props.table.getIn(['aliasFilter', 'values'], List()).join(', ')
+      values: this.props.table.getIn(['aliasFilter', 'values'], List()).join(', '),
+      error: null
     };
   },
 
@@ -109,12 +123,22 @@ export default createReactClass({
 
   onSubmit(event) {
     event.preventDefault();
+
+    if (this.state.error) {
+      this.setState({ error: null });
+    }
+
     const params = {
       operator: this.state.operator,
       column: this.state.column,
       values: this.state.values.split(',').map(value => value.trim())
     };
-    this.props.onSubmit(params).then(this.props.onHide);
+
+    this.props.onSubmit(params).then(this.onHide, (message) => {
+      this.setState({
+        error: message
+      });
+    });
   },
 
   onHide() {


### PR DESCRIPTION
Related #3130

U funkce `setAliasTableFilter` převádíme error na message
```js
const setAliasTableFilter = (tableId, params) => {
  return StorageActionCreators
    .setAliasTableFilter(tableId, params)
    .catch(HttpError, error => {
      throw error.message;
    });
};
```
ale již s tím pak v modalu nepracujeme, takže dále probublá pouze message a ne celý error objekt a nakonec to skončí jako App error.

- nově to tam chytám a zobrazuji. Stejně jako to máme v dalších modalech
- jinak ten úvodní text jsem změnil na obyčejný text místo `info` alertu