### PR TITLE
Guide Mode not working in newest Chrome browser

### DIFF
--- a/src/scripts/modules/guide-mode/react/Wizard.jsx
+++ b/src/scripts/modules/guide-mode/react/Wizard.jsx
@@ -56,9 +56,7 @@ export default createReactClass({
           setAchievedLessonFn={setAchievedLesson}
           show={this.state.wizard.showLessonModal}
           onHide={hideWizardModalFn}
-          position="aside"
           lesson={this.state.currentLesson}
-          backdrop={true}
           scriptsBasePath={this.props.scriptsBasePath}
         />
       );

--- a/src/scripts/modules/guide-mode/react/WizardModal.jsx
+++ b/src/scripts/modules/guide-mode/react/WizardModal.jsx
@@ -15,8 +15,6 @@ export default createReactClass({
     setDirection: PropTypes.func.isRequired,
     setAchievedLessonFn: PropTypes.func.isRequired,
     show: PropTypes.bool.isRequired,
-    backdrop: PropTypes.bool.isRequired,
-    position: PropTypes.string.isRequired,
     direction: PropTypes.string.isRequired,
     step: PropTypes.number.isRequired,
     achievedStep: PropTypes.number.isRequired,
@@ -27,35 +25,36 @@ export default createReactClass({
 
   render() {
     return (
-      <div>
-        <Modal
-          show={this.props.show} onHide={this.closeLessonModal} backdrop={this.isStepBackdrop()}
-          className={'guide-wizard guide-wizard-' + this.getStepPosition()}
-        >
-          <Modal.Header closeButton>
-            { this.getStepPosition() === 'center' ? (
-              this.getModalTitleExtended()
-            ) : (
-              this.getModalTitle()
-            )}
-          </Modal.Header>
-          <Modal.Body className="guide-modal-body">
-            <TransitionGroup>
-              <CSSTransition
-                key={this.props.step}
-                classNames={'guide-wizard-animated-' + this.props.direction}
-                timeout={200}
-              >
-                {this.getModalBody()}
-              </CSSTransition>
-            </TransitionGroup>
-          </Modal.Body>
-          <Modal.Footer>
-            {this.hasPreviousStep() && this.renderButtonPrev()}
-            {this.renderButtonNext()}
-          </Modal.Footer>
-        </Modal>
-      </div>
+      <Modal
+        show={this.props.show} 
+        onHide={this.closeLessonModal} 
+        backdrop={this.isStepBackdrop()}
+        className={'guide-wizard guide-wizard-' + this.getStepPosition()}
+        enforceFocus={false}
+      >
+        <Modal.Header closeButton>
+          {this.getStepPosition() === 'center' ? (
+            this.getModalTitleExtended()
+          ) : (
+            this.getModalTitle()
+          )}
+        </Modal.Header>
+        <Modal.Body className="guide-modal-body">
+          <TransitionGroup>
+            <CSSTransition
+              key={this.props.step}
+              classNames={'guide-wizard-animated-' + this.props.direction}
+              timeout={200}
+            >
+              {this.getModalBody()}
+            </CSSTransition>
+          </TransitionGroup>
+        </Modal.Body>
+        <Modal.Footer>
+          {this.hasPreviousStep() && this.renderButtonPrev()}
+          {this.renderButtonNext()}
+        </Modal.Footer>
+      </Modal>
     );
   },
 


### PR DESCRIPTION
Fixes #3296

Asi bylo fajn na chvíli odejít, pak mě napadlo něco co máme jinde a hned to zabralo. Přesně do toho teda nevidím i když jsem si o tom četl ale hlavní že to funguje. Stačilo přidat `enforceFocus=false` k modalu. Už než jsme jen zabralo pokud jsem oddělat tabindex="-1" z divu, což mi přišlo divný. Nevím proč přes ten focus to takto začlo blbnout.

Plus jsem jen vyhodil dvě nepoužívaný props `position` a `backdrop`. Jsou čtený přímo pro danou lekci, ne takto přes props.