### PR TITLE
Activity Matching

### DIFF
--- a/src/scripts/modules/components/Constants.js
+++ b/src/scripts/modules/components/Constants.js
@@ -244,7 +244,9 @@ const ActionTypes = keyMirror({
 
   STORAGE_JOBS_LOAD_MORE: null,
   STORAGE_JOBS_LOAD_MORE_SUCCESS: null,
-  STORAGE_JOBS_LOAD_MORE_ERROR: null
+  STORAGE_JOBS_LOAD_MORE_ERROR: null,
+
+  ACTIVITY_MATCHING_DATA_LOADED: null
 });
 
 const GoodDataWriterModes = keyMirror({

--- a/src/scripts/modules/components/StorageActionCreators.js
+++ b/src/scripts/modules/components/StorageActionCreators.js
@@ -1038,5 +1038,12 @@ export default {
         });
         throw error;
       });
+  },
+
+  activityMatchingDataLoaded: function(data) {
+    dispatcher.handleViewAction({
+      type: constants.ActionTypes.ACTIVITY_MATCHING_DATA_LOADED,
+      data
+    });
   }
 };

--- a/src/scripts/modules/components/StorageApi.js
+++ b/src/scripts/modules/components/StorageApi.js
@@ -392,5 +392,12 @@ export default {
 
   deleteTrigger(id) {
     return createRequest('DELETE', `triggers/${id}`);
+  },
+
+  getActivityMatchingData() {
+    return request('GET', 'https://p7pjgem0zb.execute-api.eu-west-1.amazonaws.com/dev/project/match')
+      .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString())
+      .promise()
+      .then((response) => response.body);
   }
 };

--- a/src/scripts/modules/components/StorageApi.js
+++ b/src/scripts/modules/components/StorageApi.js
@@ -392,12 +392,5 @@ export default {
 
   deleteTrigger(id) {
     return createRequest('DELETE', `triggers/${id}`);
-  },
-
-  getActivityMatchingData() {
-    return request('GET', 'https://p7pjgem0zb.execute-api.eu-west-1.amazonaws.com/dev/project/match')
-      .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString())
-      .promise()
-      .then((response) => response.body);
   }
 };

--- a/src/scripts/modules/components/react/components/SapiTableSelector.jsx
+++ b/src/scripts/modules/components/react/components/SapiTableSelector.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import Select from 'react-select';
+import TableUsagesLabel from '../../../transformations/react/components/TableUsagesLabel';
 import storageActionCreators from '../../StorageActionCreators';
 import createStoreMixin from '../../../../react/mixins/createStoreMixin';
 import storageTablesStore from '../../stores/StorageTablesStore';
@@ -17,7 +18,8 @@ export default createReactClass({
     allowedBuckets: PropTypes.array,
     disabled: PropTypes.bool,
     clearable: PropTypes.bool,
-    autoFocus: PropTypes.bool
+    autoFocus: PropTypes.bool,
+    tablesUsages: PropTypes.bool
   },
 
   getDefaultProps() {
@@ -26,14 +28,16 @@ export default createReactClass({
       allowedBuckets: ['in', 'out'],
       disabled: false,
       autoFocus: false,
-      clearable: false
+      clearable: false,
+      tablesUsages: false
     };
   },
 
   getStateFromStores() {
     return {
       isTablesLoading: storageTablesStore.getIsLoading(),
-      tables: storageTablesStore.getAll()
+      tables: storageTablesStore.getAll(),
+      tablesUsages: storageTablesStore.getAllUsages(),
     };
   },
 
@@ -42,7 +46,11 @@ export default createReactClass({
   },
 
   shouldComponentUpdate(nextProps, nextState) {
-    return nextProps.value !== this.props.value || nextState.isTablesLoading !== this.state.isTablesLoading;
+    return (
+      nextProps.value !== this.props.value || 
+      nextState.isTablesLoading !== this.state.isTablesLoading ||
+      !nextState.tablesUsages.equals(this.state.tablesUsages)
+    );
   },
 
   render() {
@@ -90,10 +98,13 @@ export default createReactClass({
       })
       .sort((a, b) => a.get('id').localeCompare(b.get('id')))
       .map(table => {
-        return {
-          label: table.get('id'),
-          value: table.get('id')
-        };
+        let label = table.get('id');
+
+        if (this.props.tablesUsages) {
+          label = <span><TableUsagesLabel usages={this.state.tablesUsages.get(table.get('id'))} /> {label}</span>;
+        }
+
+        return { label, value: table.get('id') };
       })
       .toList()
       .toJS();

--- a/src/scripts/modules/components/stores/StorageTablesStore.js
+++ b/src/scripts/modules/components/stores/StorageTablesStore.js
@@ -282,7 +282,7 @@ Dispatcher.register(function(payload) {
     case constants.ActionTypes.ACTIVITY_MATCHING_DATA_LOADED:
       const usages = action.data.toMap().mapKeys((index, row) => row.get('inputTable'));
       _store = _store.set('tablesUsages', _store.get('tables').map((table) => {
-        return usages.getIn([table.get('id'), 'countRows'], 0);
+        return parseInt(usages.getIn([table.get('id'), 'countRows'], 0));
       }));
       return StorageTablesStore.emitChange();
     

--- a/src/scripts/modules/components/stores/StorageTablesStore.js
+++ b/src/scripts/modules/components/stores/StorageTablesStore.js
@@ -6,6 +6,7 @@ import * as constants from '../Constants';
 
 let _store = Map({
   tables: Map(),
+  tablesUsages: Map(),
   isLoaded: false,
   isLoading: false,
   pendingTables: Map() // (creating/loading)
@@ -14,6 +15,10 @@ let _store = Map({
 const StorageTablesStore = StoreUtils.createStore({
   getAll() {
     return _store.get('tables');
+  },
+
+  getAllUsages() {
+    return _store.get('tablesUsages');
   },
 
   hasTable(tableId) {
@@ -272,6 +277,13 @@ Dispatcher.register(function(payload) {
 
     case constants.ActionTypes.STORAGE_TABLE_EXPORT_ERROR:
       _store = _store.deleteIn(['pendingTables', 'exporting', action.tableId]);
+      return StorageTablesStore.emitChange();
+
+    case constants.ActionTypes.ACTIVITY_MATCHING_DATA_LOADED:
+      const usages = action.data.toMap().mapKeys((index, row) => row.get('inputTable'));
+      _store = _store.set('tablesUsages', _store.get('tables').map((table) => {
+        return usages.getIn([table.get('id'), 'countRows'], 0);
+      }));
       return StorageTablesStore.emitChange();
     
     case metadataConstants.ActionTypes.METADATA_SAVE_SUCCESS:

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -9,7 +9,7 @@ export default createReactClass({
   propTypes: {
     transformation: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
-    disabled: PropTypes.object.isRequired
+    disabled: PropTypes.bool.isRequired
   },
 
   getInitialState() {

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -5,7 +5,9 @@ import classnames from 'classnames';
 import { Map, fromJS } from 'immutable';
 import { Badge } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
-import StorageApi from '../../../components/StorageApi';
+import { getActivityMatchingData } from '../../../../react/admin/project-graph/GraphApi';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+import ServicesStore from '../../../services/Store';
 import ActivityMatchingModal from '../modals/ActivityMatchingModal';
 
 export default createReactClass({
@@ -65,8 +67,11 @@ export default createReactClass({
   },
 
   loadDataAndRunSearch() {
+    const token = ApplicationStore.getSapiTokenString();
+    const graphUrl = ServicesStore.getService('graph').get('url');
+
     this.setState({ isLoading: true });
-    StorageApi.getActivityMatchingData()
+    getActivityMatchingData(graphUrl, token)
       .then((data) => this.findMatches(fromJS(data || [])))
       .finally(() => {
         this.setState({ isLoading: false });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -10,6 +10,7 @@ import StorageActionCreators from '../../../components/StorageActionCreators';
 import ApplicationStore from '../../../../stores/ApplicationStore';
 import ServicesStore from '../../../services/Store';
 import ActivityMatchingModal from '../modals/ActivityMatchingModal';
+import findMatches from './activity-matching/findMatches';
 
 export default createReactClass({
   propTypes: {
@@ -78,44 +79,10 @@ export default createReactClass({
       .then((result) => fromJS(result || []))
       .then((data) => {
         StorageActionCreators.activityMatchingDataLoaded(data);
-        this.findMatches(data);
+        this.setState({ matches: findMatches(this.props.transformation, data) });
       })
       .finally(() => {
         this.setState({ isLoading: false });
       });
-  },
-
-  findMatches(data) {
-    const sources = this.props.transformation
-      .get('input')
-      .map((mapping) => mapping.get('source'))
-      .toSet()
-      .toList();
-    const tables = data
-      .filter((row) => sources.includes(row.get('inputTable')))
-      .map((row) => row.get('usedIn'));
-
-    if (sources.count() > tables.count()) {
-      return;
-    }
-
-    const matches = tables
-      .flatten(1)
-      .filter((row) => row.get('rowId') !== this.props.transformation.get('id'))
-      .groupBy((row) => row.get('rowId'))
-      .filter((configuration) => configuration.count() === sources.count())
-      .filter((configuration) => configuration.first().get('lastRunAt'))
-      .sortBy((configuration) => {
-        const lastRun = configuration.first().get('lastRunAt');
-        return -1 * new Date(lastRun).getTime();
-      })
-      .sortBy((configuration) => {
-        const status = configuration.first().get('lastRunStatus');
-        if (status === 'success') return -1;
-        if (status === 'error' || status === 'terminated') return 1;
-        return 0;
-      });
-
-    this.setState({ matches });
   }
 });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -6,6 +6,7 @@ import { Map, fromJS } from 'immutable';
 import { Badge } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import { getActivityMatchingData } from '../../../../react/admin/project-graph/GraphApi';
+import StorageActionCreators from '../../../components/StorageActionCreators';
 import ApplicationStore from '../../../../stores/ApplicationStore';
 import ServicesStore from '../../../services/Store';
 import ActivityMatchingModal from '../modals/ActivityMatchingModal';
@@ -74,7 +75,11 @@ export default createReactClass({
 
     this.setState({ isLoading: true });
     getActivityMatchingData(graphUrl, token)
-      .then((data) => this.findMatches(fromJS(data || [])))
+      .then((result) => fromJS(result || []))
+      .then((data) => {
+        StorageActionCreators.activityMatchingDataLoaded(data);
+        this.findMatches(data);
+      })
       .finally(() => {
         this.setState({ isLoading: false });
       });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { Label } from 'react-bootstrap';
+import ActivityMatchingModal from '../modals/ActivityMatchingModal';
+
+export default createReactClass({
+  propTypes: {
+    transformation: PropTypes.object.isRequired,
+    tables: PropTypes.object.isRequired
+  },
+
+  getInitialState() {
+    return {
+      showModal: false
+    };
+  },
+
+  render() {
+    return (
+      <a onClick={() => this.setState({ showModal: true })}>
+        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
+        <Label bsStyle="info">BETA</Label>
+        <ActivityMatchingModal
+          transformation={this.props.transformation}
+          tables={this.props.tables}
+          show={this.state.showModal}
+          onHide={() => this.setState({ showModal: false })}
+        />
+      </a>
+    );
+  }
+});

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -19,29 +19,29 @@ export default createReactClass({
   },
 
   render() {
-    if (this.props.disabled) {
-      return <a>{this.renderLabel()}</a>;
-    }
-
     return (
-      <a onClick={() => this.setState({ showModal: true })}>
-        {this.renderLabel()}
+      <a onClick={this.openModal} className={classnames({ 'text-muted': this.props.disabled })}>
+        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
+        <Label bsStyle="info">BETA</Label>
         <ActivityMatchingModal
           transformation={this.props.transformation}
           tables={this.props.tables}
           show={this.state.showModal}
-          onHide={() => this.setState({ showModal: false })}
+          onHide={this.closeModal}
         />
       </a>
     );
   },
 
-  renderLabel() {
-    return (
-      <span className={classnames({ 'text-muted': this.props.disabled })}>
-        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
-        <Label bsStyle="info">BETA</Label>
-      </span>
-    );
+  openModal() {
+    if (this.props.disabled) {
+      return;
+    }
+
+    this.setState({ showModal: true });
+  },
+
+  closeModal() {
+    this.setState({ showModal: false });
   }
 });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -26,7 +26,9 @@ export default createReactClass({
   },
 
   componentDidMount() {
-    this.loadDataAndRunSearch();
+    if (!this.props.disabled) {
+      this.loadDataAndRunSearch();
+    }
   },
 
   render() {

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import classnames from 'classnames';
-import { Label } from 'react-bootstrap';
+import { Map, fromJS } from 'immutable';
+import { Badge } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import StorageApi from '../../../components/StorageApi';
 import ActivityMatchingModal from '../modals/ActivityMatchingModal';
 
 export default createReactClass({
@@ -14,16 +17,24 @@ export default createReactClass({
 
   getInitialState() {
     return {
+      matches: Map(),
+      isLoading: false,
       showModal: false
     };
+  },
+
+  componentDidMount() {
+    this.loadDataAndRunSearch();
   },
 
   render() {
     return (
       <a onClick={this.openModal} className={classnames({ 'text-muted': this.props.disabled })}>
-        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
-        <Label bsStyle="info">BETA</Label>
+        {this.renderIcon()} Activity Matching{' '}
+        {!this.state.isLoading && <Badge>{this.state.matches.count()}</Badge>}
         <ActivityMatchingModal
+          matches={this.state.matches}
+          isLoading={this.state.isLoading}
           transformation={this.props.transformation}
           tables={this.props.tables}
           show={this.state.showModal}
@@ -31,6 +42,14 @@ export default createReactClass({
         />
       </a>
     );
+  },
+
+  renderIcon() {
+    if (this.state.isLoading) {
+      return <Loader className="fa-fw" />;
+    }
+
+    return <i className="fa fa-fw fa-align-justify" />;
   },
 
   openModal() {
@@ -43,5 +62,47 @@ export default createReactClass({
 
   closeModal() {
     this.setState({ showModal: false });
+  },
+
+  loadDataAndRunSearch() {
+    this.setState({ isLoading: true });
+    StorageApi.getActivityMatchingData()
+      .then((data) => this.findMatches(fromJS(data || [])))
+      .finally(() => {
+        this.setState({ isLoading: false });
+      });
+  },
+
+  findMatches(data) {
+    const sources = this.props.transformation
+      .get('input')
+      .map((mapping) => mapping.get('source'))
+      .toSet()
+      .toList();
+    const tables = data
+      .filter((row) => sources.includes(row.get('table')))
+      .map((row) => row.get('usedIn'));
+
+    if (sources.count() > tables.count()) {
+      return;
+    }
+
+    const matches = tables
+      .flatten(1)
+      .filter((row) => row.get('rowId') !== this.props.transformation.get('id'))
+      .groupBy((row) => row.get('rowId'))
+      .filter((configuration) => configuration.count() === sources.count())
+      .sortBy((configuration) => {
+        const lastRun = configuration.first().get('lastRunAt');
+        return -1 * new Date(lastRun).getTime();
+      })
+      .sortBy((configuration) => {
+        const status = configuration.first().get('lastRunStatus');
+        if (status === 'success') return -1;
+        if (status === 'error' || status === 'terminated') return 1;
+        return 0;
+      });
+
+    this.setState({ matches });
   }
 });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -1,13 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
+import classnames from 'classnames';
 import { Label } from 'react-bootstrap';
 import ActivityMatchingModal from '../modals/ActivityMatchingModal';
 
 export default createReactClass({
   propTypes: {
     transformation: PropTypes.object.isRequired,
-    tables: PropTypes.object.isRequired
+    tables: PropTypes.object.isRequired,
+    disabled: PropTypes.object.isRequired
   },
 
   getInitialState() {
@@ -17,10 +19,13 @@ export default createReactClass({
   },
 
   render() {
+    if (this.props.disabled) {
+      return <a>{this.renderLabel()}</a>;
+    }
+
     return (
       <a onClick={() => this.setState({ showModal: true })}>
-        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
-        <Label bsStyle="info">BETA</Label>
+        {this.renderLabel()}
         <ActivityMatchingModal
           transformation={this.props.transformation}
           tables={this.props.tables}
@@ -28,6 +33,15 @@ export default createReactClass({
           onHide={() => this.setState({ showModal: false })}
         />
       </a>
+    );
+  },
+
+  renderLabel() {
+    return (
+      <span className={classnames({ 'text-muted': this.props.disabled })}>
+        <i className="fa fa-fw fa-align-justify" /> Activity Matching{' '}
+        <Label bsStyle="info">BETA</Label>
+      </span>
     );
   }
 });

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -80,7 +80,7 @@ export default createReactClass({
       .toSet()
       .toList();
     const tables = data
-      .filter((row) => sources.includes(row.get('table')))
+      .filter((row) => sources.includes(row.get('inputTable')))
       .map((row) => row.get('usedIn'));
 
     if (sources.count() > tables.count()) {
@@ -92,6 +92,7 @@ export default createReactClass({
       .filter((row) => row.get('rowId') !== this.props.transformation.get('id'))
       .groupBy((row) => row.get('rowId'))
       .filter((configuration) => configuration.count() === sources.count())
+      .filter((configuration) => configuration.first().get('lastRunAt'))
       .sortBy((configuration) => {
         const lastRun = configuration.first().get('lastRunAt');
         return -1 * new Date(lastRun).getTime();

--- a/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
+++ b/src/scripts/modules/transformations/react/components/ActivityMatchingButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import classnames from 'classnames';
 import { Map, fromJS } from 'immutable';
-import { Badge } from 'react-bootstrap';
+import { Badge, Button } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
 import { getActivityMatchingData } from '../../../../react/admin/project-graph/GraphApi';
 import StorageActionCreators from '../../../components/StorageActionCreators';
@@ -35,7 +35,11 @@ export default createReactClass({
 
   render() {
     return (
-      <a onClick={this.openModal} className={classnames({ 'text-muted': this.props.disabled })}>
+      <Button
+        bsStyle="link"
+        onClick={this.openModal}
+        className={classnames({ 'text-muted': this.props.disabled }, 'btn-block')}
+      >
         {this.renderIcon()} Activity Matching{' '}
         {!this.state.isLoading && <Badge>{this.state.matches.count()}</Badge>}
         <ActivityMatchingModal
@@ -46,7 +50,7 @@ export default createReactClass({
           show={this.state.showModal}
           onHide={this.closeModal}
         />
-      </a>
+      </Button>
     );
   },
 

--- a/src/scripts/modules/transformations/react/components/TableUsagesLabel.jsx
+++ b/src/scripts/modules/transformations/react/components/TableUsagesLabel.jsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Label } from 'react-bootstrap';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+import {
+  FEATURE_UI_DEVEL_PREVIEW,
+  FEATURE_EARLY_ADOPTER_PREVIEW
+} from '../../../../constants/KbcConstants';
+
+const TableUsagesLabel = ({ usages }) => {
+  if (
+    !ApplicationStore.hasCurrentAdminFeature(FEATURE_EARLY_ADOPTER_PREVIEW) &&
+    !ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)
+  ) {
+    return null;
+  }
+
+  return (
+    <Label bsStyle={usages > 0 ? 'info' : 'default'}>
+      <i className="fa fa-fw fa-align-justify" /> {usages !== undefined ? usages : 'N/A'}
+    </Label>
+  );
+};
+
+TableUsagesLabel.propTypes = {
+  usages: PropTypes.number
+};
+
+export default TableUsagesLabel;

--- a/src/scripts/modules/transformations/react/components/activity-matching/findMatches.js
+++ b/src/scripts/modules/transformations/react/components/activity-matching/findMatches.js
@@ -1,0 +1,37 @@
+import { Map } from 'immutable';
+
+const findMatches = (transformation, data, limit = 5) => {
+  const sources = transformation
+    .get('input')
+    .map((mapping) => mapping.get('source'))
+    .toSet()
+    .toList();
+
+  const tables = data
+    .filter((row) => sources.includes(row.get('inputTable')))
+    .map((row) => row.get('usedIn'));
+
+  if (sources.count() > tables.count()) {
+    return Map();
+  }
+
+  return tables
+    .flatten(1)
+    .filter((row) => row.get('rowId') !== transformation.get('id'))
+    .groupBy((row) => row.get('rowId'))
+    .filter((configuration) => configuration.count() === sources.count())
+    .filter((configuration) => configuration.first().get('lastRunAt'))
+    .sortBy((configuration) => {
+      const lastRun = configuration.first().get('lastRunAt');
+      return -1 * new Date(lastRun).getTime();
+    })
+    .sortBy((configuration) => {
+      const status = configuration.first().get('lastRunStatus');
+      if (status === 'success') return -1;
+      if (status === 'error' || status === 'terminated') return 1;
+      return 0;
+    })
+    .slice(0, limit);
+};
+
+export default findMatches;

--- a/src/scripts/modules/transformations/react/components/activity-matching/findMatches.test.js
+++ b/src/scripts/modules/transformations/react/components/activity-matching/findMatches.test.js
@@ -1,0 +1,124 @@
+import findMatches from './findMatches';
+import { Map, OrderedMap, fromJS } from 'immutable';
+
+const transformation = fromJS({ id: 1, input: [{ source: 'prvni' }, { source: 'druha' }] });
+let data;
+
+describe('findMatches', () => {
+  it('should return empty Map when transformation has some table in IM which we have no usages data for', () => {
+    data = fromJS([{ inputTable: 'prvni' }]);
+
+    expect(Map()).toEqual(findMatches(transformation, data));
+  });
+
+  it('should return empty OrderedMap when no relevant matches is found', () => {
+    data = fromJS([
+      {
+        inputTable: 'prvni',
+        usedIn: [{ rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' }]
+      },
+      {
+        inputTable: 'druha',
+        usedIn: [{ rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' }]
+      }
+    ]);
+
+    expect(OrderedMap()).toEqual(findMatches(transformation, data));
+  });
+
+  it('should return OrderedMap with relevant matches transformations', () => {
+    data = fromJS([
+      {
+        inputTable: 'prvni',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      },
+      {
+        inputTable: 'druha',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 4, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      }
+    ]);
+
+    expect(1).toEqual(findMatches(transformation, data).count());
+  });
+
+  it('should return OrderedMap with relevant matches sorted by most recent successful run', () => {
+    data = fromJS([
+      {
+        inputTable: 'prvni',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      },
+      {
+        inputTable: 'druha',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 4, lastRunAt: '2019-02-12T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      }
+    ]);
+
+    expect(2).toEqual(findMatches(transformation, data).count());
+    expect(3).toEqual(findMatches(transformation, data).first().first().get('rowId'));
+    expect(2).toEqual(findMatches(transformation, data).last().first().get('rowId'));
+  });
+
+  it('should return OrderedMap limited by setted limit', () => {
+    data = fromJS([
+      {
+        inputTable: 'prvni',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      },
+      {
+        inputTable: 'druha',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
+        ]
+      }
+    ]);
+
+    expect(1).toEqual(findMatches(transformation, data, 1).count());
+  });
+
+  it('should filter out never runned transformations', () => {
+    data = fromJS([
+      {
+        inputTable: 'prvni',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3 }
+        ]
+      },
+      {
+        inputTable: 'druha',
+        usedIn: [
+          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
+          { rowId: 3 }
+        ]
+      }
+    ]);
+
+    expect(1).toEqual(findMatches(transformation, data).count());
+    expect(2).toEqual(findMatches(transformation, data).first().first().get('rowId'));
+  });
+});

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowDockerEditor.jsx
@@ -143,7 +143,8 @@ export default createReactClass({
               disabled={this.props.disabled}
               placeholder="Source table"
               onSelectTableFn={this._handleChangeSource}
-              autoFocus={true}
+              autoFocus
+              tablesUsages
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowRedshiftEditor.jsx
@@ -195,7 +195,8 @@ export default createReactClass({
               disabled={this.props.disabled}
               placeholder="Source table"
               onSelectTableFn={this._handleChangeSource}
-              autoFocus={true}
+              autoFocus
+              tablesUsages
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/InputMappingRowSnowflakeEditor.jsx
@@ -264,7 +264,8 @@ export default createReactClass({
               disabled={this.props.disabled}
               placeholder="Source Table"
               onSelectTableFn={this._handleChangeSource}
-              autoFocus={true}
+              autoFocus
+              tablesUsages
             />
           </Col>
         </FormGroup>

--- a/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
+++ b/src/scripts/modules/transformations/react/components/mapping/__snapshots__/InputMappingRowSnowflakeEditor.test.js.snap
@@ -35,6 +35,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok 1`] = `
         excludeTableFn={[Function]}
         onSelectTableFn={[Function]}
         placeholder="Source Table"
+        tablesUsages={true}
         value=""
       />
     </Col>
@@ -386,6 +387,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source and des
         excludeTableFn={[Function]}
         onSelectTableFn={[Function]}
         placeholder="Source Table"
+        tablesUsages={true}
         value="in.c-keboola-ex-db-mssql-464960895.products"
       />
     </Col>
@@ -737,6 +739,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         excludeTableFn={[Function]}
         onSelectTableFn={[Function]}
         placeholder="Source Table"
+        tablesUsages={true}
         value="in.c-keboola-ex-db-mssql-464960895.products"
       />
     </Col>
@@ -1089,6 +1092,7 @@ exports[`<InputMappingRowSnowflakeEditor /> should render ok with source, dest, 
         excludeTableFn={[Function]}
         onSelectTableFn={[Function]}
         placeholder="Source Table"
+        tablesUsages={true}
         value="in.c-keboola-ex-db-mssql-464960895.products"
       />
     </Col>

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -43,7 +43,7 @@ export default createReactClass({
     }
 
     if (!this.props.matches.count()) {
-      return <p>No matches with same input mappings found.</p>;
+      return <p>No relevant matches with same input mappings found.</p>;
     }
 
     return (

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -5,9 +5,8 @@ import { Map, fromJS } from 'immutable';
 import { Button, Col, Row, Modal, Well } from 'react-bootstrap';
 import { Loader, ExternalLink } from '@keboola/indigo-ui';
 import RoutesStore from '../../../../stores/RoutesStore';
-import ApplicationStore from '../../../../stores/ApplicationStore';
+import StorageApi from '../../../components/StorageApi';
 import date from '../../../../utils/date';
-import request from '../../../../utils/request';
 import JobStatusLabel from '../../../../react/common/JobStatusLabel';
 import TableSizeLabel from '../components/TableSizeLabel';
 
@@ -133,11 +132,9 @@ export default createReactClass({
 
   loadDataAndRunSearch() {
     this.setState({ isLoading: true });
-    request('GET', 'https://p7pjgem0zb.execute-api.eu-west-1.amazonaws.com/dev/project/match')
-      .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString())
-      .promise()
-      .then((response) => {
-        this.setState({ data: fromJS(response.body), isLoading: false });
+    StorageApi.getActivityMatchingData()
+      .then((data) => {
+        this.setState({ data: fromJS(data), isLoading: false });
       })
       .then(this.findMatches)
       .finally(() => {

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { Map, fromJS } from 'immutable';
+import { Button, Col, Row, Modal, Well } from 'react-bootstrap';
+import { Loader, ExternalLink } from '@keboola/indigo-ui';
+import RoutesStore from '../../../../stores/RoutesStore';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+import date from '../../../../utils/date';
+import request from '../../../../utils/request';
+import JobStatusLabel from '../../../../react/common/JobStatusLabel';
+import TableSizeLabel from '../components/TableSizeLabel';
+
+const INITIAL_STATE = {
+  data: Map(),
+  matches: Map(),
+  isLoading: false
+};
+
+export default createReactClass({
+  propTypes: {
+    transformation: PropTypes.object.isRequired,
+    tables: PropTypes.object.isRequired,
+    show: PropTypes.bool.isRequired,
+    onHide: PropTypes.func.isRequired
+  },
+
+  getInitialState() {
+    return INITIAL_STATE;
+  },
+
+  render() {
+    return (
+      <Modal
+        bsSize="large"
+        show={this.props.show}
+        onHide={this.props.onHide}
+        onEntering={this.loadDataAndRunSearch}
+        onExit={() => this.setState({ INITIAL_STATE })}
+      >
+        <Modal.Header closeButton>
+          <Modal.Title>Activity Matching</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>{this.renderBody()}</Modal.Body>
+      </Modal>
+    );
+  },
+
+  renderBody() {
+    if (this.state.isLoading) {
+      return (
+        <p>
+          <Loader /> searching matches
+        </p>
+      );
+    }
+
+    if (!this.state.matches.count()) {
+      return <p>No matches with same input mappings found.</p>;
+    }
+
+    return (
+      <div>
+        <p>
+          Looks like someone already did transformation using same inputs before. Lets save time and
+          reuse it.
+        </p>
+        {this.props.transformation
+          .get('input')
+          .map(this.renderInputMappingRow)
+          .toArray()}
+        <br />
+        {this.state.matches.map(this.renderMatch).toArray()}
+      </div>
+    );
+  },
+
+  renderInputMappingRow(mapping, idx) {
+    const sourceTable = this.props.tables.get(mapping.get('source'), Map());
+
+    return (
+      <Well key={idx} style={{ marginBottom: '5px' }}>
+        {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}{' '}
+        {mapping.get('source')}
+      </Well>
+    );
+  },
+
+  renderMatch(match, idx) {
+    const config = match.first();
+
+    return (
+      <Well key={idx}>
+        <Row>
+          <Col sm={6}>
+            <p style={{ margin: '0 0 5px', display: 'flex', alignItems: 'center' }}>
+              <strong style={{ fontSize: '1.2em', marginRight: '10px' }}>
+                {config.get('rowName')} #{config.get('rowVersion')}
+              </strong>{' '}
+              <JobStatusLabel status={config.get('lastRunStatus')} />
+            </p>
+            <p>
+              <ExternalLink href={`mailto:${config.get('configurationCreated')}`}>
+                {config.get('configurationCreated')}
+              </ExternalLink>
+            </p>
+            <Button
+              bsStyle="default"
+              bsSize="large"
+              onClick={() => this.goToTransformation(config)}
+            >
+              Check this transformation
+            </Button>
+          </Col>
+          <Col sm={6} className="text-right text-muted">
+            <p style={{ margin: '0 0 5px' }}>Last run: {date.format(config.get('lastRunAt'))}</p>
+            <p>Last edit: {date.format(config.get('rowLastModifiedAt'))}</p>
+          </Col>
+        </Row>
+      </Well>
+    );
+  },
+
+  loadDataAndRunSearch() {
+    this.setState({ isLoading: true });
+    request('GET', 'https://p7pjgem0zb.execute-api.eu-west-1.amazonaws.com/dev/project/match')
+      .set('X-StorageApi-Token', ApplicationStore.getSapiTokenString())
+      .promise()
+      .then((response) => {
+        this.setState({ data: fromJS(response.body), isLoading: false });
+      })
+      .then(this.findMatches)
+      .finally(() => {
+        this.setState({ isLoading: false });
+      });
+  },
+
+  findMatches() {
+    const sources = this.props.transformation
+      .get('input')
+      .map((mapping) => mapping.get('source'))
+      .toSet()
+      .toList();
+    const tables = this.state.data
+      .filter((row) => sources.includes(row.get('table')))
+      .map((row) => row.get('usedIn'));
+
+    if (sources.count() > tables.count()) {
+      return;
+    }
+
+    const matches = tables
+      .flatten(1)
+      .filter((row) => row.get('rowId') !== this.props.transformation.get('id'))
+      .groupBy((row) => row.get('rowId'))
+      .filter((configuration) => configuration.count() === sources.count())
+      .sortBy((configuration) => {
+        const lastRun = configuration.first().get('lastRunAt');
+        return -1 * new Date(lastRun).getTime();
+      })
+      .sortBy((configuration) => {
+        const status = configuration.first().get('lastRunStatus');
+        if (status === 'success') return -1;
+        if (status === 'error' || status === 'terminated') return 1;
+        return 0;
+      })
+      .slice(0, 3);
+
+    this.setState({ matches });
+  },
+
+  goToTransformation(config) {
+    this.props.onHide();
+    RoutesStore.getRouter().transitionTo('transformationDetail', {
+      config: config.get('configurationId'),
+      row: config.get('rowId')
+    });
+  }
+});

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -134,7 +134,7 @@ export default createReactClass({
     this.setState({ isLoading: true });
     StorageApi.getActivityMatchingData()
       .then((data) => {
-        this.setState({ data: fromJS(data) }, this.findMatches);
+        this.setState({ data: fromJS(data || []) }, this.findMatches);
       })
       .finally(() => {
         this.setState({ isLoading: false });

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -39,7 +39,9 @@ export default createReactClass({
         onExit={this.onHide}
       >
         <Modal.Header closeButton>
-          <Modal.Title>Activity Matching</Modal.Title>
+          <Modal.Title>
+            <i className="fa fa-fw fa-align-justify" /> Activity Matching
+          </Modal.Title>
         </Modal.Header>
         <Modal.Body>{this.renderBody()}</Modal.Body>
       </Modal>

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -134,9 +134,8 @@ export default createReactClass({
     this.setState({ isLoading: true });
     StorageApi.getActivityMatchingData()
       .then((data) => {
-        this.setState({ data: fromJS(data), isLoading: false });
+        this.setState({ data: fromJS(data), isLoading: false }, this.findMatches);
       })
-      .then(this.findMatches)
       .finally(() => {
         this.setState({ isLoading: false });
       });

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -134,7 +134,7 @@ export default createReactClass({
     this.setState({ isLoading: true });
     StorageApi.getActivityMatchingData()
       .then((data) => {
-        this.setState({ data: fromJS(data), isLoading: false }, this.findMatches);
+        this.setState({ data: fromJS(data) }, this.findMatches);
       })
       .finally(() => {
         this.setState({ isLoading: false });

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -65,60 +65,68 @@ export default createReactClass({
           Looks like someone already did transformation using same inputs before. Lets save time and
           reuse it.
         </p>
-        {this.props.transformation
-          .get('input')
-          .map(this.renderInputMappingRow)
-          .toArray()}
+        {this.renderInputMappingRows()}
         <br />
-        {this.state.matches.map(this.renderMatch).toArray()}
+        {this.renderMatches()}
       </div>
     );
   },
 
-  renderInputMappingRow(mapping, idx) {
-    const sourceTable = this.props.tables.get(mapping.get('source'), Map());
+  renderInputMappingRows() {
+    return this.props.transformation
+      .get('input')
+      .map((mapping, idx) => {
+        const sourceTable = this.props.tables.get(mapping.get('source'), Map());
 
-    return (
-      <Well key={idx} style={{ marginBottom: '5px' }}>
-        {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}{' '}
-        {mapping.get('source')}
-      </Well>
-    );
+        return (
+          <Well key={idx} style={{ marginBottom: '5px' }}>
+            {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}{' '}
+            {mapping.get('source')}
+          </Well>
+        );
+      })
+      .toArray();
   },
 
-  renderMatch(match, idx) {
-    const config = match.first();
+  renderMatches() {
+    return this.state.matches
+      .map((match, idx) => {
+        const config = match.first();
 
-    return (
-      <Well key={idx}>
-        <Row>
-          <Col sm={6}>
-            <p style={{ margin: '0 0 5px', display: 'flex', alignItems: 'center' }}>
-              <strong style={{ fontSize: '1.2em', marginRight: '10px' }}>
-                {config.get('rowName')} #{config.get('rowVersion')}
-              </strong>{' '}
-              <JobStatusLabel status={config.get('lastRunStatus')} />
-            </p>
-            <p>
-              <ExternalLink href={`mailto:${config.get('configurationCreated')}`}>
-                {config.get('configurationCreated')}
-              </ExternalLink>
-            </p>
-            <Button
-              bsStyle="default"
-              bsSize="large"
-              onClick={() => this.goToTransformation(config)}
-            >
-              Check this transformation
-            </Button>
-          </Col>
-          <Col sm={6} className="text-right text-muted">
-            <p style={{ margin: '0 0 5px' }}>Last run: {date.format(config.get('lastRunAt'))}</p>
-            <p>Last edit: {date.format(config.get('rowLastModifiedAt'))}</p>
-          </Col>
-        </Row>
-      </Well>
-    );
+        return (
+          <Well key={idx}>
+            <Row>
+              <Col sm={6}>
+                <p style={{ margin: '0 0 5px', display: 'flex', alignItems: 'center' }}>
+                  <strong style={{ fontSize: '1.2em', marginRight: '10px' }}>
+                    {config.get('rowName')} #{config.get('rowVersion')}
+                  </strong>{' '}
+                  <JobStatusLabel status={config.get('lastRunStatus')} />
+                </p>
+                <p>
+                  <ExternalLink href={`mailto:${config.get('configurationCreated')}`}>
+                    {config.get('configurationCreated')}
+                  </ExternalLink>
+                </p>
+                <Button
+                  bsStyle="default"
+                  bsSize="large"
+                  onClick={() => this.goToTransformation(config)}
+                >
+                  Check this transformation
+                </Button>
+              </Col>
+              <Col sm={6} className="text-right text-muted">
+                <p style={{ margin: '0 0 5px' }}>
+                  Last run: {date.format(config.get('lastRunAt'))}
+                </p>
+                <p>Last edit: {date.format(config.get('rowLastModifiedAt'))}</p>
+              </Col>
+            </Row>
+          </Well>
+        );
+      })
+      .toArray();
   },
 
   loadDataAndRunSearch() {

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -34,9 +34,9 @@ export default createReactClass({
       <Modal
         bsSize="large"
         show={this.props.show}
-        onHide={this.props.onHide}
+        onHide={this.onHide}
         onEntering={this.loadDataAndRunSearch}
-        onExit={() => this.setState({ INITIAL_STATE })}
+        onExit={this.onHide}
       >
         <Modal.Header closeButton>
           <Modal.Title>Activity Matching</Modal.Title>
@@ -169,8 +169,13 @@ export default createReactClass({
     this.setState({ matches });
   },
 
-  goToTransformation(config) {
+  onHide() {
+    this.setState(INITIAL_STATE);
     this.props.onHide();
+  },
+
+  goToTransformation(config) {
+    this.onHide();
     RoutesStore.getRouter().transitionTo('transformationDetail', {
       config: config.get('configurationId'),
       row: config.get('rowId')

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
@@ -51,6 +51,7 @@ export default createReactClass({
                   <span className="fa fa-chevron-right fa-fw" />
                 </span>,
                 <span className="td col-xs-6" key="destination">
+                  <TableUsagesLabel usages={this.props.tablesUsages.get(sourceTable.get('id'))} />
                   {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
                   {this.props.inputMapping.get('source') || 'Not set'}
                 </span>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/InputMappingRow.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 import DeleteButton from '../../../../../react/common/DeleteButton';
 import ImmutableRenderMixin from 'react-immutable-render-mixin';
+import TableUsagesLabel from '../../components/TableUsagesLabel';
 import TableSizeLabel from '../../components/TableSizeLabel';
 import TransformationTableTypeLabel from '../../components/TransformationTableTypeLabel';
 import InputMappingModal from '../../modals/InputMapping';
@@ -15,6 +16,7 @@ export default createReactClass({
   propTypes: {
     inputMapping: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
+    tablesUsages: PropTypes.object.isRequired,
     transformation: PropTypes.object.isRequired,
     bucket: PropTypes.object.isRequired,
     editingId: PropTypes.string.isRequired,
@@ -55,6 +57,7 @@ export default createReactClass({
               ]
               : [
                 <span className="td col-xs-3" key="icons">
+                  <TableUsagesLabel usages={this.props.tablesUsages.get(sourceTable.get('id'))} />
                   {sourceTable.count() > 0 && <TableSizeLabel size={sourceTable.get('dataSizeBytes')} />}
                 </span>,
                 <span className="td col-xs-4" key="source">

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -62,6 +62,7 @@ export default createReactClass({
       editingFields: TransformationsStore.getTransformationEditingFields(bucketId, transformationId),
       pendingActions: TransformationsStore.getTransformationPendingActions(bucketId, transformationId),
       tables: StorageTablesStore.getAll(),
+      tablesUsages: StorageTablesStore.getAllUsages(),
       buckets: StorageBucketsStore.getAll(),
       bucketId,
       transformationId,
@@ -139,6 +140,7 @@ export default createReactClass({
             transformations={this.state.transformations}
             pendingActions={this.state.pendingActions}
             tables={this.state.tables}
+            tablesUsages={this.state.tablesUsages}
             buckets={this.state.buckets}
             bucketId={this.state.bucketId}
             transformationId={this.state.transformationId}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -200,10 +200,11 @@ export default createReactClass({
                 />
               </li>
             )}
-            <li>
+            <li className={classnames({ disabled: this.state.transformation.get('input').count() === 0 })}>
               <ActivityMatchingButton
                 transformation={this.state.transformation}
                 tables={this.state.tables}
+                disabled={this.state.transformation.get('input').count() === 0}
               />
             </li>
             {(backend === 'redshift' ||

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -9,6 +9,8 @@ import TransformationsStore from '../../../stores/TransformationsStore';
 import TransformationBucketsStore from '../../../stores/TransformationBucketsStore';
 import StorageTablesStore from '../../../../components/stores/StorageTablesStore';
 import StorageBucketsStore from '../../../../components/stores/StorageBucketsStore';
+import ApplicationStore from '../../../../../stores/ApplicationStore';
+import { FEATURE_UI_DEVEL_PREVIEW, FEATURE_EARLY_ADOPTER_PREVIEW } from '../../../../../constants/KbcConstants'
 import RoutesStore from '../../../../../stores/RoutesStore';
 import VersionsStore from '../../../../components/stores/VersionsStore';
 import TransformationsActionCreators from '../../../ActionCreators';
@@ -200,13 +202,16 @@ export default createReactClass({
                 />
               </li>
             )}
-            <li className={classnames({ disabled: this.state.transformation.get('input').count() === 0 })}>
-              <ActivityMatchingButton
-                transformation={this.state.transformation}
-                tables={this.state.tables}
-                disabled={this.state.transformation.get('input').count() === 0}
-              />
-            </li>
+            {(ApplicationStore.hasCurrentAdminFeature(FEATURE_EARLY_ADOPTER_PREVIEW) ||
+              ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)) && (
+              <li className={classnames({ disabled: this.state.transformation.get('input').count() === 0 })}>
+                <ActivityMatchingButton
+                  transformation={this.state.transformation}
+                  tables={this.state.tables}
+                  disabled={this.state.transformation.get('input').count() === 0}
+                />
+              </li>
+            )}
             {(backend === 'redshift' ||
               backend === 'snowflake') && (
               <li>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -206,6 +206,7 @@ export default createReactClass({
               ApplicationStore.hasCurrentAdminFeature(FEATURE_UI_DEVEL_PREVIEW)) && (
               <li className={classnames({ disabled: this.state.transformation.get('input').count() === 0 })}>
                 <ActivityMatchingButton
+                  key={`${this.state.transformationId}-${this.state.transformation.get('input').count()}`}
                   transformation={this.state.transformation}
                   tables={this.state.tables}
                   disabled={this.state.transformation.get('input').count() === 0}

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetail.jsx
@@ -18,6 +18,7 @@ import Confirm from '../../../../../react/common/Confirm';
 import CreateSandboxButton from '../../components/CreateSandboxButton';
 
 import SqlDepButton from '../../components/SqlDepButton';
+import ActivityMatchingButton from '../../components/ActivityMatchingButton';
 import ValidateQueriesButton from '../../components/ValidateQueriesButton';
 import * as sandboxUtils from '../../../utils/sandboxUtils';
 
@@ -199,6 +200,12 @@ export default createReactClass({
                 />
               </li>
             )}
+            <li>
+              <ActivityMatchingButton
+                transformation={this.state.transformation}
+                tables={this.state.tables}
+              />
+            </li>
             {(backend === 'redshift' ||
               backend === 'snowflake') && (
               <li>

--- a/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/TransformationDetailStatic.jsx
@@ -42,6 +42,7 @@ export default createReactClass({
     transformations: PropTypes.object.isRequired,
     pendingActions: PropTypes.object.isRequired,
     tables: PropTypes.object.isRequired,
+    tablesUsages: PropTypes.object.isRequired,
     buckets: PropTypes.object.isRequired,
     bucketId: PropTypes.string.isRequired,
     transformationId: PropTypes.string.isRequired,
@@ -295,6 +296,7 @@ export default createReactClass({
                               bucket={this.props.bucket}
                               inputMapping={input}
                               tables={this.props.tables}
+                              tablesUsages={this.props.tablesUsages}
                               editingInputMapping={this.props.editingFields.get(`input-${key}`, input)}
                               editingId={`input-${key}`}
                               mappingIndex={key.toString()}

--- a/src/scripts/react/admin/project-graph/GraphApi.js
+++ b/src/scripts/react/admin/project-graph/GraphApi.js
@@ -8,29 +8,30 @@ function createRequest(endpoint, token, method, path) {
 const getLineageInOrganization = (endpoint, token) => {
   return createRequest(endpoint, token, 'GET', 'organization')
     .promise()
-    .then(function(response) {
-      return response.body;
-    });
+    .then((response) => response.body);
 };
 
 const getOrganizationReliability = (endpoint, token) => {
   return createRequest(endpoint, token, 'GET', 'organization/reliability')
     .promise()
-    .then(function(response) {
-      return response.body;
-    });
+    .then((response) => response.body);
 };
 
 const getProjectReliability = (endpoint, token) => {
   return createRequest(endpoint, token, 'GET', 'project/reliability')
     .promise()
-    .then(function(response) {
-      return response.body;
-    });
+    .then((response) => response.body);
 };
+
+const getActivityMatchingData = (endpoint, token) => {
+  return createRequest(endpoint, token, 'GET', 'project/match')
+    .promise()
+    .then((response) => response.body);
+}
 
 export {
   getLineageInOrganization,
   getOrganizationReliability,
-  getProjectReliability
+  getProjectReliability,
+  getActivityMatchingData
 }


### PR DESCRIPTION
Related https://github.com/keboola/internal/issues/217

Nakonec jsem to promazal ještě daleko více:
Měl jsem tam připravený Store, api, konstatny atd, ale nakonec to šlo pryč, aby to bylo pro začátek co nejjednodušší. Ten store atd tam byl hlavně kvůli té doplňkové funkci, že by to ukazovalo u tabulek label kde by byl počet rows ve kterých daná tabulka je. Jak jsem psal to bych pak potřeboval prodiskutovat, kde všude to zobrazovat a tím pádem kde všude to znovu načítat (měl jsem to v rootu transformací ale to mi přišlo moc často). 

Nově teda pouze tlačítko a samotný modal. Všechna logika je prozatím tam, request atd se pak přesune (teď jsem to měl ve StorageApi, ono by ty data šly asi pověsit rovnou do table store, ale původně jsem měl nový store abych to nemíchal, ale to beztak až pak).

Nově teda vždy po otevřené modalu:
- načtu si "aktuální" data
- vyfiltruji si pouze tabulky které mě zajímají - ty co mám v input mappingu
- najdu jiné row kde jsou použity ty samé tabulky (musí být použity všechny)
- výsledek seřadím podle posledního spuštění (aktuální data nahoru)
- nově seřadím podle výsledku joby - success nahoru - error, terminated dolů
- vrátím první 3 výsledky pokud mám, pokud nemám napíši že jsem nenašel shodu

Prozatím tam je teda pouze ta logika že musí sedět všechny inputy, to je tak domluveno. Pokud tam doporučená tabulka má i jiné inputy tak to nevadí, prostě tam jen nesmí žádná chybět.

Btw: mám tam inline styly apod, to jen kvůli zjednodušení, kdyby to pak bylo OK a mělo se to házet do produkce, ještě bych to předělal na klasické třídy a css.