### PR TITLE
Transformation Validation - InvalidOutput - transformation not found

### DIFF
--- a/src/scripts/modules/transformations/react/components/validation/InvalidOutput.jsx
+++ b/src/scripts/modules/transformations/react/components/validation/InvalidOutput.jsx
@@ -1,12 +1,12 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
+import { Map } from 'immutable';
 import ComponentConfigurationRowLink from '../../../../components/react/components/ComponentConfigurationRowLink';
 import TransformationsStore from '../../../stores/TransformationsStore';
 import createStoreMixin from '../../../../../react/mixins/createStoreMixin';
 
 export default createReactClass({
-
   mixins: [createStoreMixin(TransformationsStore)],
 
   propTypes: {
@@ -19,7 +19,7 @@ export default createReactClass({
 
   getStateFromStores() {
     return {
-      transformation: TransformationsStore.getTransformation(this.props.bucketId, this.props.transformationId)
+      transformation: TransformationsStore.getTransformation(this.props.bucketId, this.props.transformationId) || Map()
     };
   },
 
@@ -32,7 +32,7 @@ export default createReactClass({
           rowId={this.props.transformationId}
           onClick={this.props.onClick}
         >
-          Transformation {this.state.transformation.get('name')}, output mapping of {this.props.tableId}
+          Transformation {this.state.transformation.get('name', this.props.transformationId)}, output mapping of {this.props.tableId}
         </ComponentConfigurationRowLink>
         <br />
         {this.props.message}


### PR DESCRIPTION
Fixes #3376

Nevím zda je lepší mít takto default Map a pak tam hodil transformationId (PR) nebo nemít default Map a když nemám transformaci vůbec nerenderovat odkaz ale třeba jen span.

Mě se to nepovedlo nasimulovat, tak nevím zda se to děje pouze pokud ta transformace neexisuje a nemá cenu nebo dělat link, nebo zda existovat může. Proto jsem nechal i ten odkaz.