### PR TITLE
Storage Explorer - missing bucketPermissions

### DIFF
--- a/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableAlternativeModal.jsx
+++ b/src/scripts/modules/storage-explorer/react/modals/CreateAliasTableAlternativeModal.jsx
@@ -218,13 +218,12 @@ export default createReactClass({
   },
 
   allowedBuckets() {
-    const permissions = this.props.sapiToken.get('bucketPermissions');
     const neededPermissions = ['write', 'manage'];
     const alowedStages = ['out', 'in'];
 
     return this.props.buckets
       .filter((bucket) => {
-        const bucketPermission = permissions.get(bucket.get('id'), '');
+        const bucketPermission = this.props.sapiToken.getIn(['bucketPermissions', bucket.get('id')], '');
         return neededPermissions.includes(bucketPermission) && alowedStages.includes(bucket.get('stage'));
       })
       .sortBy((bucket) => bucket.get('id').toLowerCase())


### PR DESCRIPTION
Fixes #3373

Na produkci máme chyby protože tady k těm permission přistupujeme nadvakrát a tím jak to načítáme "lazy" tak tam na začátku na produkci je asi `null` a padne to. Tím že to takto spojím dokupy by to mělo prostě vrátit prázdný string a pak donačíst a aktualizoat se.

Je to tím že se z rootu `storage-explorer` hodila pryč ta akce `verifyToken` která to jednou pro první načtení blokovalo. To tam teď není proto to musí být takto. Ale je to náchylné na chybu teda, tak spiš to tam ještě pak nějak vrátím i do toho rootu.
