### PR TITLE
Smplify JSONEditorEditor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Keboola Connection UI",
   "author": "Martin Halamicek",
   "dependencies": {
-    "@json-editor/json-editor": "^1.3.4",
+    "@json-editor/json-editor": "^1.3.5",
     "@keboola/indigo-ui": "^8.0.0",
     "aws-sdk": "^2.437.0",
     "bluebird": "^3.5.3",

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Immutable from 'immutable';
+import { Map, fromJS } from 'immutable';
 import { Controlled as CodeMirror } from 'react-codemirror2'
 import JSONSchemaEditor from './JSONSchemaEditor';
 import SaveButtons from '../../../../react/common/SaveButtons';
@@ -22,7 +22,7 @@ export default createReactClass({
   getDefaultProps() {
     return {
       saveLabel: 'Save configuration',
-      schema: Immutable.Map()
+      schema: Map()
     };
   },
 
@@ -33,7 +33,7 @@ export default createReactClass({
           <SaveButtons
             isSaving={this.props.isSaving}
             isChanged={this.props.isChanged}
-            onSave={this.handleSave}
+            onSave={this.props.onSave}
             disabled={!this.props.isValid}
             onReset={this.props.onCancel} />
         </div>
@@ -49,9 +49,8 @@ export default createReactClass({
     }
     return (
       <JSONSchemaEditor
-        ref="paramsEditor"
         schema={this.props.schema}
-        value={Immutable.fromJS(JSON.parse(this.props.data))}
+        value={fromJS(JSON.parse(this.props.data))}
         onChange={this.handleParamsChange}
         readOnly={this.props.isSaving}
         isChanged={this.props.isChanged}
@@ -89,17 +88,8 @@ export default createReactClass({
   },
 
   handleParamsChange(value) {
-    if (!value.equals(Immutable.fromJS(JSON.parse(this.props.data)))) {
+    if (!value.equals(fromJS(JSON.parse(this.props.data)))) {
       this.props.onChange(JSON.stringify(value));
     }
-  },
-
-  handleSave() {
-    if (this.refs.paramsEditor) {
-      // json-editor doesn't trigger onChange handler on each key stroke
-      // so sometimes not actualized data were saved https://github.com/keboola/kbc-ui/issues/501
-      this.handleParamsChange(this.refs.paramsEditor.getCurrentValue());
-    }
-    this.props.onSave();
   }
 });

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -55,8 +55,6 @@ export default createReactClass({
         onChange={this.handleParamsChange}
         readOnly={this.props.isSaving}
         isChanged={this.props.isChanged}
-        disableCollapse={true}
-        disableProperties={true}
       />
     );
   },

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -64,7 +64,6 @@ export default createReactClass({
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);
 
-    // When the value of the editor changes, update the JSON output and TODO validation message
     this.jsoneditor.on('change', () => {
       this.props.onChange(fromJS(this.jsoneditor.getValue()));
     });
@@ -85,10 +84,6 @@ export default createReactClass({
     if (nextReadOnly) {
       this.jsoneditor.disable();
     }
-  },
-
-  getCurrentValue() {
-    return fromJS(this.jsoneditor.getValue());
   },
 
   render() {

--- a/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
+++ b/src/scripts/modules/components/react/components/JSONSchemaEditor.jsx
@@ -58,8 +58,6 @@ export default createReactClass({
     if (nextReadOnly) {
       options.disable_array_add = true;
       options.disable_array_delete = true;
-      options.disable_collapse = true;
-      options.disable_properties = true;
     }
 
     this.jsoneditor = new JSONEditor(this.refs.jsoneditor, options);

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -54,8 +54,6 @@ export default createReactClass({
         value={this.props.editingParams}
         onChange={this.handleParamsChange}
         readOnly={this.props.isSaving}
-        disableCollapse={true}
-        disableProperties={true}
       />
     );
   },

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -8,7 +8,6 @@ import TemplateSelector from './ConfigurationTemplateSelector';
 import SaveButtons from '../../../../react/common/SaveButtons';
 
 export default createReactClass({
-
   propTypes: {
     isTemplate: PropTypes.bool.isRequired,
     editingTemplate: PropTypes.object.isRequired,
@@ -48,7 +47,6 @@ export default createReactClass({
     }
     return (
       <JSONSchemaEditor
-        ref="paramsEditor"
         isChanged={this.props.isChanged}
         schema={this.props.paramsSchema}
         value={this.props.editingParams}
@@ -66,7 +64,7 @@ export default createReactClass({
             <SaveButtons
               isSaving={this.props.isSaving}
               isChanged={this.props.isChanged}
-              onSave={this.handleSave}
+              onSave={this.props.onSave}
               disabled={!this.props.isValid}
               onReset={this.props.onCancel} />
           </div>
@@ -142,14 +140,5 @@ export default createReactClass({
   switchToTemplateEditor() {
     this.setState({showJsonEditor: false});
     this.props.onChangeEditingMode(false);
-  },
-
-  handleSave() {
-    if (this.refs.paramsEditor) {
-      // json-editor doesn't trigger onChange handler on each key stroke
-      // so sometimes not actualized data were saved https://github.com/keboola/kbc-ui/issues/501
-      this.handleParamsChange(this.refs.paramsEditor.getCurrentValue());
-    }
-    this.props.onSave();
   }
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -934,10 +934,10 @@
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/yargs" "^12.0.9"
 
-"@json-editor/json-editor@^1.3.4":
-  version "1.3.4"
-  resolved "https://registry.yarnpkg.com/@json-editor/json-editor/-/json-editor-1.3.4.tgz#730ce407e9816370a513f48fe9b74eb191149200"
-  integrity sha512-w4SGutLq8wnQzQoidw7QlQmOq3bknf8xbLrK4TX48eVcAXuDxwnY/ikdjAiJkCSiB+ecK/7qo/Vxzv50AV3p/A==
+"@json-editor/json-editor@^1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@json-editor/json-editor/-/json-editor-1.3.5.tgz#b8ec91b2ad53d65a031c90941e3c3bbd084bc321"
+  integrity sha512-maU/05CzSvW5waIqWXhhiekLhDKwu8cOkGESIVyV2UrONedRzO/qk+WBFKkBbLmm5TeyRnkwVL6CkKNyaa2d4w==
 
 "@keboola/indigo-ui@^8.0.0":
   version "8.0.2"


### PR DESCRIPTION
Related #3191 #2261

Zkoumal jsem znovu nějaké možnosti jiné json-editor komponenty ale nic nevypadá že by postoužilo lépe jak současná varianta.

Původní PR už je starší a ta validace není stopro takže je to seklé.

Tady jsem zkusil jen udělat nějaké menší úpravy, které mě nebo někomu jiného třeba příště ulehčí nějaký větší refactoring, aby to fungovalo podle představ (stejně jsme to dělal u grafů kde to na začátku bylo hodně nepřehledné ale dost se to zjednodušilo že se pak v tom docela dobře pracovalo a šlo to upravit).

- aktualizace json-editor - jen patch
- vyhození validace která se myslím vůbec nevyužije
- `disableCollapse` a `disableProperties` bylo vždy posíláno jako `true` tak jsem to udělal jako default a props vymazal
- vyhodil jsem logiku kolem `blockOnChangeOnce` když se volá onChange, tak se tam porovnávají dvě immutable struktury přes `equals`, takže pokud není nic nového nic se ani tak nestane, aspoň co jsem dohledatl
- před uložením se tam ještě přes `ref` znovu ukládala aktuální hodnota, myslím že to by nemělo být již potřeba, že by to mělo reagovat na každou změnu inputu
