### PR TITLE
Storage explorer - Columns - always show datatypes

### DIFF
--- a/src/scripts/modules/components/react/components/MetadataEditField.jsx
+++ b/src/scripts/modules/components/react/components/MetadataEditField.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import ImmutableMixin from 'react-immutable-render-mixin';
 import { Map } from 'immutable';
+import Markdown from '../../../../react/common/Markdown';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import MetadataActionCreators from '../../MetadataActionCreators';
 import MetadataStore from '../../stores/MetadataStore';
@@ -17,13 +18,15 @@ export default createReactClass({
     metadataKey: PropTypes.string.isRequired,
     editElement: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
-    tooltipPlacement: PropTypes.string
+    tooltipPlacement: PropTypes.string,
+    readOnly: PropTypes.bool
   },
 
   getDefaultProps() {
     return {
       placeholder: 'Describe this ...',
-      tooltipPlacement: 'top'
+      tooltipPlacement: 'top',
+      readOnly: false
     };
   },
 
@@ -36,6 +39,12 @@ export default createReactClass({
   },
 
   render() {
+    if (this.props.readOnly) {
+      return (
+        <Markdown source={this.metadataValue()} collapsible />
+      );
+    }
+
     const EditElement = this.props.editElement;
 
     return (

--- a/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
+++ b/src/scripts/modules/storage-explorer/react/pages/Table/ColumnDetails.jsx
@@ -27,6 +27,7 @@ export default createReactClass({
     userDataType: PropTypes.object.isRequired,
     deleteUserType: PropTypes.func.isRequired,
     saveUserType: PropTypes.func.isRequired,
+    canEdit: PropTypes.bool.isRequired
   },
 
   getInitialState() {
@@ -53,6 +54,7 @@ export default createReactClass({
           metadataKey="KBC.description"
           placeholder="Describe column"
           editElement={InlineEditArea}
+          readOnly={!this.props.canEdit}
         />
         {this.renderTypeForm()}
       </div>
@@ -63,11 +65,13 @@ export default createReactClass({
     return (
       <div>
         <h3>Data types</h3>
-        <p>
-          To set a custom data type or to override the data type set by the
-          system fill the form below. Saving a blank type will remove the
-          previously set user-defined type.
-        </p>
+        {this.props.canEdit && (
+          <p>
+            To set a custom data type or to override the data type set by the
+            system fill the form below. Saving a blank type will remove the
+            previously set user-defined type.
+          </p>
+        )}
         <table className="table table-striped table-hover">
           <thead>
             <tr>
@@ -86,6 +90,7 @@ export default createReactClass({
                   value={this.state.userDataType.get(DataTypeKeys.BASE_TYPE)}
                   options={BaseTypes.map(type => ({ label: type, value: type }))}
                   onChange={this.handleBaseTypeChange}
+                  disabled={!this.props.canEdit}
                 />
               </td>
               <td>
@@ -96,6 +101,7 @@ export default createReactClass({
                   <Checkbox
                     checked={this.state.userDataType.get(DataTypeKeys.NULLABLE, false)}
                     onChange={this.handleNullableChange}
+                    disabled={!this.props.canEdit}
                   >
                     Nullable
                   </Checkbox>
@@ -103,19 +109,21 @@ export default createReactClass({
               </td>
             </tr>
           </tbody>
-          <tfoot>
-            <tr>
-              <td colSpan={4} className="text-right">
-                <Button bsStyle="success" onClick={this.handleSaveDataType} disabled={this.isDisabled()}>
-                  {this.state.isSaving ? (
-                    <span><Loader /> Saving...</span>
-                  ) : (
-                    <span>Save</span>
-                  )}
-                </Button>
-              </td>
-            </tr>
-          </tfoot>
+          {this.props.canEdit && (
+            <tfoot>
+              <tr>
+                <td colSpan={4} className="text-right">
+                  <Button bsStyle="success" onClick={this.handleSaveDataType} disabled={this.isDisabled()}>
+                    {this.state.isSaving ? (
+                      <span><Loader /> Saving...</span>
+                    ) : (
+                      <span>Save</span>
+                    )}
+                  </Button>
+                </td>
+              </tr>
+            </tfoot>
+          )}
         </table>
       </div>
     );
@@ -131,6 +139,7 @@ export default createReactClass({
         type="text"
         value={this.state.userDataType.get(DataTypeKeys.LENGTH, '')}
         onChange={this.handleLengthChange}
+        disabled={!this.props.canEdit}
         placeholder={this.state.userDataType.get(DataTypeKeys.BASE_TYPE) === 'STRING'
           ? 'Length, eg. 255'
           : 'Length, eg. 38,0'

--- a/src/scripts/react/common/InlineEditAreaStatic.jsx
+++ b/src/scripts/react/common/InlineEditAreaStatic.jsx
@@ -7,36 +7,19 @@ export default createReactClass({
   propTypes: {
     text: PropTypes.string,
     placeholder: PropTypes.string,
-    editTooltip: PropTypes.string,
     onEditStart: PropTypes.func,
     collapsible: PropTypes.bool
   },
 
   render() {
-    return <div>{this.props.text ? this.renderText() : this.renderEdit()}</div>;
-  },
-
-  renderEdit() {
-    return (
-      <div className="text-right">
-        <button className="btn btn-link" onClick={this.props.onEditStart}>
-          <span className="kbc-icon-pencil" /> {this.props.placeholder}
-        </button>
-      </div>
-    );
-  },
-
-  renderText() {
     return (
       <div>
         <div className="text-right">
           <button className="btn btn-link" onClick={this.props.onEditStart}>
-            <span className="kbc-icon-pencil" /> {this.props.placeholder}
+            <i className="kbc-icon-pencil" /> {this.props.placeholder}
           </button>
         </div>
-        <div>
-          <Markdown source={this.props.text} collapsible={this.props.collapsible}/>
-        </div>
+        {this.props.text && <Markdown source={this.props.text} collapsible={this.props.collapsible}/>}
       </div>
     );
   }


### PR DESCRIPTION
Fixes #3289

Always render a panel with header and detail about a column. Even without right to edit it.