### PR TITLE
Component not exist - throw SimpleError

### DIFF
--- a/src/scripts/modules/components/ComponentsActionCreators.js
+++ b/src/scripts/modules/components/ComponentsActionCreators.js
@@ -1,6 +1,7 @@
 import Promise from 'bluebird';
-import ComponentsStore from './stores/ComponentsStore';
 import dispatcher from '../../Dispatcher';
+import SimpleError from '../../utils/errors/SimpleError';
+import ComponentsStore from './stores/ComponentsStore';
 import { ActionTypes } from './Constants';
 
 export default {
@@ -22,8 +23,8 @@ export default {
   loadComponent(componentId) {
     if (ComponentsStore.hasComponent(componentId)) {
       return Promise.resolve();
-    } else {
-      return Promise.reject(new Error(`Component ${componentId} not exist.`));
     }
+
+    return Promise.reject(new SimpleError('Component not exist', `Component ${componentId} not exist.`));
   }
 };

--- a/src/scripts/modules/components/ComponentsActionCreators.js
+++ b/src/scripts/modules/components/ComponentsActionCreators.js
@@ -25,6 +25,6 @@ export default {
       return Promise.resolve();
     }
 
-    return Promise.reject(new SimpleError('Component not exist', `Component ${componentId} not exist.`));
+    return Promise.reject(new SimpleError('Component not found', `Component ${componentId} does not exist.`));
   }
 };


### PR DESCRIPTION
Jen pidi úprava. Když vyhodím `SimpleError` tak dostanu lepší info na error stránce. Bez toho tam mám "Application Error" a jen v konzoli vidím že componenta neexistuje. Takto to vidím i v UI.

Text se může určo nějak upravit.