### PR TITLE
Table Input Mapping Modal - pass hasSourceTable prop from Header

### DIFF
--- a/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingHeader.jsx
@@ -92,6 +92,7 @@ export default createReactClass({
                 otherDestinations={this.props.otherDestinations}
                 definition={this.props.definition}
                 componentType={this.props.componentType}
+                hasSourceTable={sourceTable.count() > 0}
               />
             </span>
           </span>

--- a/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
+++ b/src/scripts/modules/components/react/components/generic/TableInputMappingModal.jsx
@@ -20,6 +20,7 @@ export default createReactClass({
     onSave: PropTypes.func.isRequired,
     otherDestinations: PropTypes.object.isRequired,
     componentType: PropTypes.string.isRequired,
+    hasSourceTable: PropTypes.bool,
     onEditStart: PropTypes.func,
     definition: PropTypes.object
   },
@@ -137,8 +138,7 @@ export default createReactClass({
   },
 
   editingNonExistentTable() {
-    return this.props.mode === MODE_EDIT
-      && this.props.tables.get(this.props.mapping.get('source'), Map()).count() === 0;
+    return this.props.mode === MODE_EDIT && !this.props.hasSourceTable;
   },
 
   handleCancel() {


### PR DESCRIPTION
Koukal jsem že ne vždy mám ten mapping z kterého tam koukám zda existuje tabulke nebo ne. Teda nemám ho hned, někdy se "načte" až po otevření modalu, tak předtím tam je špatná ikonka (eye místo edit).
Navíc to samé zjišťuji o jedno komponentu výše (právě z jiného objektu `value` místo `mapping`) tak jsem to přidal jako props.

Třeba ve `kds-team.app-mailgun` aplikaci to jde vidět.