### PR TITLE
Retry orchestration: pure vertical text

### DIFF
--- a/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
@@ -1,12 +1,12 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-
+import _ from 'underscore';
+import { Tree } from '@keboola/indigo-ui';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
 import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
 import ComponentIcon from '../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../react/common/ComponentName';
-import { Tree } from '@keboola/indigo-ui';
 
 export default createReactClass({
   propTypes: {
@@ -49,7 +49,17 @@ export default createReactClass({
       return config.get('name', parameters.get('config'));
     }
 
-    return <Tree data={this.props.task.get('actionParameters')} />;
+    const popover = (
+      <Popover id={_.uniqueId('parameters_')} title="Parameters" style={{ maxWidth: '600px' }}>
+        <Tree data={this.props.task.get('actionParameters')} />
+      </Popover>
+    );
+
+    return (
+      <OverlayTrigger trigger={['focus', 'hover']} placement="bottom" overlay={popover}>
+        <span>Show detail</span>
+      </OverlayTrigger>
+    );
   },
 
   _handleActiveChange() {

--- a/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/components/TaskSelectTableRow.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import _ from 'underscore';
 import { Tree } from '@keboola/indigo-ui';
-import { OverlayTrigger, Popover } from 'react-bootstrap';
+import { OverlayTrigger, Popover, Button } from 'react-bootstrap';
 import InstalledComponentsStore from '../../../components/stores/InstalledComponentsStore';
 import ComponentIcon from '../../../../react/common/ComponentIcon';
 import ComponentName from '../../../../react/common/ComponentName';
@@ -57,7 +57,9 @@ export default createReactClass({
 
     return (
       <OverlayTrigger trigger={['focus', 'hover']} placement="bottom" overlay={popover}>
-        <span>Show detail</span>
+        <Button onClick={(event) => {event.stopPropagation()}} className="btn btn-link btn-link-inline">
+          Show parameters
+        </Button>
       </OverlayTrigger>
     );
   },


### PR DESCRIPTION
Fixes #3234

Pokud mám takto data to `Tree` komponenty, zobrazím to až na hover do Popoveru. Pokud mám přímo konfiguraci zobrazím ji stejně jako doposud. 

Po úpravě:

![Screenshot 2019-04-17 at 13 52 26](https://user-images.githubusercontent.com/419849/56285677-17ec9200-6118-11e9-947b-48002b64ab9b.png)

