### PR TITLE
Load sandbox page immediately

### DIFF
--- a/src/scripts/modules/transformations/Routes.js
+++ b/src/scripts/modules/transformations/Routes.js
@@ -1,8 +1,5 @@
-/* eslint-disable react/no-multi-comp */
-// ^ due to false positive
 import React from 'react';
-
-
+import Promise from 'bluebird';
 import TransformationsIndex from './react/pages/transformations-index/TransformationsIndex';
 import TransformationBucket from './react/pages/transformation-bucket/TransformationBucket';
 import TransformationDetail from './react/pages/transformation-detail/TransformationDetail';
@@ -10,6 +7,7 @@ import TransformationGraph from './react/pages/transformation-graph/Transformati
 import Sandbox from './react/pages/sandbox/Sandbox';
 import InstalledComponentsActionCreators from './../components/InstalledComponentsActionCreators';
 import VersionsActionCreators from '../components/VersionsActionCreators';
+import ProvisioningActionCreators from '../provisioning/ActionCreators';
 import StorageActionCreators from '../components/StorageActionCreators';
 import TransformationsIndexReloaderButton from './react/components/TransformationsIndexReloaderButton';
 import TransformationBucketButtons from './react/components/TransformationBucketButtons';
@@ -19,6 +17,7 @@ import createVersionsPageRoute from '../../modules/components/utils/createVersio
 import createRowVersionsPageRoute from '../../modules/components/utils/createRowVersionsPageRoute';
 import ComponentNameEdit from '../components/react/components/ComponentName';
 import TransformationNameEdit from './react/components/TransformationNameEditField';
+import ApplicationsStore from '../../stores/ApplicationStore';
 import JobsActionCreators from '../jobs/ActionCreators';
 import injectProps from '../components/react/injectProps';
 import { createTablesRoute } from '../table-browser/routes';
@@ -117,7 +116,22 @@ const routes = {
     {
       name: 'sandbox',
       title: 'Sandbox',
-      defaultRouteHandler: Sandbox
+      defaultRouteHandler: Sandbox,
+      requireData: [
+        () => StorageActionCreators.loadTables(),
+        () => StorageActionCreators.loadBuckets(),
+        () => {
+          if (ApplicationsStore.getSapiToken().getIn(['owner', 'hasSnowflake'], false)) {
+            ProvisioningActionCreators.loadSnowflakeSandboxCredentials();
+          }
+          if (ApplicationsStore.getSapiToken().getIn(['owner', 'hasRedshift'], false)) {
+            ProvisioningActionCreators.loadRedshiftSandboxCredentials();
+          }
+          ProvisioningActionCreators.loadRStudioSandboxCredentials();
+          ProvisioningActionCreators.loadJupyterSandboxCredentials();
+          return Promise.resolve();
+        }
+      ]
     }
   ]
 };

--- a/src/scripts/modules/transformations/Routes.js
+++ b/src/scripts/modules/transformations/Routes.js
@@ -10,7 +10,6 @@ import TransformationGraph from './react/pages/transformation-graph/Transformati
 import Sandbox from './react/pages/sandbox/Sandbox';
 import InstalledComponentsActionCreators from './../components/InstalledComponentsActionCreators';
 import VersionsActionCreators from '../components/VersionsActionCreators';
-import ProvisioningActionCreators from '../provisioning/ActionCreators';
 import StorageActionCreators from '../components/StorageActionCreators';
 import TransformationsIndexReloaderButton from './react/components/TransformationsIndexReloaderButton';
 import TransformationBucketButtons from './react/components/TransformationBucketButtons';
@@ -20,7 +19,6 @@ import createVersionsPageRoute from '../../modules/components/utils/createVersio
 import createRowVersionsPageRoute from '../../modules/components/utils/createRowVersionsPageRoute';
 import ComponentNameEdit from '../components/react/components/ComponentName';
 import TransformationNameEdit from './react/components/TransformationNameEditField';
-import ApplicationsStore from '../../stores/ApplicationStore';
 import JobsActionCreators from '../jobs/ActionCreators';
 import injectProps from '../components/react/injectProps';
 import { createTablesRoute } from '../table-browser/routes';
@@ -118,26 +116,8 @@ const routes = {
     },
     {
       name: 'sandbox',
-      title() {
-        return 'Sandbox';
-      },
-      defaultRouteHandler: Sandbox,
-      requireData: [
-        () => {
-          if (ApplicationsStore.getSapiToken().getIn(['owner', 'hasRedshift'])) {
-            return ProvisioningActionCreators.loadRedshiftSandboxCredentials();
-          }
-        },
-        () => {
-          if (ApplicationsStore.getSapiToken().getIn(['owner', 'hasSnowflake'])) {
-            return ProvisioningActionCreators.loadSnowflakeSandboxCredentials();
-          }
-        },
-        () => ProvisioningActionCreators.loadRStudioSandboxCredentials(),
-        () => ProvisioningActionCreators.loadJupyterSandboxCredentials(),
-        () => StorageActionCreators.loadBuckets(),
-        () => StorageActionCreators.loadTables()
-      ]
+      title: 'Sandbox',
+      defaultRouteHandler: Sandbox
     }
   ]
 };

--- a/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
@@ -123,10 +123,10 @@ export default createReactClass({
               BETA
             </a>
           </span>
-          {' '}
-          {this.state.isLoading && <Loader />}
         </h4>
-        {!this.state.isLoading && (
+        {this.state.isLoading ? (
+          <span><Loader /> Loading...</span>
+        ) : (
           <div className="row">
             <div className="col-md-9">{this._renderCredentials()}</div>
             <div className="col-md-3">{this._renderControlButtons()}</div>

--- a/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/JupyterSandbox.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Immutable from 'immutable';
+import { Map, List, fromJS } from 'immutable';
+import { Loader } from '@keboola/indigo-ui';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import JupyterSandboxCredentialsStore from '../../../provisioning/stores/JupyterSandboxCredentialsStore';
 import CredentialsActionCreators from '../../../provisioning/ActionCreators';
@@ -11,27 +12,27 @@ import StorageTablesStore from '../../../components/stores/StorageTablesStore';
 import CreateDockerSandboxModal from '../modals/CreateDockerSandboxModal';
 import ExtendJupyterCredentials from '../../../provisioning/react/components/ExtendJupyterCredentials';
 
-var JupyterSandbox = createReactClass({
+export default createReactClass({
   mixins: [createStoreMixin(JupyterSandboxCredentialsStore, StorageBucketsStore, StorageTablesStore)],
-  displayName: 'JupyterSandbox',
-  getStateFromStores: function() {
+
+  getStateFromStores() {
     return {
       credentials: JupyterSandboxCredentialsStore.getCredentials(),
       validUntil: JupyterSandboxCredentialsStore.getValidUntil(),
       pendingActions: JupyterSandboxCredentialsStore.getPendingActions(),
       isLoading: JupyterSandboxCredentialsStore.getIsLoading(),
-      isLoaded: JupyterSandboxCredentialsStore.getIsLoaded(),
-      tables: StorageTablesStore.getAll(),
-      buckets: StorageBucketsStore.getAll()
+      tables: StorageTablesStore.getAll()
     };
   },
+
   getInitialState() {
     return {
       showModal: false,
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     };
   },
-  _renderCredentials: function() {
+
+  _renderCredentials() {
     return (
       <span>
         <JupyterCredentials
@@ -42,7 +43,8 @@ var JupyterSandbox = createReactClass({
       </span>
     );
   },
-  _renderControlButtons: function() {
+
+  _renderControlButtons() {
     if (this.state.credentials.get('id')) {
       return (
         <div>
@@ -87,7 +89,7 @@ var JupyterSandbox = createReactClass({
             tables={this.tablesList()}
             type="Jupyter"
             onConfigurationChange={this.onConfigurationChange}
-            disabled={this.state.sandboxConfiguration.getIn(['input', 'tables'], Immutable.List()).size === 0}
+            disabled={this.state.sandboxConfiguration.getIn(['input', 'tables'], List()).size === 0}
           />
           <button className="btn btn-link" onClick={this.openModal}>
             <i className="fa fa-fw fa-plus" />
@@ -108,7 +110,7 @@ var JupyterSandbox = createReactClass({
     );
   },
 
-  render: function() {
+  render() {
     return (
       <div className="kbc-row">
         <h4>
@@ -121,39 +123,43 @@ var JupyterSandbox = createReactClass({
               BETA
             </a>
           </span>
+          {' '}
+          {this.state.isLoading && <Loader />}
         </h4>
-        <div className="row">
-          <div className="col-md-9">{this._renderCredentials()}</div>
-          <div className="col-md-3">{this._renderControlButtons()}</div>
-        </div>
+        {!this.state.isLoading && (
+          <div className="row">
+            <div className="col-md-9">{this._renderCredentials()}</div>
+            <div className="col-md-3">{this._renderControlButtons()}</div>
+          </div>
+        )}
       </div>
     );
   },
-  _createCredentials: function() {
+
+  _createCredentials() {
     return CredentialsActionCreators.createJupyterSandboxCredentials(this.state.sandboxConfiguration.toJS());
   },
-  _dropCredentials: function() {
+
+  _dropCredentials() {
     return CredentialsActionCreators.dropJupyterSandboxCredentials();
   },
+
   handleClose() {
     this.setState({
       showModal: false,
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     });
   },
+
   openModal() {
     this.setState({ showModal: true });
   },
+
   onConfigurationChange(configuration) {
-    this.setState({ sandboxConfiguration: Immutable.fromJS(configuration) });
+    this.setState({ sandboxConfiguration: fromJS(configuration) });
   },
+
   tablesList() {
-    return this.state.tables
-      .map(function(table) {
-        return table.get('id');
-      })
-      .toList();
+    return this.state.tables.map((table) => table.get('id')).toList();
   }
 });
-
-export default JupyterSandbox;

--- a/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Immutable from 'immutable';
+import { Map, List, fromJS } from 'immutable';
+import { Loader } from '@keboola/indigo-ui';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import RStudioSandboxCredentialsStore from '../../../provisioning/stores/RStudioSandboxCredentialsStore';
 import CredentialsActionCreators from '../../../provisioning/ActionCreators';
@@ -11,27 +12,27 @@ import StorageTablesStore from '../../../components/stores/StorageTablesStore';
 import CreateDockerSandboxModal from '../modals/CreateDockerSandboxModal';
 import ExtendRStudioCredentials from '../../../provisioning/react/components/ExtendRStudioCredentials';
 
-var RStudioSandbox = createReactClass({
+export default createReactClass({
   mixins: [createStoreMixin(RStudioSandboxCredentialsStore, StorageBucketsStore, StorageTablesStore)],
-  displayName: 'RStudioSandbox',
-  getStateFromStores: function() {
+
+  getStateFromStores() {
     return {
       credentials: RStudioSandboxCredentialsStore.getCredentials(),
       validUntil: RStudioSandboxCredentialsStore.getValidUntil(),
       pendingActions: RStudioSandboxCredentialsStore.getPendingActions(),
       isLoading: RStudioSandboxCredentialsStore.getIsLoading(),
-      isLoaded: RStudioSandboxCredentialsStore.getIsLoaded(),
-      tables: StorageTablesStore.getAll(),
-      buckets: StorageBucketsStore.getAll()
+      tables: StorageTablesStore.getAll()
     };
   },
+
   getInitialState() {
     return {
       showModal: false,
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     };
   },
-  _renderCredentials: function() {
+
+  _renderCredentials() {
     return (
       <span>
         <RStudioCredentials
@@ -42,7 +43,8 @@ var RStudioSandbox = createReactClass({
       </span>
     );
   },
-  _renderControlButtons: function() {
+
+  _renderControlButtons() {
     if (this.state.credentials.get('id')) {
       return (
         <div>
@@ -87,7 +89,7 @@ var RStudioSandbox = createReactClass({
             tables={this.tablesList()}
             type="RStudio"
             onConfigurationChange={this.onConfigurationChange}
-            disabled={this.state.sandboxConfiguration.getIn(['input', 'tables'], Immutable.List()).size === 0}
+            disabled={this.state.sandboxConfiguration.getIn(['input', 'tables'], List()).size === 0}
           />
           <button className="btn btn-link" onClick={this.openModal}>
             <i className="fa fa-fw fa-plus" />
@@ -107,7 +109,7 @@ var RStudioSandbox = createReactClass({
     );
   },
 
-  render: function() {
+  render() {
     return (
       <div className="kbc-row">
         <h4>
@@ -120,39 +122,43 @@ var RStudioSandbox = createReactClass({
               BETA
             </a>
           </span>
+          {' '}
+          {this.state.isLoading && <Loader />}
         </h4>
-        <div className="row">
-          <div className="col-md-9">{this._renderCredentials()}</div>
-          <div className="col-md-3">{this._renderControlButtons()}</div>
-        </div>
+        {!this.state.isLoading && (
+          <div className="row">
+            <div className="col-md-9">{this._renderCredentials()}</div>
+            <div className="col-md-3">{this._renderControlButtons()}</div>
+          </div>
+        )}
       </div>
     );
   },
-  _createCredentials: function() {
+
+  _createCredentials() {
     return CredentialsActionCreators.createRStudioSandboxCredentials(this.state.sandboxConfiguration.toJS());
   },
-  _dropCredentials: function() {
+
+  _dropCredentials() {
     return CredentialsActionCreators.dropRStudioSandboxCredentials();
   },
+
   handleClose() {
     this.setState({
       showModal: false,
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     });
   },
+
   openModal() {
     this.setState({ showModal: true });
   },
+
   onConfigurationChange(configuration) {
-    this.setState({ sandboxConfiguration: Immutable.fromJS(configuration) });
+    this.setState({ sandboxConfiguration: fromJS(configuration) });
   },
+
   tablesList() {
-    return this.state.tables
-      .map(function(table) {
-        return table.get('id');
-      })
-      .toList();
+    return this.state.tables.map((table) => table.get('id')).toList();
   }
 });
-
-export default RStudioSandbox;

--- a/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RStudioSandbox.jsx
@@ -122,10 +122,10 @@ export default createReactClass({
               BETA
             </a>
           </span>
-          {' '}
-          {this.state.isLoading && <Loader />}
         </h4>
-        {!this.state.isLoading && (
+        {this.state.isLoading ? (
+          <span><Loader /> Loading...</span>
+        ) : (
           <div className="row">
             <div className="col-md-9">{this._renderCredentials()}</div>
             <div className="col-md-3">{this._renderControlButtons()}</div>

--- a/src/scripts/modules/transformations/react/components/RedshiftSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RedshiftSandbox.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Immutable from 'immutable';
-
+import { Map, List, fromJS } from 'immutable';
+import { Loader } from '@keboola/indigo-ui';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import RedshiftSandboxCredentialsStore from '../../../provisioning/stores/RedshiftSandboxCredentialsStore';
 import CredentialsActionCreators from '../../../provisioning/ActionCreators';
 import RedshiftCredentials from '../../../provisioning/react/components/RedshiftCredentials';
-import ConfigureSandbox from './ConfigureSandbox';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteButton from '../../../../react/common/DeleteButton';
 import StorageBucketsStore from '../../../components/stores/StorageBucketsStore';
 import StorageTablesStore from '../../../components/stores/StorageTablesStore';
 import Tooltip from './../../../../react/common/Tooltip';
 import RedshiftSSLInfoModal from './RedshiftSSLInfoModal';
+import ConfigureSandbox from './ConfigureSandbox';
 
 export default createReactClass({
   mixins: [createStoreMixin(RedshiftSandboxCredentialsStore, StorageBucketsStore, StorageTablesStore)],
@@ -22,7 +22,6 @@ export default createReactClass({
       credentials: RedshiftSandboxCredentialsStore.getCredentials(),
       pendingActions: RedshiftSandboxCredentialsStore.getPendingActions(),
       isLoading: RedshiftSandboxCredentialsStore.getIsLoading(),
-      isLoaded: RedshiftSandboxCredentialsStore.getIsLoaded(),
       tables: StorageTablesStore.getAll(),
       buckets: StorageBucketsStore.getAll()
     };
@@ -31,7 +30,7 @@ export default createReactClass({
   getInitialState() {
     return {
       showSSLInfoModal: false,
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     };
   },
 
@@ -61,10 +60,10 @@ export default createReactClass({
               runParams={() => this.state.sandboxConfiguration}
               modalOnHide={() => {
                 this.setState({
-                  sandboxConfiguration: Immutable.Map()
+                  sandboxConfiguration: Map()
                 });
               }}
-              modalRunButtonDisabled={this.state.sandboxConfiguration.get('include', Immutable.List()).size === 0}
+              modalRunButtonDisabled={this.state.sandboxConfiguration.get('include', List()).size === 0}
             >
               <ConfigureSandbox
                 backend="redshift"
@@ -72,7 +71,7 @@ export default createReactClass({
                 buckets={this.state.buckets}
                 onChange={params => {
                   this.setState({
-                    sandboxConfiguration: Immutable.fromJS(params)
+                    sandboxConfiguration: fromJS(params)
                   });
                 }}
               />
@@ -122,12 +121,14 @@ export default createReactClass({
     return (
       <div className="kbc-row">
         <h4>
-          Redshift
+          Redshift {this.state.isLoading && <Loader />}
         </h4>
-        <div className="row">
-          <div className="col-md-9">{this._renderCredentials()}</div>
-          <div className="col-md-3">{this._renderControlButtons()}</div>
-        </div>
+        {!this.state.isLoading && (
+          <div className="row">
+            <div className="col-md-9">{this._renderCredentials()}</div>
+            <div className="col-md-3">{this._renderControlButtons()}</div>
+          </div>
+        )}
       </div>
     );
   },

--- a/src/scripts/modules/transformations/react/components/RedshiftSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/RedshiftSandbox.jsx
@@ -121,9 +121,11 @@ export default createReactClass({
     return (
       <div className="kbc-row">
         <h4>
-          Redshift {this.state.isLoading && <Loader />}
+          Redshift
         </h4>
-        {!this.state.isLoading && (
+        {this.state.isLoading ? (
+          <span><Loader /> Loading...</span>
+        ) : (
           <div className="row">
             <div className="col-md-9">{this._renderCredentials()}</div>
             <div className="col-md-3">{this._renderControlButtons()}</div>

--- a/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
@@ -118,9 +118,11 @@ export default createReactClass({
     return (
       <div className="kbc-row">
         <h4>
-          Snowflake {this.state.isLoading && <Loader />}
+          Snowflake
         </h4>
-        {!this.state.isLoading && (
+        {this.state.isLoading ? (
+          <span><Loader /> Loading...</span>
+        ) : (
           <div className="row">
             <div className="col-md-9">{this._renderCredentials()}</div>
             <div className="col-md-3">{this._renderControlButtons()}</div>

--- a/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
+++ b/src/scripts/modules/transformations/react/components/SnowflakeSandbox.jsx
@@ -1,37 +1,37 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Immutable from 'immutable';
+import { Map, List, fromJS} from 'immutable';
+import { Loader } from '@keboola/indigo-ui';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import SnowflakeSandboxCredentialsStore from '../../../provisioning/stores/SnowflakeSandboxCredentialsStore';
 import CredentialsActionCreators from '../../../provisioning/ActionCreators';
 import SnowflakeCredentials from '../../../provisioning/react/components/SnowflakeCredentials';
-import ConfigureSandbox from './ConfigureSandbox';
 import RunComponentButton from '../../../components/react/components/RunComponentButton';
 import DeleteButton from '../../../../react/common/DeleteButton';
 import StorageBucketsStore from '../../../components/stores/StorageBucketsStore';
 import StorageTablesStore from '../../../components/stores/StorageTablesStore';
+import ConfigureSandbox from './ConfigureSandbox';
 
-var SnowflakeSandbox = createReactClass({
+export default createReactClass({
   mixins: [createStoreMixin(SnowflakeSandboxCredentialsStore, StorageBucketsStore, StorageTablesStore)],
-  displayName: 'SnowflakeSandbox',
-  getStateFromStores: function() {
+
+  getStateFromStores() {
     return {
       credentials: SnowflakeSandboxCredentialsStore.getCredentials(),
       pendingActions: SnowflakeSandboxCredentialsStore.getPendingActions(),
       isLoading: SnowflakeSandboxCredentialsStore.getIsLoading(),
-      isLoaded: SnowflakeSandboxCredentialsStore.getIsLoaded(),
       tables: StorageTablesStore.getAll(),
       buckets: StorageBucketsStore.getAll()
     };
   },
 
-  getInitialState: function() {
+  getInitialState() {
     return {
-      sandboxConfiguration: Immutable.Map()
+      sandboxConfiguration: Map()
     };
   },
 
-  _renderCredentials: function() {
+  _renderCredentials() {
     return (
       <span>
         <SnowflakeCredentials
@@ -42,7 +42,7 @@ var SnowflakeSandbox = createReactClass({
     );
   },
 
-  _renderControlButtons: function() {
+  _renderControlButtons() {
     const connectLink =
       'https://' + this.state.credentials.get('hostname') + '/console/login#/?returnUrl=sql/worksheet';
     if (this.state.credentials.get('id')) {
@@ -58,11 +58,11 @@ var SnowflakeSandbox = createReactClass({
               runParams={() => this.state.sandboxConfiguration.toJS()}
               modalOnHide={() => {
                 this.setState({
-                  sandboxConfiguration: Immutable.Map()
+                  sandboxConfiguration: Map()
                 });
               }}
               disabled={this.state.pendingActions.size > 0}
-              modalRunButtonDisabled={this.state.sandboxConfiguration.get('include', Immutable.List()).size === 0}
+              modalRunButtonDisabled={this.state.sandboxConfiguration.get('include', List()).size === 0}
             >
               <ConfigureSandbox
                 backend="snowflake"
@@ -70,7 +70,7 @@ var SnowflakeSandbox = createReactClass({
                 buckets={this.state.buckets}
                 onChange={params => {
                   this.setState({
-                    sandboxConfiguration: Immutable.fromJS(params)
+                    sandboxConfiguration: fromJS(params)
                   });
                 }}
               />
@@ -113,25 +113,28 @@ var SnowflakeSandbox = createReactClass({
       );
     }
   },
-  render: function() {
+
+  render() {
     return (
       <div className="kbc-row">
         <h4>
-          Snowflake
+          Snowflake {this.state.isLoading && <Loader />}
         </h4>
-        <div className="row">
-          <div className="col-md-9">{this._renderCredentials()}</div>
-          <div className="col-md-3">{this._renderControlButtons()}</div>
-        </div>
+        {!this.state.isLoading && (
+          <div className="row">
+            <div className="col-md-9">{this._renderCredentials()}</div>
+            <div className="col-md-3">{this._renderControlButtons()}</div>
+          </div>
+        )}
       </div>
     );
   },
-  _createCredentials: function() {
+
+  _createCredentials() {
     return CredentialsActionCreators.createSnowflakeSandboxCredentials();
   },
-  _dropCredentials: function() {
+
+  _dropCredentials() {
     return CredentialsActionCreators.dropSnowflakeSandboxCredentials();
   }
 });
-
-export default SnowflakeSandbox;

--- a/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
+++ b/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
@@ -13,9 +13,11 @@ import ApplicationStore from '../../../../../stores/ApplicationStore';
 
 export default createReactClass({
   getInitialState() {
+    const token = ApplicationStore.getSapiToken();
+
     return {
-      hasRedshift: ApplicationStore.getSapiToken().getIn(['owner', 'hasRedshift'], false),
-      hasSnowflake: ApplicationStore.getSapiToken().getIn(['owner', 'hasSnowflake'], false),
+      hasRedshift: token.getIn(['owner', 'hasRedshift'], false),
+      hasSnowflake: token.getIn(['owner', 'hasSnowflake'], false),
       loading: false
     };
   },

--- a/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
+++ b/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
@@ -1,23 +1,67 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
+import Promise from 'bluebird';
+
 import RedshiftSandbox from '../../components/RedshiftSandbox';
 import SnowflakeSandbox from '../../components/SnowflakeSandbox';
 import RStudioSandbox from '../../components/RStudioSandbox';
 import JupyterSandbox from '../../components/JupyterSandbox';
+import Loader from '../../../../../react/common/CustomLoader';
+import ProvisioningActionCreators from '../../../../provisioning/ActionCreators';
+import StorageActionCreators from '../../../../components/StorageActionCreators';
 import ApplicationStore from '../../../../../stores/ApplicationStore';
 
 export default createReactClass({
-  displayName: 'Sandbox',
-  render: function() {
+  getInitialState() {
+    return {
+      hasRedshift: ApplicationStore.getSapiToken().getIn(['owner', 'hasRedshift'], false),
+      hasSnowflake: ApplicationStore.getSapiToken().getIn(['owner', 'hasSnowflake'], false),
+      loading: false
+    };
+  },
+
+  componentDidMount() {
+    this.loadData();
+  },
+
+  componentWillUnmount() {
+    this.cancellablePromise && this.cancellablePromise.cancel();
+  },
+
+  render() {
     return (
       <div className="container-fluid">
         <div className="kbc-main-content">
-          {ApplicationStore.getSapiToken().getIn(['owner', 'hasRedshift'], false) && <RedshiftSandbox />}
-          {ApplicationStore.getSapiToken().getIn(['owner', 'hasSnowflake'], false) && <SnowflakeSandbox />}
-          <RStudioSandbox />
-          <JupyterSandbox />
+          {this.state.loading ? (
+            <div className="kbc-inner-padding">
+              <Loader show={this.state.loading} text="Loading data..." loaderSize="2x" />
+            </div>
+          ) : (
+            <div>
+              {this.state.hasRedshift && <RedshiftSandbox />}
+              {this.state.hasSnowflake && <SnowflakeSandbox />}
+              <RStudioSandbox />
+              <JupyterSandbox />
+            </div>
+          )}
         </div>
       </div>
     );
+  },
+
+  loadData() {
+    const promises = [
+      StorageActionCreators.loadBuckets(),
+      StorageActionCreators.loadTables(),
+      ProvisioningActionCreators.loadRStudioSandboxCredentials(),
+      ProvisioningActionCreators.loadJupyterSandboxCredentials(),
+      this.state.hasRedshift ? ProvisioningActionCreators.loadRedshiftSandboxCredentials() : false,
+      this.state.hasSnowflake ? ProvisioningActionCreators.loadSnowflakeSandboxCredentials() : false
+    ].filter(Boolean);
+
+    this.setState({ loading: true });
+    this.cancellablePromise = Promise.all(promises).finally(() => {
+      this.setState({ loading: false });
+    });
   }
 });

--- a/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
+++ b/src/scripts/modules/transformations/react/pages/sandbox/Sandbox.jsx
@@ -1,15 +1,10 @@
 import React from 'react';
 import createReactClass from 'create-react-class';
-import Promise from 'bluebird';
-
+import ApplicationStore from '../../../../../stores/ApplicationStore';
 import RedshiftSandbox from '../../components/RedshiftSandbox';
 import SnowflakeSandbox from '../../components/SnowflakeSandbox';
 import RStudioSandbox from '../../components/RStudioSandbox';
 import JupyterSandbox from '../../components/JupyterSandbox';
-import Loader from '../../../../../react/common/CustomLoader';
-import ProvisioningActionCreators from '../../../../provisioning/ActionCreators';
-import StorageActionCreators from '../../../../components/StorageActionCreators';
-import ApplicationStore from '../../../../../stores/ApplicationStore';
 
 export default createReactClass({
   getInitialState() {
@@ -17,53 +12,20 @@ export default createReactClass({
 
     return {
       hasRedshift: token.getIn(['owner', 'hasRedshift'], false),
-      hasSnowflake: token.getIn(['owner', 'hasSnowflake'], false),
-      loading: false
+      hasSnowflake: token.getIn(['owner', 'hasSnowflake'], false)
     };
-  },
-
-  componentDidMount() {
-    this.loadData();
-  },
-
-  componentWillUnmount() {
-    this.cancellablePromise && this.cancellablePromise.cancel();
   },
 
   render() {
     return (
       <div className="container-fluid">
         <div className="kbc-main-content">
-          {this.state.loading ? (
-            <div className="kbc-inner-padding">
-              <Loader show={this.state.loading} text="Loading data..." loaderSize="2x" />
-            </div>
-          ) : (
-            <div>
-              {this.state.hasRedshift && <RedshiftSandbox />}
-              {this.state.hasSnowflake && <SnowflakeSandbox />}
-              <RStudioSandbox />
-              <JupyterSandbox />
-            </div>
-          )}
+          {this.state.hasRedshift && <RedshiftSandbox />}
+          {this.state.hasSnowflake && <SnowflakeSandbox />}
+          <RStudioSandbox />
+          <JupyterSandbox />
         </div>
       </div>
     );
-  },
-
-  loadData() {
-    const promises = [
-      StorageActionCreators.loadBuckets(),
-      StorageActionCreators.loadTables(),
-      ProvisioningActionCreators.loadRStudioSandboxCredentials(),
-      ProvisioningActionCreators.loadJupyterSandboxCredentials(),
-      this.state.hasRedshift ? ProvisioningActionCreators.loadRedshiftSandboxCredentials() : false,
-      this.state.hasSnowflake ? ProvisioningActionCreators.loadSnowflakeSandboxCredentials() : false
-    ].filter(Boolean);
-
-    this.setState({ loading: true });
-    this.cancellablePromise = Promise.all(promises).finally(() => {
-      this.setState({ loading: false });
-    });
   }
 });


### PR DESCRIPTION
Koukal jsem že když kliknu v transformací na sandbox, tak to jakoby "zamrzne" na chvilku. Ono se sice vlevo ukáže že se něco načítá, ale je to takové že nevíš. Někdy to trvá i pár sekund než se něco stane.

Tak jsem si říkal že bych přesunul do načtení všech dat až do stránky sandboxu. Teda načtu stránku hned, tam začnu vše načítat a uživateli zobrazím Loading stav, ať ví co se děje.

Myslím že takto to je více UX friendy, co myslíš?