### PR TITLE
CodeMirror - JSON - set default tab size to 2

### DIFF
--- a/src/scripts/modules/apify/react/Index/Index.jsx
+++ b/src/scripts/modules/apify/react/Index/Index.jsx
@@ -293,6 +293,7 @@ export default createReactClass({
             readOnly: true,
             lineWrapping: true,
             cursorHeight: 0,
+            tabSize: 2,
           }}
         />
       </div>

--- a/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
+++ b/src/scripts/modules/apify/react/Index/TabbedWizard.jsx
@@ -164,6 +164,7 @@ export default createReactClass({
                 lineWrapping: true,
                 autofocus: false,
                 lint: true,
+                tabSize: 2,
                 gutters: ['CodeMirror-lint-markers']
               }}
             />
@@ -198,6 +199,7 @@ export default createReactClass({
           lineWrapping: true,
           autofocus: false,
           lint: true,
+          tabSize: 2,
           gutters: ['CodeMirror-lint-markers']
         }}
       />

--- a/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/ConfigurationEdit.jsx
@@ -76,6 +76,7 @@ export default createReactClass({
             lineWrapping: true,
             readOnly: this.props.isSaving,
             lint: true,
+            tabSize: 2,
             gutters: ['CodeMirror-lint-markers']
           }}
         />

--- a/src/scripts/modules/components/react/components/ProcessorsInput.jsx
+++ b/src/scripts/modules/components/react/components/ProcessorsInput.jsx
@@ -26,6 +26,7 @@ export default createReactClass({
                 lineNumbers: true,
                 lineWrapping: true,
                 lint: !!this.props.value,
+                tabSize: 2,
                 readOnly: this.props.disabled,
                 gutters: ['CodeMirror-lint-markers'],
                 placeholder: JSON.stringify({before: [], after: []}, null, 2)

--- a/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
+++ b/src/scripts/modules/components/react/components/TemplatedConfigurationEdit.jsx
@@ -94,6 +94,7 @@ export default createReactClass({
             lineWrapping: true,
             readOnly: this.props.isSaving,
             lint: true,
+            tabSize: 2,
             gutters: ['CodeMirror-lint-markers'],
             placeholder: '{}'
           }}

--- a/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
+++ b/src/scripts/modules/configurations/react/components/JsonConfigurationInput.jsx
@@ -26,6 +26,7 @@ export default createReactClass({
                 lineNumbers: true,
                 lint: true,
                 lineWrapping: true,
+                tabSize: 2,
                 readOnly: this.props.disabled,
                 gutters: ['CodeMirror-lint-markers']
               }}

--- a/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-mongodb/react/components/QueryEditor.jsx
@@ -87,6 +87,7 @@ export default createReactClass({
                   lineNumbers: true,
                   lineWrapping: true,
                   lint: true,
+                  tabSize: 2,
                   placeholder: 'optional, e.g. {"isActive": 1, "isDeleted": 0}'
                 }}
               />
@@ -107,6 +108,7 @@ export default createReactClass({
                   lineNumbers: true,
                   lineWrapping: true,
                   lint: true,
+                  tabSize: 2,
                   placeholder: 'optional, e.g. {"creationDate": -1}'
                 }}
               />
@@ -182,6 +184,7 @@ export default createReactClass({
                 lineNumbers: true,
                 lineWrapping: true,
                 lint: true,
+                tabSize: 2,
                 placeholder: 'e.g. {"_id.$oid": "id", "name": "name"}'
               }}
             />

--- a/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
+++ b/src/scripts/modules/geneea-nlp-analysis-v2/react/AdvancedSettings.jsx
@@ -33,6 +33,7 @@ export default createReactClass({
             lineWrapping: true,
             readOnly: this.props.isSaving,
             lint: true,
+            tabSize: 2,
             gutters: ['CodeMirror-lint-markers']
           }}
         />
@@ -49,7 +50,8 @@ export default createReactClass({
           lineNumbers: true,
           readOnly: true,
           lineWrapping: true,
-          cursorHeight: 0
+          cursorHeight: 0,
+          tabSize: 2,
         }}
       />
     );

--- a/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
+++ b/src/scripts/modules/orchestrations/react/modals/TaskParametersEdit.jsx
@@ -53,6 +53,7 @@ export default createReactClass({
           lineNumbers: true,
           lineWrapping: true,
           lint: true,
+          tabSize: 2,
           gutters: ['CodeMirror-lint-markers']
         }}
       />


### PR DESCRIPTION
Koukám že default tabSize je 4 ale mi to pak "vždy" převádíme na 2. 
Tak jsem nastavil rovnou 2, bude to častěji sedět a nezmění se "obsah" po uložení. 