### PR TITLE
oAuthComponents: component flags - default value

### DIFF
--- a/src/scripts/modules/components/utils/oAuthComponents.js
+++ b/src/scripts/modules/components/utils/oAuthComponents.js
@@ -1,9 +1,10 @@
+import { List } from 'immutable';
 import InstalledComponentsActions from '../InstalledComponentsActionCreators';
 import InstalledComponentsStore from '../stores/InstalledComponentsStore';
 
 export default {
   loadComponentsWithOAuth: () => InstalledComponentsActions.loadComponents()
     .then(() => InstalledComponentsStore.getAll()
-      .filter(component => component.get('flags').contains('genericDockerUI-authorization') || component.get('id') === 'tde-exporter')
+      .filter(component => component.get('flags', List()).contains('genericDockerUI-authorization') || component.get('id') === 'tde-exporter')
       .map(component => InstalledComponentsActions.loadComponentConfigsData(component.get('id'))))
 };


### PR DESCRIPTION
Fixes #3298

Píše to undefined nebo null že tam bylo, když kouknu na https://connection.keboola.com/v2/storage tak tam žádný null nevidím, když to nemá žádný flag tak tam vidím prázdné pole. Ale vypadá to že teda někde nebyla ta property vůbec. Pak by to měla řešit default hodnota.