### PR TITLE
Load components configs data fix

### DIFF
--- a/src/scripts/modules/components/InstalledComponentsActionCreators.js
+++ b/src/scripts/modules/components/InstalledComponentsActionCreators.js
@@ -129,9 +129,9 @@ export default {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGSDATA_LOAD_SUCCESS,
         componentId: componentId,
-        configData: configData
+        configData: configData || []
       });
-      return configData;
+      return null;
     }).catch(function(error) {
       dispatcher.handleViewAction({
         type: constants.ActionTypes.INSTALLED_COMPONENTS_CONFIGSDATA_LOAD_ERROR,


### PR DESCRIPTION
Fixes #3363

Přijde mi divné že to vrátilo `null` ale nekoukal jsem do `connection` jak to tam je naprogramované. Čekal bych prázdné pole pokud třeba nemám žádné ty konfigurace. Takto to pojistám že když dostanu `null` pošlu dát pole a dále to nepadne.

+ koukal jsem jak ej to použito a nikdy to nepracuje přímo s tím co bylo vráceno, proto jsem to tam přepsal na null (aby bluebird nehlásit varování že vracím undefined).