### PR TITLE
Snowflake writer - Scale for numbers is not propagated from storage datatypes to IM

### DIFF
--- a/src/scripts/modules/wr-db/templates/columnsMetadata.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.js
@@ -54,15 +54,10 @@ function getSnowflakeMetadataDataTypes(columnMetadata) {
     const nullable = data.find(entry => entry.get('key') === 'KBC.datatype.nullable', null, Map());
     const defaultValue = data.find(entry => entry.get('key') === 'KBC.datatype.default', null, Map());
     const length = data.find(entry => entry.get('key') === 'KBC.datatype.length', null, Map());
-    const parsedLength = parseInt(length.get('value', 0), 10);
-    const size =
-      datatype.get('size') && parsedLength > 0
-        ? Math.min(parsedLength, datatype.get('maxLength', Number.MAX_SAFE_INTEGER))
-        : '';
 
     return fromJS({
       column,
-      size,
+      size: length.get('value'),
       type: datatype.get('name'),
       defaultValue: defaultValue.get('value', ''),
       nullable: !!parseInt(nullable.get('value', 0), 10)

--- a/src/scripts/modules/wr-db/templates/columnsMetadata.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.js
@@ -57,7 +57,7 @@ function getSnowflakeMetadataDataTypes(columnMetadata) {
 
     return fromJS({
       column,
-      size: length.get('value'),
+      size: length.get('value', ''),
       type: datatype.get('name'),
       defaultValue: defaultValue.get('value', ''),
       nullable: !!parseInt(nullable.get('value', 0), 10)

--- a/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
+++ b/src/scripts/modules/wr-db/templates/columnsMetadata.test.js
@@ -19,7 +19,7 @@ const table = fromJS({
 });
 
 function metadataSnowflakeType(column) {
-  return { name: column, dbName: column, type: 'varchar', nullable: true, default: 'value', size: 16777216 };
+  return { name: column, dbName: column, type: 'varchar', nullable: true, default: 'value', size: '16777216' };
 }
 
 function defaultSnowflakeType(column) {
@@ -54,11 +54,5 @@ describe('prepareColumnsTypes', function() {
     const uknownMetadataBasetype = table.setIn(['columnMetadata', 'country', 0, 'value'], 'UNKNOWN');
     const expected = fromJS([defaultSnowflakeType('country'), defaultSnowflakeType('cars')]);
     expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, uknownMetadataBasetype));
-  });
-
-  it('if length value from metadata is bigger than allowed, default size is used', () => {
-    const updatedTable = table.setIn(['columnMetadata', 'country', 3, 'value'], 26777216);
-    const expected = fromJS([metadataSnowflakeType('country'), defaultSnowflakeType('cars')]);
-    expect(expected).toEqual(prepareColumnsTypes(SnowflakeComponentId, updatedTable));
   });
 });


### PR DESCRIPTION
Fixes #3358

Myslím že zbytečně se to tam parsovalo na number aby se mohla udělat kontrola na max, min hodnotu.
Myslím že to tam být nemusí, prostě co si človek nakliká u sloupce to tu bude mít, je to i srozumitelnější.