### PR TITLE
Fix React warning - uncontrolled components, unused props atc.

### DIFF
--- a/src/scripts/modules/components/react/components/MigrationRow.jsx
+++ b/src/scripts/modules/components/react/components/MigrationRow.jsx
@@ -327,10 +327,10 @@ export default createReactClass({
                       {this.renderOrchestrationLink(row.get('id'), row.get('name'))}
                     </td>
                     <td>
-                      <Check isChecked={row.get('hasOld')} />
+                      <Check isChecked={row.get('hasOld', false)} />
                     </td>
                     <td>
-                      <Check isChecked={row.get('hasNew')} />
+                      <Check isChecked={row.get('hasNew', false)} />
                     </td>
                   </tr>
                 );

--- a/src/scripts/modules/components/react/components/generic/FileOutputMappingDetail.jsx
+++ b/src/scripts/modules/components/react/components/generic/FileOutputMappingDetail.jsx
@@ -30,13 +30,13 @@ export default createReactClass({
         <ListGroupItem className="row">
           <strong className="col-md-4">Is public</strong>
           <span className="col-md-8">
-            <Check isChecked={this.props.value.get('is_public')} />
+            <Check isChecked={this.props.value.get('is_public', false)} />
           </span>
         </ListGroupItem>
         <ListGroupItem className="row">
           <strong className="col-md-4">Is permanent</strong>
           <span className="col-md-8">
-            <Check isChecked={this.props.value.get('is_permanent')} />
+            <Check isChecked={this.props.value.get('is_permanent', false)} />
           </span>
         </ListGroupItem>
       </ListGroup>

--- a/src/scripts/modules/ex-mongodb/react/pages/index/QueryRow.jsx
+++ b/src/scripts/modules/ex-mongodb/react/pages/index/QueryRow.jsx
@@ -39,7 +39,7 @@ export default createReactClass({
           {query.get('name') ? query.get('name') : <span className="text-muted">Untitled</span>}
         </span>
         <span className="td">
-          <Check isChecked={query.get('incremental')} />
+          <Check isChecked={query.get('incremental', false)} />
         </span>
         <span className="td text-right kbc-no-wrap">
           <QueryDeleteButton

--- a/src/scripts/modules/geneea-nlp-analysis-v2/actions.js
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/actions.js
@@ -87,7 +87,7 @@ export function startEditing(configId) {
     }
     return memo.setIn([].concat(key), value);
   }, Map());
-  editingData = editingData.set('intable', getInTable(configId) || Map());
+  editingData = editingData.set('intable', getInTable(configId) || '');
   setEditingData(configId, editingData);
 }
 

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/Index.jsx
@@ -194,8 +194,8 @@ export default createReactClass({
           <SapiTableSelector
             placeholder="Select..."
             value={this.getEditingValue('intable')}
-            onSelectTableFn= {this.intableChange}
-            excludeTableFn= { () => false}/>, 'Table conatining documents to analyze')
+            onSelectTableFn={this.intableChange}
+          />, 'Table conatining documents to analyze')
         }
         {this.renderFormElement(this.renderFilterLabel(), this.renderDataFilter(), 'Input table data filtered by specified rules, the filtered columns must be indexed.')}
         {this.renderColumnSelect('Id columns', params.PRIMARYKEY, 'Column of the input table uniquely identifying a row in the table.', true)}
@@ -503,16 +503,13 @@ export default createReactClass({
         <div className="col-sm-9 ">
           <ul className="nav nav-stacked">
             <li>
-              <SapiTableLinkEx
-                tableId={`${bucketId}.analysis-result-documents`}/>
+              <SapiTableLinkEx tableId={`${bucketId}.analysis-result-documents`} />
             </li>
             <li>
-              <SapiTableLinkEx
-                tableId={`${bucketId}.analysis-result-entities`}/>
+              <SapiTableLinkEx tableId={`${bucketId}.analysis-result-entities`} />
             </li>
             <li>
-              <SapiTableLinkEx
-                tableId={`${bucketId}.analysis-result-relations`}/>
+              <SapiTableLinkEx tableId={`${bucketId}.analysis-result-relations`} />
             </li>
           </ul>
         </div>
@@ -537,15 +534,12 @@ export default createReactClass({
   },
 
   renderIntableStatic() {
-    const tableId = this.state.intable;
     const link = (
-      <p label="Input Table"
-        className="form-control-static">
-        <SapiTableLinkEx
-          tableId={tableId}/>
+      <p className="form-control-static">
+        <SapiTableLinkEx tableId={this.state.intable || ''} />
       </p>
     );
-    return this.renderFormElement((<span>Input Table</span>), link);
+    return this.renderFormElement(<span>Input Table</span>, link);
   },
 
   RenderStaticInput(label, value, isBetaCheckobx = false) {
@@ -554,9 +548,7 @@ export default createReactClass({
         <Col componentClass={ControlLabel} sm={3}>{label}</Col>
         <Col sm={9}>
           <FormControl.Static>
-            {isBetaCheckobx ? <Check
-                isChecked={value}/>
-              : value || 'n/a'}
+            {isBetaCheckobx ? <Check isChecked={!!value} /> : value || 'n/a'}
           </FormControl.Static>
         </Col>
       </FormGroup>

--- a/src/scripts/modules/gooddata-writer-v3/react/components/NewDimensionForm.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/NewDimensionForm.jsx
@@ -34,7 +34,7 @@ export default createReactClass({
         <FormGroup>
           <Col sm={9} smOffset={3}>
             <Checkbox
-              checked={value.includeTime}
+              checked={!!value.includeTime}
               onChange={() => this.handleChange({includeTime: !value.includeTime})}>
               Include Time
             </Checkbox>

--- a/src/scripts/modules/gooddata-writer-v3/react/components/PreferencesColumn.jsx
+++ b/src/scripts/modules/gooddata-writer-v3/react/components/PreferencesColumn.jsx
@@ -128,10 +128,7 @@ export default createReactClass({
       <FormControl
         componentClass="select"
         type="select"
-        autosize={false}
-        clearable={false}
         value={column[fieldName]}
-        options={options}
         onChange={e => this.onChangeColumn(fieldName, e.target.value)}
         disabled={disabled}>
         {!settings.strict && <option value=""/>}

--- a/src/scripts/modules/gooddata-writer/react/pages/date-dimensions/DateDimensionsRow.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/date-dimensions/DateDimensionsRow.jsx
@@ -25,7 +25,7 @@ export default createReactClass({
       <tr>
         <td>{dimension.get('name')}</td>
         <td>
-          <Check isChecked={dimension.get('includeTime')} />
+          <Check isChecked={dimension.get('includeTime', false)} />
         </td>
         <td>{dimension.get('identifier')}</td>
         <td>{dimension.get('template')}</td>

--- a/src/scripts/modules/gooddata-writer/react/pages/table/DateDimensionSelectModal.jsx
+++ b/src/scripts/modules/gooddata-writer/react/pages/table/DateDimensionSelectModal.jsx
@@ -131,11 +131,11 @@ export default createReactClass({
                   >
                     <div className="td">{dimension.getIn(['data', 'name'])}</div>
                     <div className="td">
-                      <Check isChecked={dimension.getIn(['data', 'includeTime'])} />
+                      <Check isChecked={dimension.getIn(['data', 'includeTime'], false)} />
                     </div>
                     <div className="td">
                       {dimension.get('name') === this.props.column.get('dateDimension') && (
-                        <Check isChecked={true} />
+                        <Check isChecked />
                       )}
                     </div>
                   </a>

--- a/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
+++ b/src/scripts/modules/orchestrations/react/pages/orchestration-tasks/TasksTableRow.jsx
@@ -53,10 +53,10 @@ export default createReactClass({
           <span className="label label-info">{this.props.task.get('action')}</span>
         </td>
         <td>
-          <Check isChecked={this.props.task.get('active')} />
+          <Check isChecked={this.props.task.get('active', false)} />
         </td>
         <td>
-          <Check isChecked={this.props.task.get('continueOnFailure')} />
+          <Check isChecked={this.props.task.get('continueOnFailure', false)} />
         </td>
         <td>
           <div className="pull-right">

--- a/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/OutputMappingRowEditor.jsx
@@ -232,7 +232,7 @@ export default createReactClass({
           <Col sm={10} smOffset={2}>
             <Checkbox
               name="incremental"
-              checked={this.props.value.get('incremental')}
+              checked={this.props.value.get('incremental', false)}
               disabled={this.props.disabled}
               onChange={this._handleChangeIncremental}
             >

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingDetail.jsx
@@ -54,7 +54,7 @@ export default createReactClass({
           <ListGroupItem className="row">
             <strong className="col-md-4">Optional</strong>
             <span className="col-md-8">
-              <Check isChecked={this.props.inputMapping.get('optional')} />
+              <Check isChecked={this.props.inputMapping.get('optional', false)} />
             </span>
           </ListGroupItem>
         )}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/OutputMappingDetail.jsx
@@ -35,7 +35,7 @@ export default createReactClass({
         <ListGroupItem className="row">
           <strong className="col-md-4">Incremental</strong>
           <span className="col-md-8">
-            <Check isChecked={this.props.outputMapping.get('incremental')} />
+            <Check isChecked={this.props.outputMapping.get('incremental', false)} />
           </span>
         </ListGroupItem>
         <ListGroupItem className="row">


### PR DESCRIPTION
React pak klasicky posílá varování že tam je undefined někdy, asi to neplatí pro všechny tyto úpravy, některé třeba budou definované vždy ale asi lepší tam mít default hodnotu. 

Mě to teď furt hlásilo v transformacích už nějakou dobu.