### PR TITLE
Storage Explorer - initial token verification

### DIFF
--- a/src/scripts/modules/storage-explorer/Routes.js
+++ b/src/scripts/modules/storage-explorer/Routes.js
@@ -1,3 +1,5 @@
+import Promise from 'bluebird';
+import ApplicationStore from '../../stores/ApplicationStore';
 import Index from './react/pages/Index/Index';
 import Files from './react/pages/Files/Files';
 import Jobs from './react/pages/Jobs/Jobs';
@@ -7,13 +9,20 @@ import Bucket from './react/pages/Bucket/Bucket';
 import FilesReloaderButton from './react/components/FilesReloaderButton';
 import JobsReloaderButton from './react/components/JobsReloaderButton';
 import { filesLimit, jobsLimit } from './Constants';
-import { loadBuckets, loadTables, loadSharedBuckets, loadJobs, loadFiles, updateFilesSearchQuery, loadLastDocumentationSnapshot } from './Actions';
+import { tokenVerify, loadBuckets, loadTables, loadSharedBuckets, loadJobs, loadFiles, updateFilesSearchQuery, loadLastDocumentationSnapshot } from './Actions';
 
 export default {
   name: 'storage-explorer',
   title: 'Storage',
   defaultRouteHandler: Index,
   requireData: [
+    () => {
+      if (ApplicationStore.getSapiToken().has('bucketPermissions')) {
+        return Promise.resolve();
+      }
+
+      return tokenVerify();
+    },
     () => loadBuckets(),
     () => loadTables(),
     () => loadSharedBuckets()


### PR DESCRIPTION
Related https://github.com/keboola/kbc-ui/issues/3373

Bych tam hodil tu logiku co byla ve `tokenVerify` přímo do routes. 
Abych projedou udělal načtení pokud nemám žádné práva a pak už tam bude ta logika na update pokud tam něco bude chybět. 

Toto teď nic neopravuje, spíš to předchází nějakým problémům do budoucna. Protože při vývoji tam ty `bucketsPermissions` mám vždy ale na produkci je tam původně vůbec nemám. Tak se lehce může stát že by někdo poslal něco s logikou jako byla ta issue předchozí.