### PR TITLE
Table Input mapping row - do not render size atd edit icon when source table was not found 

### DIFF
--- a/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
@@ -28,6 +28,8 @@ export default createReactClass({
   },
 
   render() {
+    const sourceTable = this.props.tables.get(this.props.value.get('source'), Map());
+
     return (
       <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
@@ -41,13 +43,13 @@ export default createReactClass({
                   <span className="fa fa-chevron-right fa-fw" />
                 </span>,
                 <span className="td col-xs-6" key="source">
-                  <TableSizeLabel size={this.props.tables.getIn([this.props.value.get('source'), 'dataSizeBytes'])} />{' '}
-                  {this.props.value.get('source') !== '' ? this.props.value.get('source') : 'Not set'}
+                  {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
+                  {this.props.value.get('source') || 'Not set'}
                 </span>
               ]
               : [
                 <span className="td col-xs-3" key="icons">
-                  <TableSizeLabel size={this.props.tables.getIn([this.props.value.get('source'), 'dataSizeBytes'])} />{' '}
+                  {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
                 </span>,
                 <span className="td col-xs-4" key="source">
                   {this.props.value.get('source')}

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
@@ -21,20 +21,12 @@ export default createReactClass({
     otherDestinations: PropTypes.object.isRequired,
     componentType: PropTypes.string.isRequired,
     onEditStart: PropTypes.func,
-    definition: PropTypes.object,
-    showFileHint: PropTypes.bool,
-    buttonBsStyle: PropTypes.string,
-    buttonLabel: PropTypes.string,
-    tooltipText: PropTypes.string
+    definition: PropTypes.object
   },
 
   getDefaultProps() {
     return {
-      showFileHint: true,
-      definition: Map(),
-      buttonBsStyle: 'success',
-      buttonLabel: 'New Table Input',
-      tooltipText: 'Edit Input'
+      definition: Map()
     };
   },
 
@@ -74,7 +66,7 @@ export default createReactClass({
   render() {
     return (
       <span>
-        { this.renderOpenButton() }
+        {this.renderOpenButton()}
         <Modal onHide={this.handleCancel} show={this.state.showModal} bsSize="large">
           <Modal.Header closeButton>
             <Modal.Title>
@@ -100,18 +92,20 @@ export default createReactClass({
 
   renderOpenButton() {
     if (this.props.mode === MODE_EDIT) {
+      const editingNonExistentTable = this.editingNonExistentTable();
+
       return (
-        <Tooltip tooltip={this.props.tooltipText} placement="top">
+        <Tooltip tooltip={editingNonExistentTable ? 'Open Input' : 'Edit Input'} placement="top">
           <Button bsStyle="link" onClick={this.handleEditButtonClick}>
-            <span className="fa fa-pencil" />
+            {editingNonExistentTable ? <span className="fa fa-eye" /> : <span className="fa fa-pencil" />}
           </Button>
         </Tooltip>
       );
     }
 
     return (
-      <Button bsStyle={this.props.buttonBsStyle} onClick={this.open}>
-        <i className="kbc-icon-plus" />{this.props.buttonLabel}
+      <Button bsStyle="success" onClick={this.open}>
+        <i className="kbc-icon-plus" /> New Table Input
       </Button>
     );
   },
@@ -128,13 +122,13 @@ export default createReactClass({
   editor() {
     return (
       <Editor
+        showFileHint
         value={this.props.mapping}
         tables={this.props.tables}
         disabled={this.state.isSaving || this.editingNonExistentTable()}
         onChange={this.props.onChange}
         initialShowDetails={resolveTableInputShowDetails(this.props.mapping)}
         isDestinationDuplicate={this.isDestinationDuplicate()}
-        showFileHint={this.props.showFileHint}
         definition={this.props.definition}
         editingNonExistentTable={this.editingNonExistentTable()}
         componentType={this.props.componentType}

--- a/src/scripts/modules/transformations/react/modals/InputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/InputMapping.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
+import { Map } from 'immutable';
 import {Button, Modal} from 'react-bootstrap';
 import Tooltip from './../../../../react/common/Tooltip';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
@@ -8,7 +9,6 @@ import InputMappingRowDockerEditor from '../components/mapping/InputMappingRowDo
 import InputMappingRowRedshiftEditor from '../components/mapping/InputMappingRowRedshiftEditor';
 import InputMappingRowSnowflakeEditor from '../components/mapping/InputMappingRowSnowflakeEditor';
 import resolveInputShowDetails from './resolveInputShowDetails';
-import Immutable from 'immutable';
 
 const MODE_CREATE = 'create', MODE_EDIT = 'edit';
 
@@ -29,7 +29,7 @@ export default createReactClass({
 
   getDefaultProps() {
     return {
-      definition: Immutable.Map(),
+      definition: Map(),
       disabled: false
     };
   },
@@ -69,7 +69,7 @@ export default createReactClass({
     }
     return (
       <span>
-        { this.renderOpenButton() }
+        {this.renderOpenButton()}
         <Modal onHide={this.handleCancel} show={this.state.showModal} bsSize="large">
           <Modal.Header closeButton={true}>
             <Modal.Title>{title}</Modal.Title>
@@ -93,20 +93,26 @@ export default createReactClass({
 
   renderOpenButton() {
     if (this.props.mode === MODE_EDIT) {
+      const editingNonExistentTable = this.editingNonExistentTable();
+
       return (
-        <Tooltip tooltip="Edit Input" placement="top">
+        <Tooltip tooltip={editingNonExistentTable ? 'Open Input' : 'Edit Input'} placement="top">
           <Button bsStyle="link" onClick={this.handleOpenButtonLink} disabled={this.props.disabled}>
-            <span className="fa fa-pencil" />
+            {editingNonExistentTable ? <span className="fa fa-eye" /> : <span className="fa fa-pencil" />}
           </Button>
         </Tooltip>
       );
-    } else {
-      return (
-        <Button bsStyle="success" onClick={this.open}>
-          <i className="kbc-icon-plus" />New Input
-        </Button>
-      );
     }
+
+    return (
+      <Button bsStyle="success" onClick={this.open}>
+        <i className="kbc-icon-plus" />New Input
+      </Button>
+    );
+  },
+
+  editingNonExistentTable() {
+    return this.props.tables.get(this.props.mapping.get('source'), Map()).count() === 0;
   },
 
   handleOpenButtonLink(e) {

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
@@ -34,6 +34,8 @@ export default createReactClass({
   },
 
   render() {
+    const sourceTable = this.props.tables.get(this.props.inputMapping.get('source'), Map());
+
     return (
       <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
@@ -47,17 +49,13 @@ export default createReactClass({
                   <span className="fa fa-chevron-right fa-fw" />
                 </span>,
                 <span className="td col-xs-6" key="destination">
-                  <TableSizeLabel
-                    size={this.props.tables.getIn([this.props.inputMapping.get('source'), 'dataSizeBytes'])}
-                  />{' '}
-                  {this.props.inputMapping.get('source') !== '' ? this.props.inputMapping.get('source') : 'Not set'}
+                  {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
+                  {this.props.inputMapping.get('source') || 'Not set'}
                 </span>
               ]
               : [
                 <span className="td col-xs-3" key="icons">
-                  <TableSizeLabel
-                    size={this.props.tables.getIn([this.props.inputMapping.get('source'), 'dataSizeBytes'])}
-                  />{' '}
+                  {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
                 </span>,
                 <span className="td col-xs-4" key="source">
                   {this.props.inputMapping.get('source', 'Not set')}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingRow.jsx
@@ -1,12 +1,12 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
+import { Map } from 'immutable';
 import TableSizeLabel from '../../components/TableSizeLabel';
 import DeleteButton from '../../../../../react/common/DeleteButton';
 import OutputMappingModal from '../../modals/OutputMapping';
 import actionCreators from '../../../ActionCreators';
-import { Map } from 'immutable';
 
 export default createReactClass({
   mixins: [ImmutableRenderMixin],
@@ -34,6 +34,8 @@ export default createReactClass({
   },
 
   render() {
+    const destinationTable = this.props.tables.get(this.props.outputMapping.get('destination'), Map());
+
     return (
       <span className="table kbc-break-all kbc-break-word">
         <span className="tbody">
@@ -47,15 +49,11 @@ export default createReactClass({
                   <span className="fa fa-chevron-right fa-fw" />
                 </span>,
                 <span className="td col-xs-6" key="destination">
-                  <TableSizeLabel
-                    size={this.props.tables.getIn([this.props.outputMapping.get('destination'), 'dataSizeBytes'])}
-                  />{' '}
+                  {destinationTable.count() > 0 && <TableSizeLabel size={destinationTable.get('dataSizeBytes')} />}
                   {this.props.outputMapping.get('incremental') && (
                     <span className="label label-default">Incremental</span>
                   )}
-                  {this.props.outputMapping.get('destination') !== ''
-                    ? this.props.outputMapping.get('destination')
-                    : 'Not set'}
+                  {this.props.outputMapping.get('destination') || 'Not set'}
                 </span>
               ]
               : [
@@ -68,9 +66,7 @@ export default createReactClass({
                   <span className="fa fa-chevron-right fa-fw" />
                 </span>,
                 <span className="td col-xs-3" key="buttons">
-                  <TableSizeLabel
-                    size={this.props.tables.getIn([this.props.outputMapping.get('destination'), 'dataSizeBytes'])}
-                  />{' '}
+                  {destinationTable.count() > 0 && <TableSizeLabel size={destinationTable.get('dataSizeBytes')} />}
                   {this.props.outputMapping.get('incremental') && (
                     <span className="label label-default">Incremental</span>
                   )}


### PR DESCRIPTION
Navazuje na keboola/indigo-ui#357
A na https://github.com/keboola/kbc-ui/pull/3259

Toto je vlastně ten třetí bod:
- pokud nemám tabulku nezobrazím Size label, a místo pencil dám ikonku eye

Pak už jen nedělat odkaz na neexistující tabulku, to bude další PR.