### PR TITLE
Activity Matching - show all matches on request

### DIFF
--- a/src/scripts/modules/transformations/react/components/activity-matching/findMatches.js
+++ b/src/scripts/modules/transformations/react/components/activity-matching/findMatches.js
@@ -1,6 +1,6 @@
 import { Map } from 'immutable';
 
-const findMatches = (transformation, data, limit = 5) => {
+const findMatches = (transformation, data) => {
   const sources = transformation
     .get('input')
     .map((mapping) => mapping.get('source'))
@@ -30,8 +30,7 @@ const findMatches = (transformation, data, limit = 5) => {
       if (status === 'success') return -1;
       if (status === 'error' || status === 'terminated') return 1;
       return 0;
-    })
-    .slice(0, limit);
+    });
 };
 
 export default findMatches;

--- a/src/scripts/modules/transformations/react/components/activity-matching/findMatches.test.js
+++ b/src/scripts/modules/transformations/react/components/activity-matching/findMatches.test.js
@@ -75,29 +75,6 @@ describe('findMatches', () => {
     expect(findMatches(transformation, data).last().first().get('rowId')).toEqual(2);
   });
 
-  it('should return OrderedMap limited by setted limit', () => {
-    data = fromJS([
-      {
-        inputTable: 'prvni',
-        usedIn: [
-          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
-          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
-          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
-        ]
-      },
-      {
-        inputTable: 'druha',
-        usedIn: [
-          { rowId: 1, lastRunAt: '2017-02-13T12:01:05+0100', lastRunStatus: 'success' },
-          { rowId: 2, lastRunAt: '2018-02-13T12:01:05+0100', lastRunStatus: 'success' },
-          { rowId: 3, lastRunAt: '2019-02-13T12:01:05+0100', lastRunStatus: 'success' }
-        ]
-      }
-    ]);
-
-    expect(findMatches(transformation, data, 1).count()).toEqual(1);
-  });
-
   it('should filter out never runned transformations', () => {
     data = fromJS([
       {

--- a/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
+++ b/src/scripts/modules/transformations/react/modals/ActivityMatchingModal.jsx
@@ -24,6 +24,12 @@ export default createReactClass({
     onHide: PropTypes.func.isRequired
   },
 
+  getInitialState() {
+    return {
+      matchesLimit: 5
+    }
+  },
+
   render() {
     return (
       <Modal bsSize="large" show={this.props.show} onHide={this.props.onHide}>
@@ -59,6 +65,7 @@ export default createReactClass({
         {this.renderInputMappingRows()}
         <br />
         {this.renderMatches()}
+        {this.renderShowMore()}
       </div>
     );
   },
@@ -148,6 +155,7 @@ export default createReactClass({
 
   renderMatches() {
     return this.props.matches
+      .slice(0, this.state.matchesLimit)
       .map((match, idx) => {
         const config = match.first();
 
@@ -194,5 +202,23 @@ export default createReactClass({
         );
       })
       .toArray();
+  },
+
+  renderShowMore() {
+    const matches = this.props.matches.count();
+
+    if (matches <= this.state.matchesLimit) {
+      return null;
+    }
+
+    return (
+      <Button
+        bsStyle="link"
+        className="btn-link-inline"
+        onClick={() => this.setState({ matchesLimit: matches })}
+      >
+        Show more matches
+      </Button>
+    );
   }
 });


### PR DESCRIPTION
Vyhodil jsem limit z té funkce, prostě to vrací všechny shody. Myslím že to tak bude lepší. Ať si to případně upraví jiné komponenty pokud nechtějí zobrazit vše. To jsem i pak udělal.

- v sidebaru tak uvidím skutečný celkový počet shod
- v modalu jsem dal zase limit 5 ale je tam tlačítko na zobrazení ostatních
