### PR TITLE
fix (ExternalProjectLink): don't trim last character from project url

### DIFF
--- a/src/scripts/modules/components/react/components/ExternalProjectLink.jsx
+++ b/src/scripts/modules/components/react/components/ExternalProjectLink.jsx
@@ -1,9 +1,10 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
-import ApplicationStore from '../../../../stores/ApplicationStore';
 import { ExternalLink } from '@keboola/indigo-ui';
 import _ from 'underscore';
+import { trim, rtrim } from 'underscore.string';
+import ApplicationStore from '../../../../stores/ApplicationStore';
 
 export default createReactClass({
   propTypes: {
@@ -16,7 +17,8 @@ export default createReactClass({
     const projectPath = _.template(ApplicationStore.getProjectUrlTemplate())({
       projectId: this.props.projectId
     });
-    return this.props.stackUrl + projectPath.substring(1, projectPath.length);
+
+    return `${rtrim(this.props.stackUrl, '/')}/${trim(projectPath, '/')}`;
   },
 
   render() {
@@ -30,5 +32,4 @@ export default createReactClass({
       return this.props.children;
     }
   }
-
 });

--- a/src/scripts/modules/components/react/components/ExternalProjectLink.jsx
+++ b/src/scripts/modules/components/react/components/ExternalProjectLink.jsx
@@ -16,7 +16,7 @@ export default createReactClass({
     const projectPath = _.template(ApplicationStore.getProjectUrlTemplate())({
       projectId: this.props.projectId
     });
-    return this.props.stackUrl + projectPath.substring(1, projectPath.length - 1);
+    return this.props.stackUrl + projectPath.substring(1, projectPath.length);
   },
 
   render() {


### PR DESCRIPTION
Drobny fix, v Storage Writeri v Target Project, to usekavalo posledny znak z url projektu, takze tam bolo nespravne ID projektu.

![Alt text](https://monosnap.com/image/LKDfkbtqjRMqHvCeMpoUbdjkCLToDh)