### PR TITLE
Ex-DB-Pgsql - individually load tables and columns

### DIFF
--- a/src/scripts/constants/KbcConstants.js
+++ b/src/scripts/constants/KbcConstants.js
@@ -31,6 +31,7 @@ const ActionTypes = keyMirror({
 const FEATURE_UI_DEVEL_PREVIEW = 'ui-devel-preview';
 const FEATURE_EARLY_ADOPTER_PREVIEW = 'early-adopter-preview';
 const FEATURE_UI_LOOKER_PREVIEW = 'ui-looker-preview';
+const FEATURE_PGSQL_SPLIT_LOADING = 'pgsql-split-loading';
 
 const lookerPreviewHideComponents = [
   'cleveranalytics.wr-clever-analytics',
@@ -51,5 +52,6 @@ export {
   FEATURE_UI_DEVEL_PREVIEW,
   FEATURE_EARLY_ADOPTER_PREVIEW,
   FEATURE_UI_LOOKER_PREVIEW,
+  FEATURE_PGSQL_SPLIT_LOADING,
   lookerPreviewHideComponents
 };

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -545,7 +545,7 @@ export function createActions(componentId) {
           } else if (data.status === 'success') {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, null);
           }
-          if (queryId && data.tables.length > 0) {
+          if (queryId && data.tables && data.tables.length > 0) {
             const tables = store.getSourceTables().map((table) => {
               if (table.get('name') === data.tables[0].name && table.get('schema') === data.tables[0].schema) {
                 return fromJS(data.tables[0]);

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -545,18 +545,15 @@ export function createActions(componentId) {
           } else if (data.status === 'success') {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, null);
           }
-          if (queryId) {
-            const tableWithColumns = data.tables.shift();
-            if (tableWithColumns) {
-              const tables = store.getSourceTables().map((table) => {
-                if (table.get('name') === tableWithColumns.name && table.get('schema') === tableWithColumns.schema) {
-                  return fromJS(tableWithColumns);
-                }
-                return table;
-              });
-              updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, tables);
-            }
-          } else {
+          if (queryId && data.tables.length > 0) {
+            const tables = store.getSourceTables().map((table) => {
+              if (table.get('name') === data.tables[0].name && table.get('schema') === data.tables[0].schema) {
+                return fromJS(data.tables[0]);
+              }
+              return table;
+            });
+            updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, tables);
+          } else if (!queryId) {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, fromJS(data.tables));
             if (store.isRowConfiguration() && data.tables) {
               const candidates = getIncrementalCandidates(fromJS(data.tables));

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -1,6 +1,5 @@
 import * as storeProvisioning from './storeProvisioning';
 import {List, Map, fromJS} from 'immutable';
-import ApplicationStore from '../../stores/ApplicationStore';
 import RoutesStore from '../../stores/RoutesStore';
 
 import componentsActions from '../components/InstalledComponentsActionCreators';
@@ -9,6 +8,7 @@ import callDockerAction from '../components/DockerActionsApi';
 import getDefaultPort from './templates/defaultPorts';
 import {getProtectedProperties} from './templates/credentials';
 import {incrementalFetchingTypes} from './templates/incrementalFetchingCandidates';
+import {supportSplitLoading} from './utils';
 
 export function loadConfiguration(componentId, configId) {
   return componentsActions.loadComponentConfigData(componentId, configId);
@@ -517,7 +517,7 @@ export function createActions(componentId) {
         if (!store.isRowConfiguration()) {
           runData = runData.setIn(['parameters', 'tables'], List());
         }
-        if (componentId === 'keboola.ex-db-pgsql' && ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading')) {
+        if (supportSplitLoading(componentId)) {
           runData = runData.setIn(['parameters', 'tableListFilter', 'listColumns'], false);
 
           if (queryId) {

--- a/src/scripts/modules/ex-db-generic/actionsProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/actionsProvisioning.js
@@ -546,14 +546,16 @@ export function createActions(componentId) {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_ERROR_PATH, null);
           }
           if (queryId) {
-            const updated = data.tables[0];
-            const tables = store.getSourceTables().map((table) => {
-              if (table.get('name') === updated.name && table.get('schema') === updated.schema) {
-                return fromJS(updated);
-              }
-              return table;
-            });
-            updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, tables);
+            const tableWithColumns = data.tables.shift();
+            if (tableWithColumns) {
+              const tables = store.getSourceTables().map((table) => {
+                if (table.get('name') === tableWithColumns.name && table.get('schema') === tableWithColumns.schema) {
+                  return fromJS(tableWithColumns);
+                }
+                return table;
+              });
+              updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, tables);
+            }
           } else {
             updateLocalState(configId, storeProvisioning.SOURCE_TABLES_PATH, fromJS(data.tables));
             if (store.isRowConfiguration() && data.tables) {

--- a/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import createReactClass from 'create-react-class';
+import { Button, HelpBlock, FormControl } from 'react-bootstrap';
+import { Loader } from '@keboola/indigo-ui';
+import ApplicationStore from '../../../../stores/ApplicationStore';
+
+export default createReactClass({
+  propTypes: {
+    componentId: PropTypes.string.isRequired,
+    isLoadingColumns: PropTypes.bool.isRequired,
+    columnSelector: PropTypes.object.isRequired,
+    refreshMethod: PropTypes.func.isRequired
+  },
+
+  render() {
+    if (this.props.isLoadingColumns) {
+      return (
+        <FormControl.Static>
+          <Loader /> Fetching list of column
+        </FormControl.Static>
+      );
+    }
+
+    return (
+      <div>
+        {this.props.columnSelector}
+        {this.showColumnsReloader() && (
+          <HelpBlock>
+            Not seeing all columns?{' '}
+            <Button bsStyle="link" className="btn-link-inline" onClick={this.props.refreshMethod}>
+              Reload
+            </Button>{' '}
+            the list of columns.
+          </HelpBlock>
+        )}
+      </div>
+    );
+  },
+
+  showColumnsReloader() {
+    return (
+      this.props.componentId === 'keboola.ex-db-pgsql' &&
+      ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading')
+    );
+  }
+});

--- a/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import { Button, HelpBlock, FormControl } from 'react-bootstrap';
 import { Loader } from '@keboola/indigo-ui';
-import ApplicationStore from '../../../../stores/ApplicationStore';
+import { supportSplitLoading } from '../../utils';
 
 export default createReactClass({
   propTypes: {
@@ -25,7 +25,7 @@ export default createReactClass({
     return (
       <div>
         {this.props.columnSelector}
-        {this.showColumnsReloader() && (
+        {supportSplitLoading(this.props.componentId) && (
           <HelpBlock>
             Not seeing all columns?{' '}
             <Button bsStyle="link" className="btn-link-inline" onClick={this.props.refreshMethod}>
@@ -35,13 +35,6 @@ export default createReactClass({
           </HelpBlock>
         )}
       </div>
-    );
-  },
-
-  showColumnsReloader() {
-    return (
-      this.props.componentId === 'keboola.ex-db-pgsql' &&
-      ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading')
     );
   }
 });

--- a/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/ColumnLoaderQueryEditor.jsx
@@ -17,7 +17,7 @@ export default createReactClass({
     if (this.props.isLoadingColumns) {
       return (
         <FormControl.Static>
-          <Loader /> Fetching list of column
+          <Loader /> Fetching list of columns
         </FormControl.Static>
       );
     }

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -541,21 +541,23 @@ export default createReactClass({
             columnSelector={columnSelector}
             refreshMethod={() => this.props.refreshMethod(this.props.query.get('id'))}
           />
-          <HelpBlock>
-            If you only need to exclude a couple of columns, you can{' '}
-            <Button
-              bsStyle="link"
-              className="btn-link-inline"
-              disabled={isDisabled}
-              onClick={() => {
-                const allColumns = columnsOptions.map(option => option.value);
-                this.handleChangeColumns(allColumns);
-              }}
-            >
-              add all columns
-            </Button>{' '}
-            and then remove the ones you don&apos;t want.
-          </HelpBlock>
+          {columnsOptions.length > 0 && (
+            <HelpBlock>
+              If you only need to exclude a couple of columns, you can{' '}
+              <Button
+                bsStyle="link"
+                className="btn-link-inline"
+                disabled={isDisabled}
+                onClick={() => {
+                  const allColumns = columnsOptions.map(option => option.value);
+                  this.handleChangeColumns(allColumns);
+                }}
+              >
+                add all columns
+              </Button>{' '}
+              and then remove the ones you don&apos;t want.
+            </HelpBlock>
+          )}
         </Col>
       </FormGroup>
     );

--- a/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
+++ b/src/scripts/modules/ex-db-generic/react/components/QueryEditor.jsx
@@ -6,7 +6,6 @@ import _ from 'underscore';
 import { Controlled as CodeMirror } from 'react-codemirror2'
 import { Button, Alert, FormGroup, ControlLabel, HelpBlock, Checkbox, Col } from 'react-bootstrap';
 
-import ApplicationStore from '../../../../stores/ApplicationStore';
 import Select from '../../../../react/common/Select';
 import TableSelectorForm from '../../../../react/common/TableSelectorForm';
 import Tooltip from '../../../../react/common/Tooltip';
@@ -19,6 +18,7 @@ import {getQueryEditorPlaceholder, getQueryEditorHelpText} from '../../templates
 
 import editorMode from '../../templates/editorMode';
 import { getCustomFieldsForComponent } from '../../templates/customFields';
+import { supportSplitLoading } from '../../utils';
 
 export default createReactClass({
   propTypes: {
@@ -234,7 +234,7 @@ export default createReactClass({
     }
     this.props.onChange(newQuery);
 
-    if (this.props.componentId === 'keboola.ex-db-pgsql' && ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading')) {
+    if (supportSplitLoading(this.props.componentId)) {
       this.props.refreshMethod(this.props.query.get('id'));
     }
   },

--- a/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
+++ b/src/scripts/modules/ex-db-generic/react/pages/query-detail/QueryDetail.jsx
@@ -8,7 +8,12 @@ import StorageTablesStore from '../../../../components/stores/StorageTablesStore
 import RoutesStore from '../../../../../stores/RoutesStore';
 
 import QueryEditor from '../../components/QueryEditor';
-import {CONNECTION_ERROR_PATH, INCREMENTAL_CANDIDATES_PATH, LOADING_SOURCE_TABLES_PATH} from '../../../storeProvisioning';
+import {
+  CONNECTION_ERROR_PATH, 
+  INCREMENTAL_CANDIDATES_PATH, 
+  LOADING_COLUMNS_PATH, 
+  LOADING_SOURCE_TABLES_PATH
+} from '../../../storeProvisioning';
 import {SOURCE_TABLES_PATH} from '../../../storeProvisioning';
 import {SOURCE_TABLES_ERROR_PATH} from '../../../storeProvisioning';
 
@@ -77,8 +82,8 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
       return ExDbActionCreators.saveQueryEdit(this.state.configId, this.state.editingQuery.get('id'));
     },
 
-    handleRefreshSourceTables() {
-      return reloadSourceTables(componentId, this.state.configId);
+    handleRefreshSourceTables(queryId) {
+      return reloadSourceTables(componentId, this.state.configId, queryId);
     },
 
     getDefaultOutputTableId(name) {
@@ -97,6 +102,7 @@ export default function(componentId, actionsProvisioning, storeProvisioning) {
           componentId={componentId}
           getDefaultOutputTable={this.getDefaultOutputTableId}
           isLoadingSourceTables={this.state.localState.getIn(LOADING_SOURCE_TABLES_PATH, false)}
+          isLoadingColumns={this.state.localState.getIn(LOADING_COLUMNS_PATH, false)}
           isTestingConnection={this.state.isTestingConnection}
           validConnection={this.state.validConnection}
           connectionError={this.state.localState.getIn(CONNECTION_ERROR_PATH)}

--- a/src/scripts/modules/ex-db-generic/storeProvisioning.js
+++ b/src/scripts/modules/ex-db-generic/storeProvisioning.js
@@ -19,6 +19,7 @@ export const SOURCE_TABLES_PATH = ['sourceTables', 'data'];
 export const INCREMENTAL_CANDIDATES_PATH = ['sourceTables', 'incrementalCandidates'];
 export const SOURCE_TABLES_ERROR_PATH = ['sourceTables', 'error'];
 export const LOADING_SOURCE_TABLES_PATH = ['sourceTables', 'loading'];
+export const LOADING_COLUMNS_PATH = ['sourceTables', 'columnsLoading'];
 export const TESTING_CONNECTION_PATH = ['connection', 'testing'];
 export const CONNECTION_ERROR_PATH = ['connection', 'error'];
 export const CONNECTION_VALID_PATH = ['connection', 'valid'];

--- a/src/scripts/modules/ex-db-generic/utils.js
+++ b/src/scripts/modules/ex-db-generic/utils.js
@@ -1,0 +1,11 @@
+import ApplicationStore from '../../stores/ApplicationStore';
+
+const supported = ['keboola.ex-db-pgsql'];
+
+const supportSplitLoading = (componentId) => {
+  return supported.includes(componentId) && ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading');
+}
+
+export {
+  supportSplitLoading
+}

--- a/src/scripts/modules/ex-db-generic/utils.js
+++ b/src/scripts/modules/ex-db-generic/utils.js
@@ -1,9 +1,11 @@
 import ApplicationStore from '../../stores/ApplicationStore';
+import { FEATURE_PGSQL_SPLIT_LOADING } from '../../constants/KbcConstants';
 
 const supported = ['keboola.ex-db-pgsql'];
 
 const supportSplitLoading = (componentId) => {
-  return supported.includes(componentId) && ApplicationStore.hasCurrentProjectFeature('pgsql-split-loading');
+  return supported.includes(componentId)
+    && ApplicationStore.hasCurrentProjectFeature(FEATURE_PGSQL_SPLIT_LOADING);
 }
 
 export {

--- a/src/scripts/stores/ApplicationStore.js
+++ b/src/scripts/stores/ApplicationStore.js
@@ -75,7 +75,7 @@ const ApplicationStore = StoreUtils.createStore({
   },
 
   hasCurrentProjectFeature(feature) {
-    return this.getCurrentProjectFeatures().includes(feature);
+    return [...this.getCurrentProjectFeatures(), 'pgsql-split-loading'].includes(feature);
   },
 
   getCurrentAdmin() {

--- a/src/scripts/stores/ApplicationStore.js
+++ b/src/scripts/stores/ApplicationStore.js
@@ -75,7 +75,7 @@ const ApplicationStore = StoreUtils.createStore({
   },
 
   hasCurrentProjectFeature(feature) {
-    return [...this.getCurrentProjectFeatures(), 'pgsql-split-loading'].includes(feature);
+    return this.getCurrentProjectFeatures().includes(feature);
   },
 
   getCurrentAdmin() {


### PR DESCRIPTION
Related https://github.com/keboola/internal/issues/198#issuecomment-493596001

Tohle je teda podivný. Ještě to zkusím zítra nějak lépe.

Pokud zvolím nějakou tabulku tak mi načtou znovu ty sloupce. Pokud ale edituji nějakou "starou" tak tam mám jen ty sloupce co jsem vybral a musím kliknout na reload abych vynutil to načtení všech sloupců. Což není nic moc ale moc nevím jak jinak. Ono jak je to generický pro všechny DB tak mi přijde hrozně divný tam něco upravovat. I to načítání sloupců přes `queryId` parametr je podivný. No jsem zvědav zda to aspoň funguje podle představ částečně.

Přijde mi to spíše takové hacknuté.

Jinak je to přes featuru projektu `pgsql-split-loading`.