### PR TITLE
Transformation - highlight query fix

### DIFF
--- a/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
+++ b/src/scripts/modules/transformations/react/pages/transformation-detail/QueriesEdit.jsx
@@ -23,7 +23,7 @@ export default createReactClass({
     const splitQueries = this.props.splitQueries;
     const query = splitQueries.get(this.props.highlightQueryNumber - 1);
     const positionStart = this.props.queries.indexOf(query);
-    if (positionStart === -1) {
+    if (!query || positionStart === -1) {
       return;
     }
     const lineStart = (this.props.queries.substring(0, positionStart).match(/\n/g) || []).length;


### PR DESCRIPTION
Koukám že `String​.prototype​.indexOf()` pracuje trochu neočekávaně, nebo na javascript možné očekávaně, nevím. :)

Když `query` nanajdu v těch `splitQueries` tak mi immutable vrátí `undefined`.

Pokud pak mám `const positionStart = this.props.queries.indexOf(query);` kde query je `undefined` a zároveň někde v technu `this.props.queries` je string "undefined", tak mi to vrátí tu pozici. Porovnává to jako string rovnou. Možné to tak dává smysl nevím.

Proto přidaná ta kontrola zda vážně mám nějakou `query`.