### PR TITLE
Do not return undefined from promise.

### DIFF
--- a/src/scripts/modules/configurations/ConfigurationRowsActionCreators.js
+++ b/src/scripts/modules/configurations/ConfigurationRowsActionCreators.js
@@ -44,12 +44,13 @@ export default {
       .then(function(response) {
         VersionActionCreators.loadVersionsForce(componentId, configurationId);
         createCallback(response.id);
-        return Dispatcher.handleViewAction({
+        Dispatcher.handleViewAction({
           type: Constants.ActionTypes.CONFIGURATION_ROWS_CREATE_SUCCESS,
           componentId: componentId,
           configurationId: configurationId,
           data: response
         });
+        return null;
       }).catch(function(e) {
         Dispatcher.handleViewAction({
           type: Constants.ActionTypes.CONFIGURATION_ROWS_CREATE_ERROR,

--- a/src/scripts/modules/guide-mode/stores/ActionCreators.js
+++ b/src/scripts/modules/guide-mode/stores/ActionCreators.js
@@ -37,7 +37,7 @@ export const setAchievedLesson = (lessonId) => {
 };
 
 export const showWizardModalFn = (lessonNumber) => {
-  return Dispatcher.handleViewAction({
+  Dispatcher.handleViewAction({
     type: ActionTypes.GUIDE_MODE_UPDATE_MODAL_STATE,
     showLessonModal: true,
     step: 0,


### PR DESCRIPTION
Super drobnost, jen zamezí zobrazení varování Bluebirdu že mám unhandled promise. 
Už se to řešilo, toto jen je nové nebo se to zapomnělo. U toho `showWizardModalFn` to nic nedělá ale beztak tam nemusí být return.