### PR TITLE
Remove intl and intl-messageformat lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,6 @@
     "fuzzaldrin": "^2.1.0",
     "fuzzy": "~0.1.0",
     "immutable": "~3.7.3",
-    "intl": "^0.1.4",
-    "intl-messageformat": "^1.1.0",
     "keen-js": "^3.4.0",
     "later": "~1.1.6",
     "lodash.defaultsdeep": "^4.6.0",

--- a/src/scripts/modules/home/react/Expiration.jsx
+++ b/src/scripts/modules/home/react/Expiration.jsx
@@ -1,17 +1,9 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import moment from 'moment';
+import { AlertBlock } from '@keboola/indigo-ui';
 import contactSupport from '../../../utils/contactSupport';
-import IntlMessageFormat from 'intl-messageformat';
-import {AlertBlock} from '@keboola/indigo-ui';
-
-const MESSAGES = {
-  DAYS: '{days, plural, ' +
-  '=0 {less than a day}' +
-  '=1 {# day}' +
-  'other {# days}}'
-};
 
 export default createReactClass({
   propTypes: {
@@ -19,9 +11,7 @@ export default createReactClass({
   },
 
   render() {
-    const {expires} = this.props;
-
-    if (!expires || parseInt(this.days(), 10) > 30) {
+    if (!this.props.expires || parseInt(this.days(), 10) > 30) {
       return null;
     }
 
@@ -33,9 +23,15 @@ export default createReactClass({
   },
 
   days() {
-    // Math.round is used for compatibility with ranges computed by backend (settings page)
-    return new IntlMessageFormat(MESSAGES.DAYS).format({
-      days: Math.max(0, Math.round(moment(this.props.expires).diff(moment(), 'days', true)))
-    });
+    const days = Math.max(0, Math.round(moment(this.props.expires).diff(moment(), 'days', true)));
+
+    switch(days) {
+      case 0:
+        return 'less than a day';
+      case 1:
+        return '1 day';
+      default:
+        return `${days} days`;
+    }
   }
 });

--- a/webpack/make-config.js
+++ b/webpack/make-config.js
@@ -37,21 +37,12 @@ module.exports = function(options) {
   var entry = {};
   if (isDevelopment) {
     entry = {
-      bundle: [
-        './src/styles/kbc.less',
-        './node_modules/intl/Intl.js',
-        './node_modules/intl/locale-data/jsonp/en.js',
-        options.entry
-      ],
+      bundle: ['./src/styles/kbc.less', options.entry],
       parts: ['./src/styles/kbc.less', './src/scripts/parts']
     };
   } else {
     entry = {
-      bundle: [
-        './node_modules/intl/Intl.js',
-        './node_modules/intl/locale-data/jsonp/en.js',
-        './src/scripts/app'
-      ],
+      bundle: ['./src/scripts/app'],
       parts: ['./src/scripts/parts']
     };
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4926,20 +4926,6 @@ interpret@^1.1.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
   integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
-intl-messageformat-parser@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat-parser/-/intl-messageformat-parser-1.2.0.tgz#5906b7f953ab7470e0dc8549097b648b991892ff"
-
-intl-messageformat@^1.1.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/intl-messageformat/-/intl-messageformat-1.3.0.tgz#f7d926aded7a3ab19b2dc601efd54e99a4bd4eae"
-  dependencies:
-    intl-messageformat-parser "1.2.0"
-
-intl@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/intl/-/intl-0.1.4.tgz#bf567c6139fbbadc848618db4f578e2804812e80"
-
 invariant@^2.0.0, invariant@^2.1.0, invariant@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
Myslím zbytečné pokud to máme použito pouze na jednom místě.

Navíc tyto "staré" verze nepodporují pořádný importy a tak to je takto přímo ve webpack configu. Koukal jsem že novější verze jsou už v tom lepší. Ale právě mi přišlo lepší to vyhodil úplně.

