### PR TITLE
SAPI Token canPurgeTrash permission

### DIFF
--- a/src/scripts/modules/tokens/react/components/tokenEditor/TokenEditor.jsx
+++ b/src/scripts/modules/tokens/react/components/tokenEditor/TokenEditor.jsx
@@ -114,6 +114,10 @@ export default createReactClass({
             wrapperClassName="cols-sm-offset-3 col-sm-9"
           />
         )}
+        {this.renderFormGroup(
+          'Trash',
+          this.renderTrashAccessInput()
+        )}
         {this.props.isEditing && this.renderFormGroup(
           'Manage Tokens',
           <div className="col-sm-9">
@@ -231,6 +235,43 @@ export default createReactClass({
         </div>
         <span className="help-block">
           Only files uploaded by the token are accessible
+        </span>
+      </div>
+    );
+  },
+
+  renderTrashAccessInput() {
+    const canPurgeTrash = this.props.token.get('canPurgeTrash', false);
+
+    return (
+      <div className="col-sm-9">
+        <div className="radio">
+          <label>
+            <input
+              disabled={this.props.disabled}
+              type="radio"
+              checked={canPurgeTrash}
+              onChange={() => this.props.updateToken('canPurgeTrash', true)}
+            />
+            <span>Full Access</span>
+          </label>
+        </div>
+        <span className="help-block">
+          Token can list, restore and permanently delete configurations in trash.
+        </span>
+        <div className="radio">
+          <label>
+            <input
+              disabled={this.props.disabled}
+              type="radio"
+              checked={!canPurgeTrash}
+              onChange={() => this.props.updateToken('canPurgeTrash', false)}
+            />
+            <span>Restricted Access</span>
+          </label>
+        </div>
+        <span className="help-block">
+          Token can only list and restore configurations in trash.
         </span>
       </div>
     );

--- a/src/scripts/modules/trash/react/components/DeletedComponentRow.jsx
+++ b/src/scripts/modules/trash/react/components/DeletedComponentRow.jsx
@@ -13,7 +13,8 @@ export default createReactClass({
     component: PropTypes.object.isRequired,
     configurations: PropTypes.object.isRequired,
     deletingConfigurations: PropTypes.object.isRequired,
-    restoringConfigurations: PropTypes.object.isRequired
+    restoringConfigurations: PropTypes.object.isRequired,
+    isDeleteEnabled: PropTypes.bool.isRequired
   },
 
   render() {
@@ -42,6 +43,7 @@ export default createReactClass({
             component={this.props.component}
             config={configuration}
             componentId={this.props.component.get('id')}
+            isDeleteEnabled={this.props.isDeleteEnabled}
             isDeleting={this.props.deletingConfigurations.has(configuration.get('id'))}
             isRestoring={this.props.restoringConfigurations.has(configuration.get('id'))}
             key={configuration.get('id')}

--- a/src/scripts/modules/trash/react/components/DeletedConfigurationRow.jsx
+++ b/src/scripts/modules/trash/react/components/DeletedConfigurationRow.jsx
@@ -55,30 +55,28 @@ export default createReactClass({
             </span>
         </Tooltip>
       );
-    } else {
-      return (
-        <RestoreConfigurationButton
-          tooltip="Restore"
-          isPending={this.props.isRestoring}
-          confirm={this.restoreConfirmProps()}
-        />
-      );
     }
+    return (
+      <RestoreConfigurationButton
+        tooltip="Restore"
+        isPending={this.props.isRestoring}
+        confirm={this.restoreConfirmProps()}
+      />
+    );
   },
 
   deleteButton() {
     if (!this.props.isDeleteEnabled) {
-      return (null);
-    } else {
-      return (
-        <DeleteButton
-          tooltip="Delete Forever"
-          icon="fa-times"
-          isPending={this.props.isDeleting}
-          confirm={this.deleteConfirmProps()}
-        />
-      );
+      return null;
     }
+    return (
+      <DeleteButton
+        tooltip="Delete Forever"
+        icon="fa-times"
+        isPending={this.props.isDeleting}
+        confirm={this.deleteConfirmProps()}
+      />
+    );
   },
 
   description() {

--- a/src/scripts/modules/trash/react/components/DeletedConfigurationRow.jsx
+++ b/src/scripts/modules/trash/react/components/DeletedConfigurationRow.jsx
@@ -17,6 +17,7 @@ export default createReactClass({
     config: PropTypes.object.isRequired,
     component: PropTypes.object.isRequired,
     componentId: PropTypes.string.isRequired,
+    isDeleteEnabled: PropTypes.bool.isRequired,
     isDeleting: PropTypes.bool.isRequired,
     isRestoring: PropTypes.bool.isRequired
   },
@@ -33,49 +34,51 @@ export default createReactClass({
             Removed by <strong>{this.props.config.getIn(['currentVersion', 'creatorToken', 'description'])}</strong>{' '}
             <Finished endTime={this.props.config.getIn(['currentVersion', 'created'])} />
           </span>
-          {this.buttons()}
+          <span>
+            {this.restoreButton()}
+            {this.deleteButton()}
+          </span>
         </span>
       </span>
     );
   },
 
-  buttons() {
+  restoreButton() {
     if (isObsoleteComponent(this.props.componentId)) {
       return (
-        <span>
-          <Tooltip
-            placement="top"
-            tooltip="Configuration restore is not supported by component"
-          >
+        <Tooltip
+          placement="top"
+          tooltip="Configuration restore is not supported by component"
+        >
             <span className="btn btn-link">
               <i className="fa fa-exclamation-triangle" />
             </span>
-          </Tooltip>
-          <DeleteButton
-            tooltip="Delete Forever"
-            icon="fa-times"
-            isPending={this.props.isDeleting}
-            confirm={this.deleteConfirmProps()}
-          />
-        </span>
+        </Tooltip>
       );
-    }
-
-    return (
-      <span>
+    } else {
+      return (
         <RestoreConfigurationButton
           tooltip="Restore"
           isPending={this.props.isRestoring}
           confirm={this.restoreConfirmProps()}
         />
+      );
+    }
+  },
+
+  deleteButton() {
+    if (!this.props.isDeleteEnabled) {
+      return (null);
+    } else {
+      return (
         <DeleteButton
           tooltip="Delete Forever"
           icon="fa-times"
           isPending={this.props.isDeleting}
           confirm={this.deleteConfirmProps()}
         />
-      </span>
-    );
+      );
+    }
   },
 
   description() {

--- a/src/scripts/modules/trash/react/pages/TrashIndex.jsx
+++ b/src/scripts/modules/trash/react/pages/TrashIndex.jsx
@@ -12,6 +12,7 @@ import { SearchBar } from '@keboola/indigo-ui';
 import DeletedComponentRow from '../components/DeletedComponentRow';
 import TrashHeaderButtons from '../components/TrashHeaderButtons';
 import SettingsTabs from '../../../../react/layout/SettingsTabs';
+import ApplicationStore from "../../../../stores/ApplicationStore";
 
 const typeFilterOptions = [
   {
@@ -46,7 +47,8 @@ export default createReactClass({
       installedFilteredComponents: InstalledComponentsStore.getAllDeletedFiltered(),
       deletingConfigurations: InstalledComponentsStore.getDeletingConfigurations(),
       restoringConfigurations: InstalledComponentsStore.getRestoringConfigurations(),
-      components: ComponentsStore.getAll()
+      components: ComponentsStore.getAll(),
+      sapiToken: ApplicationStore.getSapiToken(),
     };
   },
 
@@ -68,6 +70,7 @@ export default createReactClass({
           configurations={this.sortedConfigurations(component)}
           deletingConfigurations={this.state.deletingConfigurations.get(component.get('id'), Map())}
           restoringConfigurations={this.state.restoringConfigurations.get(component.get('id'), Map())}
+          isDeleteEnabled={this.canPurgeTrash()}
           key={component.get('id')}
         />
       ))
@@ -94,8 +97,12 @@ export default createReactClass({
     return 'Trash is empty';
   },
 
+  canPurgeTrash() {
+    return this.state.sapiToken.get('canPurgeTrash', false);
+  },
+
   render() {
-    const additionalActions = [
+    let additionalActions = [
       <Select
         value={this.state.filterType}
         onChange={selected => {
@@ -106,9 +113,14 @@ export default createReactClass({
         placeholder="All components"
         className="settings-trash-select"
         key="searchbar-component-filter"
-      />,
-      <TrashHeaderButtons key="searchbar-trash-header-buttons" />
+      />
     ];
+
+    if (this.canPurgeTrash()) {
+      additionalActions.push(
+        <TrashHeaderButtons key="searchbar-trash-header-buttons" />
+      );
+    }
 
     return (
       <div className="container-fluid">


### PR DESCRIPTION
Nové oprávnění pro SAPI tokeny `canPurgeTrash`, které dovoluje/zakazuje mazat konfigurace z koše.

**Nemergovat dokud nebude nasazeno v SAPI**

![image](https://user-images.githubusercontent.com/1726727/57851994-3f4f8100-77e2-11e9-822e-d97c0bdb7d85.png)
