### PR TITLE
show link to storage documentation for ui-devel-preview feature

### DIFF
--- a/src/scripts/modules/storage-explorer/react/components/NavButtons.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/NavButtons.jsx
@@ -22,6 +22,9 @@ export default createReactClass({
         <li className={classnames({ active: isJobsActive })}>
           <Link to="storage-explorer-jobs">Jobs</Link>
         </li>
+        <li className={classnames({ active: isDocumentationActive})}>
+          <Link to="storage-explorer-documentation">Documentation</Link>
+        </li>
       </ul>
     );
   }

--- a/src/scripts/modules/storage-explorer/react/components/NavButtons.jsx
+++ b/src/scripts/modules/storage-explorer/react/components/NavButtons.jsx
@@ -2,6 +2,8 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import classnames from 'classnames';
 import { Link, State } from 'react-router';
+import {FEATURE_UI_DEVEL_PREVIEW} from '../../../../constants/KbcConstants';
+import ApplicationStore from '../../../../stores/ApplicationStore';
 
 export default createReactClass({
   mixins: [State],
@@ -22,9 +24,10 @@ export default createReactClass({
         <li className={classnames({ active: isJobsActive })}>
           <Link to="storage-explorer-jobs">Jobs</Link>
         </li>
-        <li className={classnames({ active: isDocumentationActive})}>
-          <Link to="storage-explorer-documentation">Documentation</Link>
-        </li>
+        {ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW) &&
+         <li className={classnames({ active: isDocumentationActive})}>
+           <Link to="storage-explorer-documentation">Documentation</Link>
+         </li>}
       </ul>
     );
   }


### PR DESCRIPTION
related to https://github.com/keboola/kbc-ui/pull/3255

Uzivatel s ui-devel-preview feature(prakticky cely dev team) ma moznost vidit storage documentation link
![image](https://user-images.githubusercontent.com/1412120/56955410-977b5780-6b41-11e9-9225-32c7667263fc.png)

Lepsie sa tak bude iterovat v dalsom vyvoji Storage Documentation issue vid https://github.com/keboola/internal/issues/148.

