### PR TITLE
Transformations - OpenRefine - Input mapping fix

### DIFF
--- a/src/scripts/modules/transformations/react/modals/InputMapping.jsx
+++ b/src/scripts/modules/transformations/react/modals/InputMapping.jsx
@@ -117,7 +117,11 @@ export default createReactClass({
   },
 
   editingNonExistentTable() {
-    return this.props.mode === MODE_EDIT && this.props.tables.get(this.props.mapping.get('source'), Map()).count() === 0;
+    return (
+      this.props.mode === MODE_EDIT &&
+      this.props.tables.get(this.props.mapping.get('source'), Map()).count() === 0 &&
+      this.props.type !== 'openrefine'
+    );
   },
 
   handleOpenButtonLink(e) {


### PR DESCRIPTION
Divné že to nikdo nereportoval, asi jak je to BETA tak se to moc nepoužívá.

Nešlo přidat Input Mapping po založení nové OpenRefine transformace. Nevím zda nejlepší způsob jak to vyřešit je takto to nehlídat pro ten `openrefine` ale myslím že by to mělo být ok.

Asi další varianta je koukat zda mám `definition.count() > 0`. V případě teda že se to definuje pouze pro openrefine, ale to je pak čitelnější zase použít ten typ asi.