### PR TITLE
Better diff in Python/R/OpenRefine transformations

### DIFF
--- a/src/scripts/modules/transformations/ActionCreators.js
+++ b/src/scripts/modules/transformations/ActionCreators.js
@@ -403,7 +403,7 @@ export default {
     const transformationEditingFields = TransformationsStore.getTransformationEditingFields(bucketId, transformationId);
     const pendingAction = 'save-queries';
     const changeDescription = transformationEditingFields.get('description', 'Change Scripts in ' + transformation.get('name'));
-    transformation = transformation.set('queries', List([transformationEditingFields.get('queriesString')]));
+    transformation = transformation.set('queries', List(transformationEditingFields.get('queriesString').split(/\n/)));
     dispatcher.handleViewAction({
       type: constants.ActionTypes.TRANSFORMATION_EDIT_SAVE_START,
       transformationId: transformationId,


### PR DESCRIPTION
Fixes #1000

Byl tam nějaký problém proč se to neudělalo jak navrhoval Najlos přes ten split takto jen?
Příjde mi že takto to je lepší ten diff, asi ne ideální ale furt lepší jak jeden nekonečný řádek. Pokud se to zpracovává i po rozdělení stejně tak asi cajk.
