### PR TITLE
AutoSuggest - trim value

### DIFF
--- a/src/scripts/modules/transformations/react/components/mapping/AutoSuggestWrapper.jsx
+++ b/src/scripts/modules/transformations/react/components/mapping/AutoSuggestWrapper.jsx
@@ -1,8 +1,8 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import createReactClass from 'create-react-class';
 import AutoSuggest from 'react-autosuggest';
-import {List} from 'immutable';
+import { List } from 'immutable';
 
 function sortSuggestionsByGeneric(item) {
   return item;
@@ -89,8 +89,8 @@ export default createReactClass({
   },
 
   handleChange(e, options) {
-    this.setState({value: options.newValue});
-    this.props.onChange(options.newValue);
+    const value = options.newValue.trim();
+    this.setState({ value });
+    this.props.onChange(value);
   }
-
 });


### PR DESCRIPTION
Fixes #3410

Tata komponenta se používá pro tabulky a sloupce, u abou myslím mezera není povolená tak bych to nechal takto jednoduše. Nebo případně přes nějakou props ale myslím zbytečné.