### PR TITLE
Storage Explerer - Time travel modal - check timestamp

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
@@ -156,6 +156,11 @@ export default createReactClass({
   },
 
   isDisabled() {
-    return !this.state.timestamp || !this.state.destinationBucket || !this.state.tableName;
+    return (
+      !this.state.timestamp ||
+      !moment.isMoment(this.state.timestamp) ||
+      !this.state.destinationBucket ||
+      !this.state.tableName
+    );
   }
 });

--- a/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
@@ -110,7 +110,7 @@ export default createReactClass({
   handleTimestamp(timestamp) {
     let tableName = this.state.tableName;
 
-    if (this.state.tableName.match(/_\d{14}$/)) {
+    if (this.state.tableName.match(/_\d{14}$/) && moment.isMoment(timestamp)) {
       tableName = this.props.table.get('name') + '_' + moment(timestamp).format('YYYYMMDDHHmmss');
     }
 

--- a/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/TimeTravelModal.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import createReactClass from 'create-react-class';
 import moment from 'moment';
-import { Modal, Col, Alert, Form, FormGroup, FormControl, ControlLabel } from 'react-bootstrap';
+import {Modal, Col, Alert, Form, FormGroup, FormControl, ControlLabel, HelpBlock} from 'react-bootstrap';
 import Select from 'react-select';
 import DateTime from 'react-datetime';
 import ConfirmButtons from '../../../../react/common/ConfirmButtons';
@@ -63,6 +63,9 @@ export default createReactClass({
                   onChange={this.handleTimestamp}
                   isValidDate={this.isValidDate}
                 />
+                <HelpBlock>
+                  Date in <code>YYYY-MM-DD hh:mm:ss</code> format.
+                </HelpBlock>
               </Col>
             </FormGroup>
             <FormGroup>


### PR DESCRIPTION
Fixes #3370

Kontroluji zda zadané datum je moment objekt. Ten je vždy pokud mám celé kompletní datum nebo pokud prostě vyberu datum s pickeru. Pokud ale část datumu umažu ručně a nějak upravím špatně, tak mám pouze string a tudiž nebudu moci odeslat form.