### PR TITLE
ex facebook: update default fb graph api versions to the latest

### DIFF
--- a/src/scripts/modules/ex-facebook/storeProvisioning.js
+++ b/src/scripts/modules/ex-facebook/storeProvisioning.js
@@ -7,9 +7,9 @@ import OauthStore from '../oauth-v2/Store';
 export const storeMixins = [InstalledComponentStore, OauthStore];
 
 const DEFAULT_VERSIONS_MAP = {
-  'keboola.ex-instagram': 'v3.2',
-  'keboola.ex-facebook-ads': 'v3.2',
-  'keboola.ex-facebook': 'v3.2'
+  'keboola.ex-instagram': 'v3.3',
+  'keboola.ex-facebook-ads': 'v3.3',
+  'keboola.ex-facebook': 'v3.3'
 };
 
 const DEFAULT_BACKEND_VERSION = 'v3.2';


### PR DESCRIPTION
vydali novu verziu `v3.3` a u marketing api(ex fb ads) budu vsetky < 3.2 od zajtra deprekovane. V tejto miniuprave dviham poslednu verziu s 3.2 na 3.3
https://developers.facebook.com/docs/graph-api/changelog