### PR TITLE
CodeMirror - turn off autofocus

### DIFF
--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -75,7 +75,6 @@ export default createReactClass({
             theme: 'solarized',
             mode: 'application/json',
             lineNumbers: true,
-            autofocus: true,
             lineWrapping: true,
             readOnly: this.props.isSaving,
             lint: true,

--- a/src/scripts/modules/components/react/components/ProcessorsInput.jsx
+++ b/src/scripts/modules/components/react/components/ProcessorsInput.jsx
@@ -22,7 +22,6 @@ export default createReactClass({
               options={{
                 theme: 'solarized',
                 mode: 'application/json',
-                autofocus: true,
                 lineNumbers: true,
                 lineWrapping: true,
                 lint: !!this.props.value,

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -95,7 +95,6 @@ export default createReactClass({
             mode: 'application/json',
             lineNumbers: true,
             lineWrapping: true,
-            autofocus: true,
             readOnly: this.props.isSaving,
             lint: true,
             gutters: ['CodeMirror-lint-markers'],

--- a/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
+++ b/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
@@ -24,23 +24,15 @@ export default createReactClass({
                 placeholder: 'Your JSON config goes here...',
                 lineNumbers: true,
                 lint: true,
-                autofocus: true,
                 lineWrapping: true,
                 readOnly: this.props.disabled,
                 gutters: ['CodeMirror-lint-markers']
               }}
             />
           </div>
-          <div className="small help-block">
-            {this.help()}
-          </div>
         </div>
       </div>
     );
-  },
-
-  help() {
-    return null;
   },
 
   handleChange(editor, data, value) {

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
@@ -29,7 +29,6 @@ export default createReactClass({
             theme: 'solarized',
             mode: 'application/json',
             lineNumbers: true,
-            autofocus: true,
             lineWrapping: true,
             readOnly: this.props.isSaving,
             lint: true,

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
@@ -68,7 +68,6 @@ export default createReactClass({
                 mode: resolveHighlightMode(this.props.backend, null),
                 lineNumbers: true,
                 lineWrapping: true,
-                autofocus: true,
                 readOnly: this.props.disabled,
                 placeholder: '-- Your SQL goes here...'
               }}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/ScriptsEdit.jsx
@@ -40,7 +40,6 @@ export default createReactClass({
                 theme: 'solarized',
                 mode: resolveHighlightMode('docker', this.props.backend),
                 lineNumbers: true,
-                autofocus: true,
                 lineWrapping: true,
                 readOnly: this.props.disabled,
                 ...codeMirrorParams


### PR DESCRIPTION
Navrhuji zrušit autofocus pro CodeMirrory.

Většinou tyto editory nejsou první co uživatel vidí. Navíc pokud třeba na detailu transformace udělám refresh, vždy mi to rovnou skočí k tomu editoru, což je takové divné. Asi to tak bude i na jiných stránkách kde byl CodeMirror a měl autofocus true.

Autofocus mi dává smysl spíše v takových jednodušších formulářích. Viz třeba nový bucket apod. Kde vyskočí modal kde je pár inputů a první dostane focus. V těch větších formulářích nebo obecně detailu nějaké transformace, extractoru apod bych to spíše nepoužíval.
