### PR TITLE
Long content in CodeMirror editor is not render correctly.

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "bluebird": "^3.5.3",
     "byte-converter": "^0.1.4",
     "classnames": "^2.2.6",
-    "codemirror": "^5.45.0",
+    "codemirror": "^5.46.0",
     "create-react-class": "^15.6.3",
     "crypto-js": "^3.1.9-1",
     "d3": "~4.3.0",

--- a/src/scripts/modules/apify/react/Index/Index.jsx
+++ b/src/scripts/modules/apify/react/Index/Index.jsx
@@ -284,6 +284,7 @@ export default createReactClass({
     return (
       <div className="form-control-static">
         <CodeMirror
+          editorDidMount={(editor) => editor.refresh()}
           value={value}
           options={{
             theme: 'solarized',

--- a/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
+++ b/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
@@ -153,6 +153,7 @@ export default createReactClass({
           </div>
           <div className="col-xs-10">
             <CodeMirror
+              editorDidMount={(editor) => editor.refresh()}
               value={this.props.settings}
               onBeforeChange={this.handleCrawlerSettingsChange}
               options={{
@@ -186,6 +187,7 @@ export default createReactClass({
   renderCrawlerSettingsForm() {
     const editor = (
       <CodeMirror
+        editorDidMount={(editor) => editor.refresh()}
         value={this.props.settings}
         onBeforeChange={this.handleCrawlerSettingsChange}
         options={{

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -69,6 +69,7 @@ export default createReactClass({
       <span>
         <p className="help-block small">Properties prefixed with <code>#</code> sign will be encrypted on save. Already encrypted strings will persist.</p>
         <CodeMirror
+          editorDidMount={(editor) => editor.refresh()}
           value={this.props.data}
           onBeforeChange={this.handleChange}
           options={{

--- a/src/scripts/modules/components/react/components/ProcessorsInput.jsx
+++ b/src/scripts/modules/components/react/components/ProcessorsInput.jsx
@@ -17,6 +17,7 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-processor-editor">
             <CodeMirror
+              editorDidMount={(editor) => editor.refresh()}
               value={this.props.value}
               onBeforeChange={this.handleChange}
               options={{

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -88,6 +88,7 @@ export default createReactClass({
         <p className="kbc-template-editor-toggle"><a onClick={this.switchToTemplateEditor}><small>Switch to templates</small></a></p>
         <p>JSON configuration uses <ExternalLink href="https://developers.keboola.com/extend/generic-extractor/">Generic extractor</ExternalLink> format.</p>
         <CodeMirror
+          editorDidMount={(editor) => editor.refresh()}
           value={this.props.editingString}
           onBeforeChange={this.handleStringChange}
           options={{

--- a/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
+++ b/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
@@ -16,6 +16,7 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-json-editor">
             <CodeMirror
+              editorDidMount={(editor) => editor.refresh()}
               value={this.props.value}
               onBeforeChange={this.handleChange}
               options={{

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -451,13 +451,14 @@ export default createReactClass({
           <label className="control-label">SQL Query</label>
           {this.renderQueryHelpBlock()}
           <CodeMirror
+            editorDidMount={(editor) => editor.refresh()}
             value={this.getQuery()}
             onBeforeChange={this.handleQueryChange}
             options={{
               theme: 'solarized',
               mode: editorMode(this.props.componentId),
               lineNumbers: true,
-              lineWrapping: false,
+              lineWrapping: true,
               placeholder: getQueryEditorPlaceholder(this.props.componentId),
             }}
             style={{ width: '100%' }}

--- a/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
+++ b/src/scripts/modules/ex-google-bigquery-v2/react/components/Query.jsx
@@ -46,13 +46,14 @@ export default createReactClass({
           </Col>
           <Col sm={8}>
             <CodeMirror
+              editorDidMount={(editor) => editor.refresh()}
               value={this.props.value.query}
               onBeforeChange={(editor, data, value) => this.props.onChange({query: value})}
               options={{
                 theme: 'solarized',
                 mode: editorMode(ExGoogleBigQueryV2ComponentId),
                 lineNumbers: true,
-                lineWrapping: false,
+                lineWrapping: true,
                 readOnly: this.props.disabled,
                 placeholder: 'e.g. SELECT `id`, `name` FROM `myTable`'
               }}

--- a/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryDetailStatic.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/QueryDetail/QueryDetailStatic.jsx
@@ -61,12 +61,13 @@ const QueryDetailStatic = ({ query, componentId }) => {
             <div className="form-control-static">
               {query.get('query').length ? (
                 <CodeMirror
+                  editorDidMount={(editor) => editor.refresh()}
                   value={query.get('query')}
                   options={{
                     theme: 'solarized',
                     mode: editorMode(componentId),
                     lineNumbers: false,
-                    lineWrapping: false,
+                    lineWrapping: true,
                     readOnly: true
                   }}
                   style={{width: '100%'}}

--- a/src/scripts/modules/ex-google-bigquery/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-google-bigquery/react/components/QueryEditor.jsx
@@ -123,13 +123,14 @@ export default createReactClass({
             <div className="col-md-10 ">
               <div className="form-control-static">
                 <CodeMirror
+                  editorDidMount={(editor) => editor.refresh()}
                   value={this.props.query.get('query')}
                   onBeforeChange={this._handleQueryChange}
                   options={{
                     theme: 'solarized',
                     mode: editorMode(this.props.componentId),
                     lineNumbers: true,
-                    lineWrapping: false,
+                    lineWrapping: true,
                     placeholder: 'e.g. SELECT `id`, `name` FROM `myTable`'
                   }}
                   style={{width: '100%'}}

--- a/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
@@ -78,6 +78,7 @@ export default createReactClass({
             <Col componentClass={ControlLabel} md={3}>Query</Col>
             <Col md={9}>
               <CodeMirror
+                editorDidMount={(editor) => editor.refresh()}
                 value={this.props.query.has('query') ? this.props.query.get('query') : ''}
                 onBeforeChange={this.handleQueryChange}
                 options={{
@@ -97,6 +98,7 @@ export default createReactClass({
             <Col componentClass={ControlLabel} md={3}>Sort</Col>
             <Col md={9}>
               <CodeMirror
+                editorDidMount={(editor) => editor.refresh()}
                 value={this.props.query.has('sort') ? this.props.query.get('sort').toString() : ''}
                 onBeforeChange={this.handleSortChange}
                 options={{
@@ -171,6 +173,7 @@ export default createReactClass({
           <Col componentClass={ControlLabel} md={3}>Mapping</Col>
           <Col md={9}>
             <CodeMirror
+              editorDidMount={(editor) => editor.refresh()}
               value={mappingValue}
               onBeforeChange={this.handleMappingChange}
               options={{

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
@@ -23,6 +23,7 @@ export default createReactClass({
     if (this.props.isEditing) {
       return (
         <CodeMirror
+          editorDidMount={(editor) => editor.refresh()}
           value={this.props.data}
           onBeforeChange={this.handleChange}
           options={{
@@ -40,6 +41,7 @@ export default createReactClass({
 
     return (
       <CodeMirror
+        editorDidMount={(editor) => editor.refresh()}
         value={this.props.data}
         options={{
           theme: 'solarized',

--- a/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
+++ b/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
@@ -40,6 +40,7 @@ export default createReactClass({
   renderJsonArea() {
     return (
       <CodeMirror
+        editorDidMount={(editor) => editor.refresh()}
         value={this.state.parametersString}
         onBeforeChange={this._handleChange}
         options={{

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
@@ -60,7 +60,10 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-queries-editor">
             <CodeMirror
-              editorDidMount={editor => { this.editor = editor }}
+              editorDidMount={(editor) => {
+                this.editor = editor;
+                editor.refresh();
+              }}
               value={normalizeNewlines(this.props.queries)}
               onBeforeChange={this.handleChange}
               options={{

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
@@ -34,6 +34,7 @@ export default createReactClass({
         <div>
           <div className="edit form-group kbc-queries-editor">
             <CodeMirror 
+              editorDidMount={(editor) => editor.refresh()}
               value={normalizeNewlines(this.props.script)}
               onBeforeChange={this.handleChange}
               options={{

--- a/src/scripts/react/common/VersionsDiffModalComponents/DetailedDiff.jsx
+++ b/src/scripts/react/common/VersionsDiffModalComponents/DetailedDiff.jsx
@@ -96,6 +96,7 @@ export default createReactClass({
 
     return (
       <CodeMirror
+        editorDidMount={(editor) => editor.refresh()}
         value={multiDiff}
         options={{
           theme: 'solarized',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,10 +2134,10 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
-codemirror@^5.45.0:
-  version "5.45.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.45.0.tgz#db5ebbb3bf44028c684053f3954d011efcec27ad"
-  integrity sha512-c19j644usCE8gQaXa0jqn2B/HN9MnB2u6qPIrrhrMkB+QAP42y8G4QnTwuwbVSoUS1jEl7JU9HZMGhCDL0nsAw==
+codemirror@^5.46.0:
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.46.0.tgz#be3591572f88911e0105a007c324856a9ece0fb7"
+  integrity sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w==
 
 collection-visit@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes #3248

Koukal jsem na to a může za to `lineWrapping: true` kde se to pak nějak špatně dopočítá. Existuje nějaký refresh plugin ale nepřišlo mi že to fungovalo a takto ta úprava byla jednoduchá.

Prostě to refreshnu až do je celé mountnuté v DOMu. Podobný postup je i doporučený někde na netu pokud to někomu také dělalo problémy.

- první co tak jsem aktualizovat CodeMirror - nepomohlo ale myslím vůbec nevadí to tam nechat
- pak jsem teda všude dal ten refresh - on je potřeba jen tam, kde je `lineWrapping: true`, což nebylo všude. Na několika místech jsem to teda změnil z `false` na `true`, protože mi to přišlo lepší pro konzistentnost, abych to měl spíše skoro všude. Jediné místo kde jsem to nechal vypnuté je DIFF, tam by teda nemusel být ani ten refresh, ale nechal jsem to tam pro jistotu i do budoucnu, kdyby se nějaké `options` měnily, aby to najednou nedělalo do samé.