### PR TITLE
WR-DB - Columns editor update

### DIFF
--- a/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import { ExternalLink } from "@keboola/indigo-ui";
 import { Table } from 'react-bootstrap';
 import ColumnRow from './ColumnRow';
 import Tooltip from '../../../../../react/common/Tooltip';
@@ -109,11 +108,6 @@ export default createReactClass({
     return (
       <th>
         <span>Null </span>
-        <ExternalLink href="https://help.keboola.com/writers/database/">
-          <Tooltip tooltip="Read more in documentation" placement="top">
-            <i className="fa fa-question-circle fa-fw" />
-          </Tooltip>
-        </ExternalLink>
         {this.props.editingColumns && this._createCheckbox()}
       </th>
     );

--- a/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
@@ -107,7 +107,7 @@ export default createReactClass({
 
     return (
       <th>
-        <span>Null </span>
+        <span>Nullable </span>
         {this.props.editingColumns && this._createCheckbox()}
       </th>
     );

--- a/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/ColumnsEditor.jsx
@@ -1,8 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
+import { ExternalLink } from "@keboola/indigo-ui";
+import { Table } from 'react-bootstrap';
 import ColumnRow from './ColumnRow';
-import Hint from '../../../../../react/common/Hint';
 import Tooltip from '../../../../../react/common/Tooltip';
 
 export default createReactClass({
@@ -10,7 +11,6 @@ export default createReactClass({
     columns: PropTypes.object.isRequired,
     filterColumnFn: PropTypes.func.isRequired,
     onToggleHideIgnored: PropTypes.func.isRequired,
-    editButtons: PropTypes.object.isRequired,
     disabledColumnFields: PropTypes.array.isRequired,
     onSetAllColumnsNull: PropTypes.func.isRequired,
     editingColumns: PropTypes.object,
@@ -24,6 +24,38 @@ export default createReactClass({
   },
 
   render() {
+    return (
+      <Table responsive striped className="kbc-table-editor">
+        <thead>
+          <tr>
+            <th>Column</th>
+            <th>
+              Database Column Name
+              {this.props.editingColumns && this.props.setAllColumnsName}
+            </th>
+            <th>
+              Data Type
+              <div style={{ margin: 0 }} className="checkbox">
+                <label className="">
+                  <input type="checkbox" label="Hide IGNORED" onChange={this.props.onToggleHideIgnored} />
+                  {' Hide Ignored'}
+                </label>
+              </div>
+              {this.props.editingColumns && this.props.setAllColumnsType}
+            </th>
+            {this.renderNullableHeader()}
+            {this.renderDefaultHeader()}
+            <th>Preview</th>
+          </tr>
+        </thead>
+        <tbody>
+          {this.renderRows()}
+        </tbody>
+      </Table>
+    );
+  },
+
+  renderRows() {
     const columns = this.props.columns.filter(column => {
       let fn = column;
       if (this.props.editingColumns) {
@@ -31,6 +63,7 @@ export default createReactClass({
       }
       return this.props.filterColumnFn(fn);
     });
+
     const rows = columns.map((column, index) => {
       const cname = column.get('name');
       let editingColumn = null;
@@ -55,70 +88,43 @@ export default createReactClass({
       );
     });
 
+    if (!rows.count()) {
+      return (
+        <tr>
+          <td colSpan="6">
+            <div className="text-center">No Columns.</div>
+          </td>
+        </tr>
+      );
+    }
+
+    return rows;
+  },
+
+  renderNullableHeader() {
+    if (this.props.disabledColumnFields.includes('nullable')) {
+      return <th />;
+    }
+
     return (
-      <div style={{ overflow: 'scroll' }}>
-        <table className="table table-striped kbc-table-editor">
-          <thead>
-            <tr>
-              <th>Column</th>
-              <th>
-                Database Column Name
-                {this.props.editingColumns && this.props.setAllColumnsName}
-              </th>
-              <th>
-                Data Type
-                <div style={{ margin: 0 }} className="checkbox">
-                  <label className="">
-                    <input type="checkbox" label="Hide IGNORED" onChange={this.props.onToggleHideIgnored} />
-                    {' Hide Ignored'}
-                  </label>
-                </div>
-                {this.props.editingColumns && this.props.setAllColumnsType}
-              </th>
-              {this._renderNullableHeader()}
-              {this._renderDefaultHeader()}
-              <th>{this.props.editButtons}</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.count() > 0 ? (
-              rows
-            ) : (
-              <tr>
-                <td colSpan="6">
-                  <div className="text-center">No Columns.</div>
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+      <th>
+        <span>Null </span>
+        <ExternalLink href="https://help.keboola.com/writers/database/">
+          <Tooltip tooltip="Read more in documentation" placement="top">
+            <i className="fa fa-question-circle fa-fw" />
+          </Tooltip>
+        </ExternalLink>
+        {this.props.editingColumns && this._createCheckbox()}
+      </th>
     );
   },
 
-  _renderNullableHeader() {
-    if (this.props.disabledColumnFields.includes('nullable')) {
-      return <th />;
-    } else {
-      return (
-        <th>
-          <span>Null</span>{' '}
-          <Hint title="Nullable Column">
-            {'Empty strings in the source data will be replaced with SQL '}
-            <code>NULL</code>.
-          </Hint>
-          {this.props.editingColumns && this._createCheckbox()}
-        </th>
-      );
-    }
-  },
-
-  _renderDefaultHeader() {
+  renderDefaultHeader() {
     if (this.props.disabledColumnFields.includes('default')) {
       return <th />;
-    } else {
-      return <th>Default Value</th>;
     }
+
+    return <th>Default Value</th>;
   },
 
   _createCheckbox() {

--- a/src/scripts/modules/wr-db/react/pages/table/Table.jsx
+++ b/src/scripts/modules/wr-db/react/pages/table/Table.jsx
@@ -152,6 +152,12 @@ export default componentId => {
               </Alert>
               }
             </div>
+            <div className="kbc-row">
+              <h2>
+                <span>Columns</span>
+                {this.state.columns.count() && this._renderEditButtons()}
+              </h2>
+            </div>
             <ColumnsEditor
               onToggleHideIgnored={e => {
                 const path = ['hideIgnored', this.state.tableId];
@@ -166,7 +172,6 @@ export default componentId => {
               filterColumnsFn={this._hideIgnoredFilter}
               filterColumnFn={this._filterColumn}
               dataPreview={this.state.dataPreview}
-              editButtons={this._renderEditButtons()}
               setAllColumnsType={this._renderSetColumnsType()}
               setAllColumnsName={this._renderSetColumnsName()}
               disabledColumnFields={this._getDisabledColumnFields()}
@@ -517,7 +522,7 @@ export default componentId => {
         : null;
 
       return (
-        <div className="kbc-buttons pull-right">
+        <span className="pull-right">
           <EditButtons
             isEditing={!!this.state.editingColumns}
             isSaving={this.state.isSavingColumns}
@@ -527,7 +532,7 @@ export default componentId => {
             onEditStart={this._handleEditColumnsStart}
             editLabel="Edit Columns"
           />
-        </div>
+        </span>
       );
     },
 


### PR DESCRIPTION
Fixes #2789

Pár změn:
- úprava podle issue - chování nastavení null je různé a tak popis byl matoucí, přidal jsem tam tada odkaz na dokumentaci, kde si to člověk může dohledat (šlo by asi poznat ještě ten jeden level dát a nabídnou tento odkaz, druhá varianta je tam nemít vůbec odkaz)
- Edit columns button jsem hodil mimo tu tabulku, místo toho tam je normal popisek sloupce (preview)
- použil jsem Table z react-bootstrap
