### PR TITLE
User data types not available in transformation IM for manually created tables

### DIFF
--- a/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
+++ b/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
@@ -33,8 +33,8 @@ describe('tableMetadataHelper', function() {
     });
 
     it('return false if table has no valid column metadata (no column has defined KBC.datatype.basetype', function() {
-      const tableWithoutMetadata = table.set('columnMetadata', Map());
-      expect(false).toEqual(hasTableColumnMetadataDatatypes(tableWithoutMetadata));
+      const tableWithoutValidMetadata = table.set('columnMetadata', fromJS({ column: [userMetadata] }));
+      expect(false).toEqual(hasTableColumnMetadataDatatypes(tableWithoutValidMetadata));
     });
   });
 

--- a/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
+++ b/src/scripts/modules/components/utils/tableMetadataHelper.spec.js
@@ -1,6 +1,5 @@
 import {
   hasTableColumnMetadataDatatypes,
-  getTableLastUpdatedInfo,
   getColumnMetadataByProvider,
   getMachineColumnMetadata,
   getUserColumnMetadata
@@ -17,110 +16,61 @@ const table = fromJS({
         timestamp: '2018-12-12T08:17:37+0100'
       }
     ]
-  },
-  metadata: [
-    {
-      key: 'KBC.createdBy.component.id',
-      value: 'keboola.ex-db-snowflake',
-      provider: 'system',
-      timestamp: '2018-12-12T08:17:37+0100'
-    },
-    {
-      key: 'KBC.createdBy.configuration.id',
-      value: '469551086',
-      provider: 'system',
-      timestamp: '2018-12-12T08:17:37+0100'
-    },
-    {
-      key: 'KBC.lastUpdatedBy.component.id',
-      value: 'keboola.ex-db-snowflake',
-      provider: 'system',
-      timestamp: '2018-12-12T08:19:05+0100'
-    },
-    {
-      key: 'KBC.lastUpdatedBy.configuration.id',
-      value: '469551086',
-      provider: 'system',
-      timestamp: '2018-12-12T08:19:05+0100'
-    }
-  ]
+  }
 });
 
+let userMetadata = {
+  key: 'KBC.description',
+  value: 'popis',
+  provider: 'user',
+  timestamp: '2019-02-02T08:00:00+0100'
+};
+
 describe('tableMetadataHelper', function() {
-  describe('getTableLastUpdatedInfo', function() {
-    it('should return valid object if table has KBC.lastUpdatedBy.component.id and KBC.lastUpdatedBy.configuration.id metadata', function() {
-      expect({
-        component: 'keboola.ex-db-snowflake',
-        config: '469551086',
-        timestamp: '2018-12-12T08:19:05+0100'
-      }).toEqual(getTableLastUpdatedInfo(table));
-    });
-
-    it('should return valid object if table has KBC.createdBy.component.id and KBC.createdBy.configuration.id metadata', function() {
-      expect({
-        component: 'keboola.ex-db-snowflake',
-        config: '469551086',
-        timestamp: '2018-12-12T08:17:37+0100'
-      }).toEqual(getTableLastUpdatedInfo(table.deleteIn(['metadata', 3])));
-    });
-
-    it('should return null if table has no KBC.lastUpdatedBy.component.id and KBC.lastUpdatedBy.configuration.id or KBC.createdBy.component.id and KBC.createdBy.configuration.id metadata', function() {
-      expect(null).toEqual(
-        getTableLastUpdatedInfo(table.deleteIn(['metadata', 1]).deleteIn(['metadata', 2]))
-      );
-    });
-  });
-
   describe('hasTableColumnMetadataDatatypes', function() {
     it('return true if table has any valid column metadata (any column has defined KBC.datatype.basetype)', function() {
       expect(true).toEqual(hasTableColumnMetadataDatatypes(table));
     });
 
     it('return false if table has no valid column metadata (no column has defined KBC.datatype.basetype', function() {
-      expect(false).toEqual(
-        hasTableColumnMetadataDatatypes(table.deleteIn(['columnMetadata', 'country']))
-      );
+      const tableWithoutMetadata = table.set('columnMetadata', Map());
+      expect(false).toEqual(hasTableColumnMetadataDatatypes(tableWithoutMetadata));
     });
   });
 
   describe('getColumnMetadataByProvider', function() {
     it('return empty Map when table has no column metadata field', function() {
-      expect(Map()).toEqual(
-        getColumnMetadataByProvider(table.delete('columnMetadata'), 'keboola.ex-db-snowflake')
-      );
+      const tableWithoutMetadata = table.set('columnMetadata', Map());
+      expect(Map()).toEqual(getColumnMetadataByProvider(tableWithoutMetadata, 'keboola.ex-db-snowflake'));
     });
 
     it('return filtered metadata by provider', function() {
-      expect(
-        fromJS({
-          country: []
-        })
-      ).toEqual(getColumnMetadataByProvider(table, 'user'));
+      expect(fromJS({ country: [] })).toEqual(getColumnMetadataByProvider(table, 'user'));
     });
 
     it('return filtered metadata by provider', function() {
-      expect(
-        fromJS({
-          country: [
-            {
-              key: 'KBC.datatype.basetype',
-              value: 'STRING',
-              provider: 'keboola.ex-db-snowflake',
-              timestamp: '2018-12-12T08:17:37+0100'
-            }
-          ]
-        })
-      ).toEqual(getColumnMetadataByProvider(table, 'keboola.ex-db-snowflake'));
+      expect(table.get('columnMetadata')).toEqual(getColumnMetadataByProvider(table, 'keboola.ex-db-snowflake'));
     });
   });
 
   describe('getMachineColumnMetadata', function() {
-    it('return empty Map when table has no valid metadata - KBC.lastUpdatedBy.* or KBC.createdBy.*', function() {
-      expect(Map()).toEqual(getMachineColumnMetadata(table.delete('metadata')));
+    it('return empty Map when table has no metadata written by other provider than user', function() {
+      const tableWithOnlyUserMetdata = table.set('columnMetadata', fromJS({
+        country: [userMetadata]
+      }));
+      expect(Map()).toEqual(getMachineColumnMetadata(tableWithOnlyUserMetdata));
     });
 
-    it('return filtered column metadata by component - has KBC.lastUpdatedBy.* or KBC.createdBy.*', function() {
-      expect(table.get('columnMetadata')).toEqual(getMachineColumnMetadata(table));
+    it('return filtered column metadata by last active provider other than user', function() {
+      const tableWithAnotherOlderMetadata = table.updateIn(['columnMetadata', 'country'], (metadata) => {
+        return metadata.push(fromJS({
+          key: 'KBC.datatype.basetype',
+          value: 'STRING',
+          provider: 'other',
+          timestamp: '2017-12-12T08:17:37+0100'
+        }));
+      });
+      expect(table.get('columnMetadata')).toEqual(getMachineColumnMetadata(tableWithAnotherOlderMetadata));
     });
   });
 
@@ -130,20 +80,10 @@ describe('tableMetadataHelper', function() {
     });
 
     it('return only column metadata created by user', function() {
-      const userMetadata = {
-        key: 'KBC.description',
-        value: 'popis',
-        provider: 'user',
-        timestamp: '2019-02-02T08:00:00+0100'
-      };
-
-      expect(fromJS({ country: [userMetadata] })).toEqual(
-        getUserColumnMetadata(
-          table.updateIn(['columnMetadata', 'country'], (metadata) => {
-            return metadata.push(fromJS(userMetadata));
-          })
-        )
-      );
+      const tableWithMachineAndUserMetadata = table.updateIn(['columnMetadata', 'country'], (metadata) => {
+        return metadata.push(fromJS(userMetadata));
+      });
+      expect(fromJS({ country: [userMetadata] })).toEqual(getUserColumnMetadata(tableWithMachineAndUserMetadata));
     });
   });
 });


### PR DESCRIPTION
Fixes #3247

Soubor by šel možná i přejmenovat na `tableColumnMetadataHelper` ale už jen kvůli diffu jsem to sám nedělal.

Jinak jsem vyhodil teda závislosti na metadatech tabulky a vše se řeší jen v rámci metadata sloupců dané tabulky.

Místo `getTableLastUpdatedInfo` je `getLastActiveProvider` který vrací pouze posledního providera, který provedl nějaký zápis do metadata sloupců. Používám to jen pro nějaké jiné helpery, tak to ani neexportuji.

Jinak `getLastActiveProvider` by mělo "srovnat" všechny metadata do jednoho Listu, tam to případně profiltrovat podle providera, seřadit od nejnovějšího a použít první záznam, teda poslední přidaný/upravený metadata. Z tohoto záznamu se vrátí `provider`.