### PR TITLE
GoodData Writer - change varchar limit to 10000

### DIFF
--- a/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.js
+++ b/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.js
@@ -16,8 +16,8 @@ function checkDataTypeSize(dataType, dataTypeSize) {
   switch (dataType) {
     case DataTypes.VARCHAR:
       const size = Number(dataTypeSize);
-      if (isNaN(size) || size < 1 || size > 255) {
-        return 'Data size must by valid number between 1 and 255: ' + dataTypeSize;
+      if (isNaN(size) || size < 1 || size > 10000) {
+        return 'Data size must by valid number between 1 and 10000: ' + dataTypeSize;
       }
       return false;
 

--- a/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.spec.js
+++ b/src/scripts/modules/gooddata-writer-v3/helpers/makeColumnDefinition.spec.js
@@ -68,7 +68,7 @@ describe('makeColumnDefinition', () => {
       title: 'attribute',
       type: Types.ATTRIBUTE,
       dataType: DataTypes.VARCHAR,
-      dataTypeSize: '258'
+      dataTypeSize: '10010'
     });
 
     const definition2 = makeColumnDefinition({

--- a/src/scripts/modules/gooddata-writer-v3/react/components/DataTypeSizeHint.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/DataTypeSizeHint.jsx
@@ -15,7 +15,7 @@ export default createReactClass({
     return (
       <Popover title="Maximum possible values" id="gooddata-writer-v3-data-type-hint">
         <ul className="container-fluid">
-          <li>VARCHAR – 255</li>
+          <li>VARCHAR – 10000</li>
           <li>DECIMAL - 15,6</li>
         </ul>
       </Popover>


### PR DESCRIPTION
Přistál na to požadavek na Zendesku.

Ověženo v dokumentaci že je povoleno až 10000, s tím že doporučeno je stále 255 (nevím zda to tam hodit třeba i do toho hintu).
https://help.gooddata.com/doc/en/building-on-gooddata-platform/data-modeling-and-logical-data-model/data-modeling-tutorials/changing-the-length-of-attribute-labels#ChangingtheLengthofAttributeLabels-Howtheattributelabellengthvariesinuploadeddata

Potvrzeno padádek, že je možné to zvednou https://keboola.slack.com/archives/C02CGRFK2/p1556613367006500?thread_ts=1556612142.005800&cid=C02CGRFK2