### PR TITLE
Ex Email Attachments - Select, Form fixes

### DIFF
--- a/src/scripts/modules/ex-email-attachments/react/ConfigurationForm.jsx
+++ b/src/scripts/modules/ex-email-attachments/react/ConfigurationForm.jsx
@@ -1,15 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-
-import {FormGroup, FormControl, Form, ControlLabel, Col, Checkbox, HelpBlock, Accordion, Panel} from 'react-bootstrap';
+import { List } from 'immutable';
+import Select from 'react-select';
+import {FormGroup, FormControl, ControlLabel, Col, Checkbox, HelpBlock, Accordion, Panel} from 'react-bootstrap';
 import CsvDelimiterInput from '../../../react/common/CsvDelimiterInput';
 import SaveButtons from '../../../react/common/SaveButtons';
-import Select from '../../../react/common/Select';
 
 export default createReactClass({
-
   propTypes: {
     requestedEmail: PropTypes.string.isRequired,
     incremental: PropTypes.bool.isRequired,
@@ -40,7 +38,7 @@ export default createReactClass({
   },
 
   onChangePrimaryKey(value) {
-    this.props.onChange('primaryKey', value);
+    this.props.onChange('primaryKey', List(value));
   },
 
   renderButtons() {
@@ -75,15 +73,14 @@ export default createReactClass({
   },
 
   render() {
-    const component = this;
     return (
       <Accordion
         className="kbc-accordion"
-        onSelect={function(activeTab) {
-          if (activeTab === component.state.accordionActiveTab) {
-            component.setState({accordionActiveTab: null});
+        onSelect={(activeTab) => {
+          if (activeTab === this.state.accordionActiveTab) {
+            this.setState({accordionActiveTab: null});
           } else {
-            component.setState({accordionActiveTab: activeTab});
+            this.setState({accordionActiveTab: activeTab});
           }
         }}
         defaultActiveKey="settings"
@@ -92,7 +89,7 @@ export default createReactClass({
           header={this.accordionHeader('Import Settings', this.state.accordionActiveTab === 'settings')}
           eventKey="settings"
         >
-          <Form horizontal>
+          <div className="form-horizontal">
             {this.renderButtons()}
             <br/>
             <CsvDelimiterInput
@@ -123,21 +120,17 @@ export default createReactClass({
                 Primary Key
               </Col>
               <Col sm={8}>
-                <Select
-                  name="primaryKey"
-                  value={this.props.primaryKey}
-                  multi={true}
-                  allowCreate={true}
-                  delimiter=","
+                <Select.Creatable
+                  multi
                   placeholder="Add a column"
-                  emptyStrings={false}
+                  value={this.props.primaryKey.toJS()}
                   onChange={this.onChangePrimaryKey}
                 />
                 <HelpBlock>Primary key of the table. If a primary key is set, updates can be done on the table by selecting <strong>incremental loads</strong>. The primary key can consist of multiple columns.</HelpBlock>
               </Col>
             </FormGroup>
             <FormGroup>
-              <Col sm={8} smPush={4}>
+              <Col sm={8} smOffset={4}>
                 <Checkbox
                   checked={this.props.incremental}
                   onChange={this.onChangeIncremental}>
@@ -147,7 +140,7 @@ export default createReactClass({
                   a primary key will have rows updated, tables without a primary key will have rows appended.</HelpBlock>
               </Col>
             </FormGroup>
-          </Form>
+          </div>
         </Panel>
       </Accordion>
     );

--- a/src/scripts/modules/ex-email-attachments/react/Index.jsx
+++ b/src/scripts/modules/ex-email-attachments/react/Index.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import createReactClass from 'create-react-class';
 
 import storeProvisioning, {storeMixins} from '../storeProvisioning';
-import InstalledComponentStore from '../../components/stores/InstalledComponentsStore';
 import RoutesStore from '../../../stores/RoutesStore';
 import createStoreMixin from '../../../react/mixins/createStoreMixin';
 
@@ -21,18 +20,16 @@ import ScheduleConfigurationButton from '../../components/react/components/Sched
 import SidebarJobsContainer from '../../components/react/components/SidebarJobsContainer';
 import ConfigurationForm from './ConfigurationForm';
 import StorageTablesStore from '../../components/stores/StorageTablesStore';
-import StorageBucketsStore from '../../components/stores/StorageBucketsStore';
 import ClipboardButton from '../../../react/common/Clipboard';
 import SapiTableLinkEx from '../../components/react/components/StorageApiTableLinkEx';
 import getDefaultBucket from '../../../utils/getDefaultBucket';
-import {Alert, FormGroup, FormControl, Form, ControlLabel, Col, InputGroup, Button, HelpBlock} from 'react-bootstrap';
+import {Alert, FormGroup, FormControl, ControlLabel, Col, InputGroup, Button, HelpBlock} from 'react-bootstrap';
 import Processors from '../../components/react/components/Processors';
-
 
 const COMPONENT_ID = 'keboola.ex-email-attachments';
 
 export default createReactClass({
-  mixins: [createStoreMixin(...storeMixins, InstalledComponentStore, StorageTablesStore, StorageBucketsStore)],
+  mixins: [createStoreMixin(...storeMixins, StorageTablesStore)],
 
   getStateFromStores() {
     const configId = RoutesStore.getCurrentRouteParam('config');
@@ -43,7 +40,6 @@ export default createReactClass({
       configId: configId,
       store: store,
       actions: actions,
-      tables: StorageTablesStore.getAll(),
       localState: store.getLocalState(),
       settings: store.settings,
       processors: store.processors
@@ -71,7 +67,7 @@ export default createReactClass({
         </Col>
         <Col sm={8}>
           <InputGroup>
-            <SapiTableLinkEx tableId={this.getDefaultBucketName()}/>
+            <SapiTableLinkEx tableId={this.getDefaultBucketName()} />
           </InputGroup>
           <HelpBlock>
             Table in Storage, where the .csv attachments will be imported. If the table or bucket does not exist, it will be created.
@@ -94,10 +90,10 @@ export default createReactClass({
           {this.state.store.requestedEmail ?
             <div>
               <div className="kbc-inner-padding kbc-inner-padding-with-bottom-border">
-                <Form horizontal>
+                <div className="form-horizontal">
                   <FormGroup>
                     <Col componentClass={ControlLabel} sm={4}>
-                  Email address
+                      Email address
                     </Col>
                     <Col sm={8}>
                       <InputGroup>
@@ -120,7 +116,7 @@ export default createReactClass({
                     </Col>
                   </FormGroup>
                   {this.renderImportedResult()}
-                </Form>
+                </div>
               </div>
               <ConfigurationForm
                 incremental={this.state.settings.get('incremental')}
@@ -185,16 +181,15 @@ export default createReactClass({
   renderInitConfig() {
     if (this.state.store.error) {
       return this.renderError();
-    } else {
-      // if we either have email or it is being generated
-      return (
-        <div className="kbc-inner-padding kbc-inner-padding-with-bottom-border">
-          <p>
-            <RefreshIcon isLoading={true}/> Generating email address, please wait.
-          </p>
-        </div>
-      );
     }
+
+    return (
+      <div className="kbc-inner-padding kbc-inner-padding-with-bottom-border">
+        <p>
+          <RefreshIcon isLoading /> Generating email address, please wait.
+        </p>
+      </div>
+    );
   },
 
   renderError() {


### PR DESCRIPTION
Fixes #3325

Chyba asi byla v Selectu, předělal jsem to přímo na `react-select`.
Koukal jsem že někdy tam byl `List` pak zas prázdné pole. Tak jsem to upravil aby to byl vždy `List`.

Rovnou jsem projel zbytek modulu zběžně když má jen 2 soubory. Jen menší věci jsem upravoval.

- vyhodil jsem `Form` bez akce aby nešlo odesílat enterem "pryč"
- vyhodil jsem nějaké story které nebyly použity, StorageTablesStore tam není použitý také přímo ale bez něj to hlásí "varování" ani jsme přesně nedohledal proč. Mrknu ještě v týdnu na to
